### PR TITLE
Port mount-session storage identity and camera-card root safety

### DIFF
--- a/docs/STORAGE_IDENTITY.md
+++ b/docs/STORAGE_IDENTITY.md
@@ -1,0 +1,24 @@
+# Storage identity
+
+Photo Organizer must never treat a path string, drive letter, mount point, persistent UUID, or volume GUID as sufficient proof that the currently mounted storage is the same mount session that was scanned earlier.
+
+The unified app therefore separates two concepts:
+
+1. **OS volume fingerprint** — Windows volume GUID or macOS mounted-device fingerprint. This distinguishes different backing volumes when available.
+2. **Process-local mount session ID** — a random identifier created when a mounted volume is first observed. It is discarded on removal or fingerprint change and is never persisted.
+
+A safety approval can only remain valid while both the fingerprint and the current mount-session ID match. Removal followed by reinsertion creates a new session ID even for the same physical card.
+
+## Event sources
+
+Windows uses `Win32_VolumeChangeEvent` with a one-second enumeration fallback. macOS watches `/Volumes` with `FileSystemWatcher` and also uses the same periodic fallback. Removal events explicitly invalidate the old session before refreshing current mounts.
+
+## Fail-closed rules
+
+- If the platform fingerprint cannot be obtained, no storage identity snapshot is issued.
+- Persistent identifiers are never accepted without the process-local session ID.
+- Camera-card manual selection must resolve to a non-system mounted volume root that itself contains `DCIM` or `PRIVATE`.
+- Selecting `DCIM/100NIKON` or another child expands to the complete mounted camera-card root.
+- An ordinary folder is never accepted merely because its path resembles camera media.
+
+Real-device acceptance must still exercise removal/reinsertion, same drive-letter or mount-path replacement, source removal during import, and destination removal during verification on both supported operating systems.

--- a/src/PhotoOrganizer.App/App.axaml.cs
+++ b/src/PhotoOrganizer.App/App.axaml.cs
@@ -1,11 +1,24 @@
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Markup.Xaml;
+using PhotoOrganizer.Core;
 
 namespace PhotoOrganizer.App;
 
 public sealed partial class App : Application
 {
+    private StorageMonitor? _storageMonitor;
+
+    public PlatformStorageVolumeProvider StorageProvider { get; } = new();
+    public StorageSessionTracker StorageSessions { get; }
+    public CameraCardRootResolver CameraCardRoots { get; }
+
+    public App()
+    {
+        StorageSessions = new StorageSessionTracker(StorageProvider);
+        CameraCardRoots = new CameraCardRootResolver(StorageProvider);
+    }
+
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);
@@ -15,6 +28,9 @@ public sealed partial class App : Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
+            _storageMonitor = new StorageMonitor(StorageSessions);
+            _storageMonitor.Start();
+            desktop.Exit += (_, _) => _storageMonitor.Dispose();
             desktop.MainWindow = new MainWindow();
         }
 

--- a/src/PhotoOrganizer.App/PhotoOrganizer.App.csproj
+++ b/src/PhotoOrganizer.App/PhotoOrganizer.App.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Avalonia" Version="12.1.1" />
     <PackageReference Include="Avalonia.Desktop" Version="12.1.1" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.1" />
+    <PackageReference Include="System.Management" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PhotoOrganizer.App/PlatformStorageVolumeProvider.cs
+++ b/src/PhotoOrganizer.App/PlatformStorageVolumeProvider.cs
@@ -1,0 +1,135 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+using PhotoOrganizer.Core;
+
+namespace PhotoOrganizer.App;
+
+public sealed class PlatformStorageVolumeProvider : IStorageVolumeProvider
+{
+    public StringComparison PathComparison => OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+
+    public IReadOnlyList<MountedVolumeInfo> GetMountedVolumes()
+    {
+        var systemRoot = OperatingSystem.IsWindows()
+            ? Path.GetPathRoot(Environment.SystemDirectory)
+            : "/";
+
+        var volumes = new List<MountedVolumeInfo>();
+        foreach (var drive in DriveInfo.GetDrives())
+        {
+            try
+            {
+                if (!drive.IsReady) continue;
+                var root = PathSafety.Normalize(drive.RootDirectory.FullName);
+                if (OperatingSystem.IsMacOS()
+                    && root != "/"
+                    && !root.StartsWith("/Volumes/", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var fingerprint = TryGetFingerprint(root);
+                if (string.IsNullOrWhiteSpace(fingerprint)) continue;
+
+                var isSystem = !string.IsNullOrWhiteSpace(systemRoot)
+                    && string.Equals(PathSafety.Normalize(systemRoot), root, PathComparison);
+                var isRemovable = drive.DriveType == DriveType.Removable
+                    || (OperatingSystem.IsMacOS() && root.StartsWith("/Volumes/", StringComparison.Ordinal));
+
+                volumes.Add(new MountedVolumeInfo(root, fingerprint, isRemovable, isSystem));
+            }
+            catch
+            {
+                // Identity enumeration is fail-closed. Unreadable volumes are not candidates.
+            }
+        }
+
+        return volumes;
+    }
+
+    public MountedVolumeInfo? ResolveVolumeForPath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return null;
+
+        string current;
+        try
+        {
+            current = PathSafety.Normalize(path);
+        }
+        catch
+        {
+            return null;
+        }
+
+        while (!File.Exists(current) && !Directory.Exists(current))
+        {
+            var parent = Directory.GetParent(current)?.FullName;
+            if (string.IsNullOrWhiteSpace(parent) || string.Equals(parent, current, PathComparison)) break;
+            current = parent;
+        }
+
+        if (!File.Exists(current) && !Directory.Exists(current)) return null;
+
+        return GetMountedVolumes()
+            .Where(v => PathSafety.IsSameOrDescendant(current, v.RootPath, PathComparison))
+            .OrderByDescending(v => PathSafety.Normalize(v.RootPath).Length)
+            .FirstOrDefault();
+    }
+
+    private static string? TryGetFingerprint(string root)
+    {
+        if (OperatingSystem.IsWindows()) return TryGetWindowsVolumeGuid(root);
+        if (OperatingSystem.IsMacOS()) return TryGetMacDeviceFingerprint(root);
+        return null;
+    }
+
+    private static string? TryGetWindowsVolumeGuid(string root)
+    {
+        var mountPoint = root.EndsWith('\\') ? root : root + "\\";
+        var buffer = new StringBuilder(1024);
+        return GetVolumeNameForVolumeMountPoint(mountPoint, buffer, (uint)buffer.Capacity)
+            ? "windows-volume:" + buffer.ToString()
+            : null;
+    }
+
+    private static string? TryGetMacDeviceFingerprint(string root)
+    {
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "/usr/bin/stat",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+            process.StartInfo.ArgumentList.Add("-f");
+            process.StartInfo.ArgumentList.Add("%d");
+            process.StartInfo.ArgumentList.Add(root);
+
+            if (!process.Start()) return null;
+            var output = process.StandardOutput.ReadToEnd().Trim();
+            process.WaitForExit(3000);
+            if (process.ExitCode != 0 || string.IsNullOrWhiteSpace(output)) return null;
+            return "mac-device:" + output;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool GetVolumeNameForVolumeMountPoint(
+        string lpszVolumeMountPoint,
+        StringBuilder lpszVolumeName,
+        uint cchBufferLength);
+}

--- a/src/PhotoOrganizer.App/StorageMonitor.cs
+++ b/src/PhotoOrganizer.App/StorageMonitor.cs
@@ -1,0 +1,148 @@
+using System.Management;
+using System.Runtime.Versioning;
+using PhotoOrganizer.Core;
+
+namespace PhotoOrganizer.App;
+
+public sealed class StorageMonitor : IDisposable
+{
+    private readonly StorageSessionTracker _tracker;
+    private readonly object _refreshGate = new();
+    private Timer? _pollTimer;
+    private FileSystemWatcher? _macVolumesWatcher;
+    private ManagementEventWatcher? _windowsWatcher;
+    private bool _started;
+
+    public StorageMonitor(StorageSessionTracker tracker)
+    {
+        _tracker = tracker;
+    }
+
+    public void Start()
+    {
+        if (_started) return;
+        _started = true;
+
+        SafeRefresh();
+        _pollTimer = new Timer(_ => SafeRefresh(), null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+
+        if (OperatingSystem.IsWindows())
+        {
+            StartWindowsWatcher();
+        }
+        else if (OperatingSystem.IsMacOS())
+        {
+            StartMacWatcher();
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private void StartWindowsWatcher()
+    {
+        try
+        {
+            _windowsWatcher = new ManagementEventWatcher(
+                new WqlEventQuery("SELECT * FROM Win32_VolumeChangeEvent"));
+            _windowsWatcher.EventArrived += OnWindowsVolumeChanged;
+            _windowsWatcher.Start();
+        }
+        catch
+        {
+            _windowsWatcher?.Dispose();
+            _windowsWatcher = null;
+            // The periodic poll remains active as the fallback detector.
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private void OnWindowsVolumeChanged(object sender, EventArrivedEventArgs e)
+    {
+        try
+        {
+            var eventType = Convert.ToUInt16(e.NewEvent.Properties["EventType"]?.Value ?? 0);
+            var driveName = e.NewEvent.Properties["DriveName"]?.Value?.ToString();
+            if (eventType == 3 && !string.IsNullOrWhiteSpace(driveName))
+            {
+                _tracker.MarkRemoved(PathSafety.Normalize(driveName));
+            }
+        }
+        catch
+        {
+            // Refresh below is still fail-closed.
+        }
+
+        SafeRefresh();
+    }
+
+    private void StartMacWatcher()
+    {
+        try
+        {
+            if (!Directory.Exists("/Volumes")) return;
+            _macVolumesWatcher = new FileSystemWatcher("/Volumes")
+            {
+                IncludeSubdirectories = false,
+                NotifyFilter = NotifyFilters.DirectoryName,
+                EnableRaisingEvents = true
+            };
+            _macVolumesWatcher.Created += OnMacVolumeChanged;
+            _macVolumesWatcher.Changed += OnMacVolumeChanged;
+            _macVolumesWatcher.Deleted += OnMacVolumeRemoved;
+            _macVolumesWatcher.Renamed += OnMacVolumeRenamed;
+            _macVolumesWatcher.Error += (_, _) => SafeRefresh();
+        }
+        catch
+        {
+            _macVolumesWatcher?.Dispose();
+            _macVolumesWatcher = null;
+        }
+    }
+
+    private void OnMacVolumeChanged(object sender, FileSystemEventArgs e) => SafeRefresh();
+
+    private void OnMacVolumeRemoved(object sender, FileSystemEventArgs e)
+    {
+        _tracker.MarkRemoved(e.FullPath);
+        SafeRefresh();
+    }
+
+    private void OnMacVolumeRenamed(object sender, RenamedEventArgs e)
+    {
+        _tracker.MarkRemoved(e.OldFullPath);
+        SafeRefresh();
+    }
+
+    private void SafeRefresh()
+    {
+        if (!Monitor.TryEnter(_refreshGate)) return;
+        try
+        {
+            _tracker.Refresh();
+        }
+        catch
+        {
+            // A failed enumeration cannot create a new safe identity. The next event/poll retries.
+        }
+        finally
+        {
+            Monitor.Exit(_refreshGate);
+        }
+    }
+
+    public void Dispose()
+    {
+        _started = false;
+        _pollTimer?.Dispose();
+        _pollTimer = null;
+
+        if (_windowsWatcher is not null)
+        {
+            try { _windowsWatcher.Stop(); } catch { }
+            _windowsWatcher.Dispose();
+            _windowsWatcher = null;
+        }
+
+        _macVolumesWatcher?.Dispose();
+        _macVolumesWatcher = null;
+    }
+}

--- a/src/PhotoOrganizer.App/StorageMonitor.cs
+++ b/src/PhotoOrganizer.App/StorageMonitor.cs
@@ -129,17 +129,24 @@ public sealed class StorageMonitor : IDisposable
         }
     }
 
+    [SupportedOSPlatform("windows")]
+    private void DisposeWindowsWatcher()
+    {
+        if (_windowsWatcher is null) return;
+        try { _windowsWatcher.Stop(); } catch { }
+        _windowsWatcher.Dispose();
+        _windowsWatcher = null;
+    }
+
     public void Dispose()
     {
         _started = false;
         _pollTimer?.Dispose();
         _pollTimer = null;
 
-        if (_windowsWatcher is not null)
+        if (OperatingSystem.IsWindows())
         {
-            try { _windowsWatcher.Stop(); } catch { }
-            _windowsWatcher.Dispose();
-            _windowsWatcher = null;
+            DisposeWindowsWatcher();
         }
 
         _macVolumesWatcher?.Dispose();

--- a/src/PhotoOrganizer.Core/CameraCardRootResolver.cs
+++ b/src/PhotoOrganizer.Core/CameraCardRootResolver.cs
@@ -1,0 +1,61 @@
+namespace PhotoOrganizer.Core;
+
+public sealed class CameraCardRootResolver
+{
+    private readonly IStorageVolumeProvider _provider;
+
+    public CameraCardRootResolver(IStorageVolumeProvider provider)
+    {
+        _provider = provider;
+    }
+
+    public string? Resolve(string selectedPath)
+    {
+        if (string.IsNullOrWhiteSpace(selectedPath)) return null;
+
+        string selected;
+        try
+        {
+            selected = PathSafety.Normalize(selectedPath);
+        }
+        catch
+        {
+            return null;
+        }
+
+        if (!Directory.Exists(selected)) return null;
+
+        var volume = _provider.GetMountedVolumes()
+            .Where(v => !v.IsSystem)
+            .Where(v => PathSafety.IsSameOrDescendant(selected, v.RootPath, _provider.PathComparison))
+            .OrderByDescending(v => PathSafety.Normalize(v.RootPath).Length)
+            .FirstOrDefault();
+
+        if (volume is null) return null;
+
+        var root = PathSafety.Normalize(volume.RootPath);
+        if (!Directory.Exists(root)) return null;
+
+        var hasDcim = Directory.Exists(Path.Combine(root, "DCIM"));
+        var hasPrivate = Directory.Exists(Path.Combine(root, "PRIVATE"));
+        if (!hasDcim && !hasPrivate) return null;
+
+        return root;
+    }
+
+    public IReadOnlyList<string> GetCandidateRoots()
+    {
+        return _provider.GetMountedVolumes()
+            .Where(v => !v.IsSystem)
+            .Select(v => PathSafety.Normalize(v.RootPath))
+            .Where(root => Directory.Exists(Path.Combine(root, "DCIM"))
+                || Directory.Exists(Path.Combine(root, "PRIVATE")))
+            .Distinct(_provider.PathComparison == StringComparison.OrdinalIgnoreCase
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal)
+            .OrderBy(root => root, _provider.PathComparison == StringComparison.OrdinalIgnoreCase
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal)
+            .ToList();
+    }
+}

--- a/src/PhotoOrganizer.Core/StorageIdentity.cs
+++ b/src/PhotoOrganizer.Core/StorageIdentity.cs
@@ -1,0 +1,155 @@
+namespace PhotoOrganizer.Core;
+
+public sealed record MountedVolumeInfo(
+    string RootPath,
+    string Fingerprint,
+    bool IsRemovable,
+    bool IsSystem);
+
+public sealed record StorageSessionIdentity(
+    string RootPath,
+    string Fingerprint,
+    Guid SessionId);
+
+public interface IStorageVolumeProvider
+{
+    StringComparison PathComparison { get; }
+
+    IReadOnlyList<MountedVolumeInfo> GetMountedVolumes();
+
+    MountedVolumeInfo? ResolveVolumeForPath(string path);
+}
+
+public static class PathSafety
+{
+    public static string Normalize(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return string.Empty;
+
+        var full = Path.GetFullPath(path);
+        var root = Path.GetPathRoot(full);
+        if (!string.IsNullOrEmpty(root) && string.Equals(full, root, StringComparison.OrdinalIgnoreCase))
+        {
+            return root;
+        }
+
+        return full.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+
+    public static bool IsSameOrDescendant(string path, string ancestor, StringComparison comparison)
+    {
+        var normalizedPath = Normalize(path);
+        var normalizedAncestor = Normalize(ancestor);
+        if (string.Equals(normalizedPath, normalizedAncestor, comparison)) return true;
+
+        var prefix = normalizedAncestor.EndsWith(Path.DirectorySeparatorChar)
+            || normalizedAncestor.EndsWith(Path.AltDirectorySeparatorChar)
+            ? normalizedAncestor
+            : normalizedAncestor + Path.DirectorySeparatorChar;
+
+        return normalizedPath.StartsWith(prefix, comparison);
+    }
+}
+
+/// <summary>
+/// Tracks a process-local identity for each currently mounted filesystem volume.
+/// A persistent OS volume identifier is only a fingerprint; it never authorizes reuse by itself.
+/// Once a mount disappears or its fingerprint changes, its session id is discarded permanently.
+/// </summary>
+public sealed class StorageSessionTracker
+{
+    private sealed record SessionEntry(string Fingerprint, Guid SessionId);
+
+    private readonly IStorageVolumeProvider _provider;
+    private readonly object _gate = new();
+    private readonly Dictionary<string, SessionEntry> _sessions;
+
+    public StorageSessionTracker(IStorageVolumeProvider provider)
+    {
+        _provider = provider;
+        _sessions = new Dictionary<string, SessionEntry>(
+            provider.PathComparison == StringComparison.OrdinalIgnoreCase
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal);
+    }
+
+    public event Action<string>? VolumeMounted;
+    public event Action<string>? VolumeRemoved;
+
+    public void Refresh()
+    {
+        var mounted = _provider.GetMountedVolumes()
+            .Where(v => !string.IsNullOrWhiteSpace(v.RootPath) && !string.IsNullOrWhiteSpace(v.Fingerprint))
+            .Select(v => v with { RootPath = PathSafety.Normalize(v.RootPath) })
+            .ToDictionary(
+                v => v.RootPath,
+                v => v,
+                _provider.PathComparison == StringComparison.OrdinalIgnoreCase
+                    ? StringComparer.OrdinalIgnoreCase
+                    : StringComparer.Ordinal);
+
+        List<string> removed = [];
+        List<string> added = [];
+
+        lock (_gate)
+        {
+            foreach (var existing in _sessions.Keys.ToList())
+            {
+                if (!mounted.TryGetValue(existing, out var current)
+                    || !string.Equals(_sessions[existing].Fingerprint, current.Fingerprint, StringComparison.Ordinal))
+                {
+                    _sessions.Remove(existing);
+                    removed.Add(existing);
+                }
+            }
+
+            foreach (var volume in mounted.Values)
+            {
+                if (_sessions.ContainsKey(volume.RootPath)) continue;
+                _sessions[volume.RootPath] = new SessionEntry(volume.Fingerprint, Guid.NewGuid());
+                added.Add(volume.RootPath);
+            }
+        }
+
+        foreach (var root in removed) VolumeRemoved?.Invoke(root);
+        foreach (var root in added) VolumeMounted?.Invoke(root);
+    }
+
+    public void MarkRemoved(string rootPath)
+    {
+        var normalized = PathSafety.Normalize(rootPath);
+        var removed = false;
+        lock (_gate)
+        {
+            removed = _sessions.Remove(normalized);
+        }
+
+        if (removed) VolumeRemoved?.Invoke(normalized);
+    }
+
+    public StorageSessionIdentity? Capture(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return null;
+        Refresh();
+
+        var volume = _provider.ResolveVolumeForPath(path);
+        if (volume is null || string.IsNullOrWhiteSpace(volume.Fingerprint)) return null;
+
+        var root = PathSafety.Normalize(volume.RootPath);
+        lock (_gate)
+        {
+            if (!_sessions.TryGetValue(root, out var entry)) return null;
+            if (!string.Equals(entry.Fingerprint, volume.Fingerprint, StringComparison.Ordinal)) return null;
+            return new StorageSessionIdentity(root, entry.Fingerprint, entry.SessionId);
+        }
+    }
+
+    public bool Matches(StorageSessionIdentity identity, string path)
+    {
+        var current = Capture(path);
+        return current is not null
+            && current.SessionId == identity.SessionId
+            && string.Equals(current.Fingerprint, identity.Fingerprint, StringComparison.Ordinal)
+            && string.Equals(current.RootPath, identity.RootPath, _provider.PathComparison);
+    }
+}

--- a/tests/PhotoOrganizer.Core.Tests/StorageIdentityTests.cs
+++ b/tests/PhotoOrganizer.Core.Tests/StorageIdentityTests.cs
@@ -1,4 +1,5 @@
 using PhotoOrganizer.Core;
+using Xunit;
 
 namespace PhotoOrganizer.Core.Tests;
 

--- a/tests/PhotoOrganizer.Core.Tests/StorageIdentityTests.cs
+++ b/tests/PhotoOrganizer.Core.Tests/StorageIdentityTests.cs
@@ -1,0 +1,147 @@
+using PhotoOrganizer.Core;
+
+namespace PhotoOrganizer.Core.Tests;
+
+public sealed class StorageIdentityTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "photo-organizer-storage-tests-" + Guid.NewGuid().ToString("N"));
+
+    public StorageIdentityTests()
+    {
+        Directory.CreateDirectory(_root);
+    }
+
+    [Fact]
+    public void Capture_MatchesWithinSameMountSession()
+    {
+        var provider = new FakeProvider(_root, "volume-a");
+        var tracker = new StorageSessionTracker(provider);
+
+        var snapshot = tracker.Capture(_root);
+
+        Assert.NotNull(snapshot);
+        Assert.True(tracker.Matches(snapshot!, _root));
+    }
+
+    [Fact]
+    public void RemovalAndReinsert_InvalidatesOldSessionEvenForSameFingerprint()
+    {
+        var provider = new FakeProvider(_root, "volume-a");
+        var tracker = new StorageSessionTracker(provider);
+        var snapshot = tracker.Capture(_root)!;
+
+        provider.Mounted = false;
+        tracker.Refresh();
+        provider.Mounted = true;
+        tracker.Refresh();
+
+        Assert.False(tracker.Matches(snapshot, _root));
+        var replacement = tracker.Capture(_root);
+        Assert.NotNull(replacement);
+        Assert.NotEqual(snapshot.SessionId, replacement!.SessionId);
+    }
+
+    [Fact]
+    public void SamePathDifferentVolume_InvalidatesOldSession()
+    {
+        var provider = new FakeProvider(_root, "volume-a");
+        var tracker = new StorageSessionTracker(provider);
+        var snapshot = tracker.Capture(_root)!;
+
+        provider.Fingerprint = "volume-b";
+        tracker.Refresh();
+
+        Assert.False(tracker.Matches(snapshot, _root));
+    }
+
+    [Fact]
+    public void MissingFingerprint_FailsClosed()
+    {
+        var provider = new FakeProvider(_root, string.Empty);
+        var tracker = new StorageSessionTracker(provider);
+
+        Assert.Null(tracker.Capture(_root));
+    }
+
+    [Fact]
+    public void NestedDcimSelection_ExpandsToMountedCardRoot()
+    {
+        var nested = Path.Combine(_root, "DCIM", "100NIKON");
+        Directory.CreateDirectory(nested);
+        var provider = new FakeProvider(_root, "volume-a", isRemovable: true);
+        var resolver = new CameraCardRootResolver(provider);
+
+        Assert.Equal(PathSafety.Normalize(_root), resolver.Resolve(nested));
+    }
+
+    [Fact]
+    public void PrivateCameraStructure_IsAccepted()
+    {
+        var nested = Path.Combine(_root, "PRIVATE", "AVCHD");
+        Directory.CreateDirectory(nested);
+        var provider = new FakeProvider(_root, "volume-a", isRemovable: true);
+        var resolver = new CameraCardRootResolver(provider);
+
+        Assert.Equal(PathSafety.Normalize(_root), resolver.Resolve(nested));
+    }
+
+    [Fact]
+    public void ArbitraryMountedFolderWithoutCameraStructure_IsRejected()
+    {
+        var child = Path.Combine(_root, "Pictures");
+        Directory.CreateDirectory(child);
+        var provider = new FakeProvider(_root, "volume-a", isRemovable: true);
+        var resolver = new CameraCardRootResolver(provider);
+
+        Assert.Null(resolver.Resolve(child));
+    }
+
+    [Fact]
+    public void SystemVolume_IsRejectedEvenWhenItContainsDcim()
+    {
+        Directory.CreateDirectory(Path.Combine(_root, "DCIM"));
+        var provider = new FakeProvider(_root, "system", isSystem: true);
+        var resolver = new CameraCardRootResolver(provider);
+
+        Assert.Null(resolver.Resolve(_root));
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_root, recursive: true); } catch { }
+    }
+
+    private sealed class FakeProvider : IStorageVolumeProvider
+    {
+        private readonly string _root;
+        private readonly bool _isRemovable;
+        private readonly bool _isSystem;
+
+        public FakeProvider(string root, string fingerprint, bool isRemovable = false, bool isSystem = false)
+        {
+            _root = PathSafety.Normalize(root);
+            Fingerprint = fingerprint;
+            _isRemovable = isRemovable;
+            _isSystem = isSystem;
+        }
+
+        public bool Mounted { get; set; } = true;
+        public string Fingerprint { get; set; }
+        public StringComparison PathComparison => OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        public IReadOnlyList<MountedVolumeInfo> GetMountedVolumes()
+        {
+            if (!Mounted) return [];
+            return [new MountedVolumeInfo(_root, Fingerprint, _isRemovable, _isSystem)];
+        }
+
+        public MountedVolumeInfo? ResolveVolumeForPath(string path)
+        {
+            if (!Mounted || string.IsNullOrWhiteSpace(Fingerprint)) return null;
+            if (!PathSafety.IsSameOrDescendant(path, _root, PathComparison)) return null;
+            return new MountedVolumeInfo(_root, Fingerprint, _isRemovable, _isSystem);
+        }
+    }
+}

--- a/tests/PhotoOrganizer.Core.Tests/StorageIdentityTests.cs
+++ b/tests/PhotoOrganizer.Core.Tests/StorageIdentityTests.cs
@@ -1,115 +1,112 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PhotoOrganizer.Core;
-using Xunit;
 
 namespace PhotoOrganizer.Core.Tests;
 
-public sealed class StorageIdentityTests : IDisposable
+[TestClass]
+public sealed class StorageIdentityTests
 {
-    private readonly string _root = Path.Combine(Path.GetTempPath(), "photo-organizer-storage-tests-" + Guid.NewGuid().ToString("N"));
-
-    public StorageIdentityTests()
-    {
-        Directory.CreateDirectory(_root);
-    }
-
-    [Fact]
+    [TestMethod]
     public void Capture_MatchesWithinSameMountSession()
     {
-        var provider = new FakeProvider(_root, "volume-a");
+        using var temp = new TempDirectory();
+        var provider = new FakeProvider(temp.Path, "volume-a");
         var tracker = new StorageSessionTracker(provider);
 
-        var snapshot = tracker.Capture(_root);
+        var snapshot = tracker.Capture(temp.Path);
 
-        Assert.NotNull(snapshot);
-        Assert.True(tracker.Matches(snapshot!, _root));
+        Assert.IsNotNull(snapshot);
+        Assert.IsTrue(tracker.Matches(snapshot, temp.Path));
     }
 
-    [Fact]
+    [TestMethod]
     public void RemovalAndReinsert_InvalidatesOldSessionEvenForSameFingerprint()
     {
-        var provider = new FakeProvider(_root, "volume-a");
+        using var temp = new TempDirectory();
+        var provider = new FakeProvider(temp.Path, "volume-a");
         var tracker = new StorageSessionTracker(provider);
-        var snapshot = tracker.Capture(_root)!;
+        var snapshot = tracker.Capture(temp.Path)!;
 
         provider.Mounted = false;
         tracker.Refresh();
         provider.Mounted = true;
         tracker.Refresh();
 
-        Assert.False(tracker.Matches(snapshot, _root));
-        var replacement = tracker.Capture(_root);
-        Assert.NotNull(replacement);
-        Assert.NotEqual(snapshot.SessionId, replacement!.SessionId);
+        Assert.IsFalse(tracker.Matches(snapshot, temp.Path));
+        var replacement = tracker.Capture(temp.Path);
+        Assert.IsNotNull(replacement);
+        Assert.AreNotEqual(snapshot.SessionId, replacement.SessionId);
     }
 
-    [Fact]
+    [TestMethod]
     public void SamePathDifferentVolume_InvalidatesOldSession()
     {
-        var provider = new FakeProvider(_root, "volume-a");
+        using var temp = new TempDirectory();
+        var provider = new FakeProvider(temp.Path, "volume-a");
         var tracker = new StorageSessionTracker(provider);
-        var snapshot = tracker.Capture(_root)!;
+        var snapshot = tracker.Capture(temp.Path)!;
 
         provider.Fingerprint = "volume-b";
         tracker.Refresh();
 
-        Assert.False(tracker.Matches(snapshot, _root));
+        Assert.IsFalse(tracker.Matches(snapshot, temp.Path));
     }
 
-    [Fact]
+    [TestMethod]
     public void MissingFingerprint_FailsClosed()
     {
-        var provider = new FakeProvider(_root, string.Empty);
+        using var temp = new TempDirectory();
+        var provider = new FakeProvider(temp.Path, string.Empty);
         var tracker = new StorageSessionTracker(provider);
 
-        Assert.Null(tracker.Capture(_root));
+        Assert.IsNull(tracker.Capture(temp.Path));
     }
 
-    [Fact]
+    [TestMethod]
     public void NestedDcimSelection_ExpandsToMountedCardRoot()
     {
-        var nested = Path.Combine(_root, "DCIM", "100NIKON");
+        using var temp = new TempDirectory();
+        var nested = Path.Combine(temp.Path, "DCIM", "100NIKON");
         Directory.CreateDirectory(nested);
-        var provider = new FakeProvider(_root, "volume-a", isRemovable: true);
+        var provider = new FakeProvider(temp.Path, "volume-a", isRemovable: true);
         var resolver = new CameraCardRootResolver(provider);
 
-        Assert.Equal(PathSafety.Normalize(_root), resolver.Resolve(nested));
+        Assert.AreEqual(PathSafety.Normalize(temp.Path), resolver.Resolve(nested));
     }
 
-    [Fact]
+    [TestMethod]
     public void PrivateCameraStructure_IsAccepted()
     {
-        var nested = Path.Combine(_root, "PRIVATE", "AVCHD");
+        using var temp = new TempDirectory();
+        var nested = Path.Combine(temp.Path, "PRIVATE", "AVCHD");
         Directory.CreateDirectory(nested);
-        var provider = new FakeProvider(_root, "volume-a", isRemovable: true);
+        var provider = new FakeProvider(temp.Path, "volume-a", isRemovable: true);
         var resolver = new CameraCardRootResolver(provider);
 
-        Assert.Equal(PathSafety.Normalize(_root), resolver.Resolve(nested));
+        Assert.AreEqual(PathSafety.Normalize(temp.Path), resolver.Resolve(nested));
     }
 
-    [Fact]
+    [TestMethod]
     public void ArbitraryMountedFolderWithoutCameraStructure_IsRejected()
     {
-        var child = Path.Combine(_root, "Pictures");
+        using var temp = new TempDirectory();
+        var child = Path.Combine(temp.Path, "Pictures");
         Directory.CreateDirectory(child);
-        var provider = new FakeProvider(_root, "volume-a", isRemovable: true);
+        var provider = new FakeProvider(temp.Path, "volume-a", isRemovable: true);
         var resolver = new CameraCardRootResolver(provider);
 
-        Assert.Null(resolver.Resolve(child));
+        Assert.IsNull(resolver.Resolve(child));
     }
 
-    [Fact]
+    [TestMethod]
     public void SystemVolume_IsRejectedEvenWhenItContainsDcim()
     {
-        Directory.CreateDirectory(Path.Combine(_root, "DCIM"));
-        var provider = new FakeProvider(_root, "system", isSystem: true);
+        using var temp = new TempDirectory();
+        Directory.CreateDirectory(Path.Combine(temp.Path, "DCIM"));
+        var provider = new FakeProvider(temp.Path, "system", isSystem: true);
         var resolver = new CameraCardRootResolver(provider);
 
-        Assert.Null(resolver.Resolve(_root));
-    }
-
-    public void Dispose()
-    {
-        try { Directory.Delete(_root, recursive: true); } catch { }
+        Assert.IsNull(resolver.Resolve(temp.Path));
     }
 
     private sealed class FakeProvider : IStorageVolumeProvider
@@ -143,6 +140,22 @@ public sealed class StorageIdentityTests : IDisposable
             if (!Mounted || string.IsNullOrWhiteSpace(Fingerprint)) return null;
             if (!PathSafety.IsSameOrDescendant(path, _root, PathComparison)) return null;
             return new MountedVolumeInfo(_root, Fingerprint, _isRemovable, _isSystem);
+        }
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"PhotoOrganizerStorageTests-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Path, recursive: true); } catch { }
         }
     }
 }


### PR DESCRIPTION
Closes #2

Implements the cross-platform storage identity boundary required by the unified data-safety model.

- process-local mount-session IDs invalidate on removal/reinsertion
- OS volume identifiers are fingerprints only and never authorize reuse by themselves
- same mount path with a changed fingerprint invalidates old approval
- Windows volume GUID fingerprinting
- macOS mounted-device fingerprinting
- Windows `Win32_VolumeChangeEvent` plus polling fallback
- macOS `/Volumes` watcher plus polling fallback
- manual nested `DCIM`/`PRIVATE` selection resolves to the mounted card root
- arbitrary/system folders fail closed
- missing platform identity fails closed
- regression tests for same-path replacement, same-volume remount, nested camera roots, arbitrary folders, and system-volume rejection

Real-device acceptance remains required before production release, but the app now has a single testable storage-identity abstraction used by both OSes.