### PR TITLE
Port fail-closed import and SD-reuse state machine to shared Core

### DIFF
--- a/docs/IMPORT_SAFETY.md
+++ b/docs/IMPORT_SAFETY.md
@@ -1,0 +1,47 @@
+# Import and camera-card reuse safety
+
+This document defines the cross-platform import state machine. It applies equally to Windows and macOS and belongs in `PhotoOrganizer.Core`, not in either platform UI.
+
+## Safety invariant
+
+**Copy completion is not camera-card reuse approval.**
+
+The only transition to `SafeToReuse` is the complete sequence below. Every error, cancellation, storage replacement, incomplete scan, missing file, or verification failure ends in `Blocked`.
+
+## Sequence
+
+1. Resolve a manual or automatic selection to the complete mounted camera-card root containing `DCIM` or `PRIVATE`.
+2. Capture the card's process-local mount-session identity.
+3. Scan the whole card for supported media. Supported media is JPG/JPEG, configured RAW, MOV, and MP4.
+4. Require an error-free scan and re-check the same source mount session after scanning.
+5. Capture the destination mount-session identity and reject the source volume, parent/child overlap, or unavailable identity.
+6. Search the existing destination library for byte-identical prior imports using file size and SHA-256. This is only a skip optimization; it is not the final reuse proof.
+7. Compute the event date from files that still need copying, falling back to all supported files for a duplicate-only run. The earliest detected capture date is used.
+8. Preflight free space for pending bytes when capacity is available.
+9. Before every copy, re-check both source and destination mount-session identities.
+10. Copy only to a new hidden `.partial-*` file, verify size and SHA-256, re-hash the source, finalize without overwrite, flush, and verify the final file again.
+11. Report copy processing complete. The card is **still not approved for reuse**.
+12. Re-check both storage identities.
+13. Re-scan the complete card.
+14. Require the rescan to be complete and non-empty, and require every supported path observed before import to still be present.
+15. Freshly verify every supported file currently visible on the card against the destination library by size and SHA-256.
+16. Re-check both storage identities after hashing.
+17. Only then transition to `SafeToReuse`.
+
+A new supported file that appears on the card after copying is intentionally included by the final rescan. If no byte-identical destination copy exists, reuse approval is blocked.
+
+## Filesystem boundaries
+
+Source scans, destination-library searches, and final verification never descend into another mounted volume nested under the selected root. Reparse points/symlinks and hidden directories are skipped. This prevents a camera card mounted below a destination tree from accidentally proving its own backup.
+
+## Source immutability
+
+The application never deletes, moves, renames, overwrites, formats, or otherwise modifies source camera media. Cleanup is limited to application-created destination-side temporary files that were never finalized.
+
+## Duplicate-only runs
+
+If every supported source file already has an independent byte-identical copy in the destination library, no new event directory is created. A fresh post-import scan and fresh final verification are still required before reuse approval.
+
+## Cancellation and application exit
+
+Cancellation, exceptions, or process termination before the final verification completes cannot produce or preserve a `SafeToReuse` state. The UI must present these cases as blocked/not verified.

--- a/src/PhotoOrganizer.Core/DestinationLibrary.cs
+++ b/src/PhotoOrganizer.Core/DestinationLibrary.cs
@@ -1,0 +1,161 @@
+namespace PhotoOrganizer.Core;
+
+public sealed record BackupLookupResult(
+    IReadOnlySet<string> MatchedSources,
+    IReadOnlyList<string> Errors);
+
+public sealed class DestinationLibrary
+{
+    private readonly IStorageVolumeProvider? _volumeProvider;
+
+    public DestinationLibrary(IStorageVolumeProvider? volumeProvider = null)
+    {
+        _volumeProvider = volumeProvider;
+    }
+
+    public async Task<BackupLookupResult> FindVerifiedBackupsAsync(
+        IEnumerable<string> sourceFiles,
+        string destinationRoot,
+        CancellationToken cancellationToken = default)
+    {
+        var index = BuildIndex(destinationRoot);
+        var matched = new HashSet<string>(PathComparer.Instance);
+        var errors = index.Errors.ToList();
+        var destinationHashCache = new Dictionary<string, string>(PathComparer.Instance);
+
+        foreach (var source in sourceFiles.Select(Path.GetFullPath).Distinct(PathComparer.Instance))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var sourceInfo = new FileInfo(source);
+                if (!sourceInfo.Exists || sourceInfo.Length <= 0) continue;
+                if (!index.FilesBySize.TryGetValue(sourceInfo.Length, out var candidates)) continue;
+
+                // Avoid hashing a source when the library has no same-size candidate.
+                var sourceHash = await Hashing.Sha256Async(source, cancellationToken).ConfigureAwait(false);
+
+                foreach (var candidate in candidates)
+                {
+                    if (PathComparer.Instance.Equals(Path.GetFullPath(candidate), source)) continue;
+
+                    if (!destinationHashCache.TryGetValue(candidate, out var candidateHash))
+                    {
+                        try
+                        {
+                            candidateHash = await Hashing.Sha256Async(candidate, cancellationToken).ConfigureAwait(false);
+                            destinationHashCache[candidate] = candidateHash;
+                        }
+                        catch (Exception ex) when (ex is not OperationCanceledException)
+                        {
+                            errors.Add($"{candidate}: {ex.Message}");
+                            continue;
+                        }
+                    }
+
+                    if (string.Equals(sourceHash, candidateHash, StringComparison.Ordinal))
+                    {
+                        matched.Add(source);
+                        break;
+                    }
+                }
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                errors.Add($"{source}: {ex.Message}");
+            }
+        }
+
+        return new BackupLookupResult(matched, errors);
+    }
+
+    private DestinationIndex BuildIndex(string destinationRoot)
+    {
+        var filesBySize = new Dictionary<long, List<string>>();
+        var errors = new List<string>();
+
+        if (string.IsNullOrWhiteSpace(destinationRoot))
+        {
+            errors.Add("Destination root is empty.");
+            return new DestinationIndex(filesBySize, errors);
+        }
+
+        if (!Directory.Exists(destinationRoot))
+        {
+            return new DestinationIndex(filesBySize, errors);
+        }
+
+        var root = Path.GetFullPath(destinationRoot);
+        VolumeTraversalGuard guard;
+        try
+        {
+            guard = VolumeTraversalGuard.Create(root, _volumeProvider);
+        }
+        catch (Exception ex)
+        {
+            errors.Add($"Unable to establish destination volume boundary: {ex.Message}");
+            return new DestinationIndex(filesBySize, errors);
+        }
+
+        var stack = new Stack<string>();
+        stack.Push(root);
+
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            FileSystemInfo[] entries;
+            try
+            {
+                entries = new DirectoryInfo(current).EnumerateFileSystemInfos().ToArray();
+            }
+            catch (Exception ex)
+            {
+                errors.Add($"{current}: {ex.Message}");
+                continue;
+            }
+
+            foreach (var entry in entries)
+            {
+                try
+                {
+                    var attributes = entry.Attributes;
+                    if ((attributes & FileAttributes.ReparsePoint) != 0) continue;
+
+                    if ((attributes & FileAttributes.Directory) != 0)
+                    {
+                        if ((attributes & FileAttributes.Hidden) != 0 || entry.Name.StartsWith('.')) continue;
+                        if (guard.IsNestedMountedVolume(entry.FullName)) continue;
+                        stack.Push(entry.FullName);
+                        continue;
+                    }
+
+                    if (entry is not FileInfo file
+                        || file.Length <= 0
+                        || file.Name.StartsWith(".partial-", StringComparison.Ordinal)
+                        || file.Name.Contains(".partial-", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    if (!filesBySize.TryGetValue(file.Length, out var candidates))
+                    {
+                        candidates = [];
+                        filesBySize[file.Length] = candidates;
+                    }
+                    candidates.Add(file.FullName);
+                }
+                catch (Exception ex)
+                {
+                    errors.Add($"{entry.FullName}: {ex.Message}");
+                }
+            }
+        }
+
+        return new DestinationIndex(filesBySize, errors);
+    }
+
+    private sealed record DestinationIndex(
+        Dictionary<long, List<string>> FilesBySize,
+        IReadOnlyList<string> Errors);
+}

--- a/src/PhotoOrganizer.Core/FormatSafetyVerifier.cs
+++ b/src/PhotoOrganizer.Core/FormatSafetyVerifier.cs
@@ -9,15 +9,24 @@ public sealed record FormatVerificationResult(
     public bool IsSafe => Total > 0 && Verified == Total && UnverifiedFiles.Count == 0 && Errors.Count == 0;
 }
 
-public sealed class FormatSafetyVerifier(MediaClassifier classifier)
+public sealed class FormatSafetyVerifier
 {
+    private readonly MediaClassifier _classifier;
+    private readonly IStorageVolumeProvider? _volumeProvider;
+
+    public FormatSafetyVerifier(MediaClassifier classifier, IStorageVolumeProvider? volumeProvider = null)
+    {
+        _classifier = classifier;
+        _volumeProvider = volumeProvider;
+    }
+
     public async Task<FormatVerificationResult> VerifyAsync(
         IEnumerable<string> sourceFiles,
         string destinationRoot,
         CancellationToken cancellationToken = default)
     {
         var supported = sourceFiles
-            .Where(classifier.IsSupported)
+            .Where(_classifier.IsSupported)
             .Select(Path.GetFullPath)
             .Distinct(PathComparer.Instance)
             .OrderBy(path => path, PathComparer.Instance)
@@ -41,6 +50,7 @@ public sealed class FormatSafetyVerifier(MediaClassifier classifier)
         var unverified = new List<string>();
         var errors = new List<string>();
         var verified = 0;
+        var destinationHashCache = new Dictionary<string, string>(PathComparer.Instance);
 
         foreach (var source in supported)
         {
@@ -74,7 +84,12 @@ public sealed class FormatSafetyVerifier(MediaClassifier classifier)
 
                     try
                     {
-                        var destinationHash = await Hashing.Sha256Async(candidate, cancellationToken).ConfigureAwait(false);
+                        if (!destinationHashCache.TryGetValue(candidate, out var destinationHash))
+                        {
+                            destinationHash = await Hashing.Sha256Async(candidate, cancellationToken).ConfigureAwait(false);
+                            destinationHashCache[candidate] = destinationHash;
+                        }
+
                         if (string.Equals(sourceHash, destinationHash, StringComparison.Ordinal))
                         {
                             matched = true;
@@ -106,7 +121,7 @@ public sealed class FormatSafetyVerifier(MediaClassifier classifier)
         return new FormatVerificationResult(supported.Length, verified, unverified, errors);
     }
 
-    private static DestinationIndex BuildDestinationIndex(string destinationRoot)
+    private DestinationIndex BuildDestinationIndex(string destinationRoot)
     {
         var index = new Dictionary<long, List<string>>();
         var errors = new List<string>();
@@ -117,8 +132,20 @@ public sealed class FormatSafetyVerifier(MediaClassifier classifier)
             return new DestinationIndex(index, errors);
         }
 
+        var root = Path.GetFullPath(destinationRoot);
+        VolumeTraversalGuard guard;
+        try
+        {
+            guard = VolumeTraversalGuard.Create(root, _volumeProvider);
+        }
+        catch (Exception ex)
+        {
+            errors.Add($"Unable to establish destination volume boundary: {ex.Message}");
+            return new DestinationIndex(index, errors);
+        }
+
         var stack = new Stack<string>();
-        stack.Push(Path.GetFullPath(destinationRoot));
+        stack.Push(root);
 
         while (stack.Count > 0)
         {
@@ -152,11 +179,19 @@ public sealed class FormatSafetyVerifier(MediaClassifier classifier)
                             continue;
                         }
 
+                        if (guard.IsNestedMountedVolume(entry.FullName))
+                        {
+                            continue;
+                        }
+
                         stack.Push(entry.FullName);
                         continue;
                     }
 
-                    if (entry is not FileInfo file || file.Length <= 0 || file.Name.StartsWith(".partial-", StringComparison.Ordinal))
+                    if (entry is not FileInfo file
+                        || file.Length <= 0
+                        || file.Name.StartsWith(".partial-", StringComparison.Ordinal)
+                        || file.Name.Contains(".partial-", StringComparison.Ordinal))
                     {
                         continue;
                     }

--- a/src/PhotoOrganizer.Core/ImportCoordinator.cs
+++ b/src/PhotoOrganizer.Core/ImportCoordinator.cs
@@ -1,0 +1,421 @@
+namespace PhotoOrganizer.Core;
+
+public enum ImportSafetyStatus
+{
+    Ready,
+    Copying,
+    Verifying,
+    SafeToReuse,
+    Blocked
+}
+
+public enum ImportProgressPhase
+{
+    Scanning,
+    Copying,
+    Rescanning,
+    Verifying
+}
+
+public sealed record ImportProgress(ImportProgressPhase Phase, int Current, int Total, string Message);
+
+public sealed record ImportScanSession(
+    string CardRoot,
+    StorageSessionIdentity SourceIdentity,
+    IReadOnlyList<string> Files);
+
+public sealed record ScanSessionResult(
+    ImportSafetyStatus Status,
+    ImportScanSession? Session,
+    string Message,
+    IReadOnlyList<string> Errors)
+{
+    public bool IsReady => Status == ImportSafetyStatus.Ready && Session is not null;
+}
+
+public sealed record ImportSummary(
+    int TotalSupported,
+    int Copied,
+    int SkippedAlreadyBackedUp,
+    int Failed,
+    string BasePath,
+    IReadOnlyList<string> Warnings,
+    IReadOnlyList<string> Errors);
+
+public sealed record ImportRunResult(
+    ImportSafetyStatus Status,
+    string Message,
+    ImportSummary Summary,
+    FormatVerificationResult? Verification = null)
+{
+    public bool IsSafeToReuse => Status == ImportSafetyStatus.SafeToReuse;
+}
+
+public sealed class ImportCoordinator
+{
+    private readonly MediaClassifier _classifier;
+    private readonly MediaScanner _scanner;
+    private readonly SafeCopyService _copyService;
+    private readonly FormatSafetyVerifier _verifier;
+    private readonly DestinationLibrary _destinationLibrary;
+    private readonly MediaDateResolver _dateResolver;
+    private readonly StorageSessionTracker _storageSessions;
+    private readonly CameraCardRootResolver _cardRoots;
+
+    public ImportCoordinator(
+        MediaClassifier classifier,
+        StorageSessionTracker storageSessions,
+        CameraCardRootResolver cardRoots,
+        IStorageVolumeProvider volumeProvider)
+    {
+        _classifier = classifier;
+        _scanner = new MediaScanner(classifier, volumeProvider);
+        _copyService = new SafeCopyService();
+        _verifier = new FormatSafetyVerifier(classifier, volumeProvider);
+        _destinationLibrary = new DestinationLibrary(volumeProvider);
+        _dateResolver = new MediaDateResolver();
+        _storageSessions = storageSessions;
+        _cardRoots = cardRoots;
+    }
+
+    public ScanSessionResult ScanCard(string selectedPath)
+    {
+        var root = _cardRoots.Resolve(selectedPath);
+        if (root is null)
+        {
+            return BlockedScan("A complete camera-card root containing DCIM or PRIVATE could not be established.");
+        }
+
+        var identity = _storageSessions.Capture(root);
+        if (identity is null)
+        {
+            return BlockedScan("The camera-card mount-session identity is unavailable.");
+        }
+
+        var scan = _scanner.Scan(root);
+        if (!_storageSessions.Matches(identity, root))
+        {
+            return BlockedScan("The camera-card volume changed while it was being scanned.");
+        }
+
+        if (!scan.IsComplete)
+        {
+            return new ScanSessionResult(
+                ImportSafetyStatus.Blocked,
+                null,
+                "The camera card could not be scanned completely.",
+                scan.Errors);
+        }
+
+        if (scan.Files.Count == 0)
+        {
+            return BlockedScan("No supported media exists on the selected camera card.");
+        }
+
+        return new ScanSessionResult(
+            ImportSafetyStatus.Ready,
+            new ImportScanSession(root, identity, scan.Files),
+            $"Complete scan: {scan.Files.Count} supported file(s).",
+            []);
+    }
+
+    public async Task<ImportRunResult> ImportAsync(
+        ImportScanSession session,
+        string destinationRoot,
+        string eventName,
+        IProgress<ImportProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        var warnings = new List<string>();
+        var errors = new List<string>();
+        var summary = new ImportSummary(session.Files.Count, 0, 0, session.Files.Count, string.Empty, warnings, errors);
+
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!_storageSessions.Matches(session.SourceIdentity, session.CardRoot))
+            {
+                return Blocked("The camera card changed after the successful scan. Scan it again.", summary);
+            }
+
+            if (string.IsNullOrWhiteSpace(destinationRoot))
+            {
+                return Blocked("Destination is empty.", summary);
+            }
+
+            if (string.IsNullOrWhiteSpace(eventName))
+            {
+                return Blocked("Event name is empty.", summary);
+            }
+
+            var destination = PathSafety.Normalize(destinationRoot);
+            if (PathSafety.IsSameOrDescendant(destination, session.CardRoot, _storageSessions.PathComparison)
+                || PathSafety.IsSameOrDescendant(session.CardRoot, destination, _storageSessions.PathComparison))
+            {
+                return Blocked("Destination must not be the camera card or its parent/child path.", summary);
+            }
+
+            var destinationIdentity = _storageSessions.Capture(destination);
+            if (destinationIdentity is null)
+            {
+                return Blocked("Destination mount-session identity is unavailable.", summary);
+            }
+
+            if (destinationIdentity.SessionId == session.SourceIdentity.SessionId
+                || string.Equals(destinationIdentity.Fingerprint, session.SourceIdentity.Fingerprint, StringComparison.Ordinal))
+            {
+                return Blocked("Destination must be on a different volume from the camera card.", summary);
+            }
+
+            var initialFiles = session.Files
+                .Where(_classifier.IsSupported)
+                .Select(Path.GetFullPath)
+                .ToHashSet(PathComparer.Instance);
+
+            if (initialFiles.Count == 0)
+            {
+                return Blocked("The scan session contains no supported media.", summary);
+            }
+
+            var lookup = await _destinationLibrary
+                .FindVerifiedBackupsAsync(initialFiles, destination, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (lookup.Errors.Count > 0)
+            {
+                warnings.Add($"Destination library lookup reported {lookup.Errors.Count} error(s). Final reuse verification remains fail-closed.");
+            }
+
+            var pending = initialFiles
+                .Where(path => !lookup.MatchedSources.Contains(path))
+                .OrderBy(path => path, PathComparer.Instance)
+                .ToArray();
+
+            var skipped = initialFiles.Count - pending.Length;
+            if (skipped > 0)
+            {
+                warnings.Add($"Skipped {skipped} file(s) already proven byte-identical in the destination library.");
+            }
+
+            IEnumerable<string> dateFiles = pending.Length == 0 ? initialFiles : pending;
+            var dateKey = _dateResolver.ResolveDateKey(dateFiles);
+            var dateKeys = _dateResolver.ResolveDateKeys(dateFiles);
+            if (dateKeys.Count > 1)
+            {
+                warnings.Add($"Multiple capture dates detected ({string.Join(", ", dateKeys)}); using earliest date {dateKey}.");
+            }
+
+            var sanitizedEvent = SanitizeEventName(eventName);
+            if (string.IsNullOrWhiteSpace(sanitizedEvent))
+            {
+                return Blocked("Event name contains no usable filename characters.", summary);
+            }
+
+            var basePath = Path.Combine(destination, dateKey[..4], $"{dateKey}_{sanitizedEvent}");
+            summary = summary with
+            {
+                Failed = 0,
+                SkippedAlreadyBackedUp = skipped,
+                BasePath = basePath
+            };
+
+            if (pending.Length > 0)
+            {
+                var requiredBytes = pending.Sum(path => new FileInfo(path).Length);
+                var availableBytes = TryGetAvailableBytes(destinationIdentity.RootPath);
+                if (availableBytes is not null && availableBytes.Value < requiredBytes)
+                {
+                    return Blocked(
+                        $"Destination free space is insufficient. Required {requiredBytes} bytes; available {availableBytes.Value} bytes.",
+                        summary with { Failed = pending.Length });
+                }
+
+                foreach (var kind in Enum.GetValues<MediaKind>())
+                {
+                    Directory.CreateDirectory(Path.Combine(basePath, MediaClassifier.FolderName(kind)));
+                }
+            }
+
+            var copied = 0;
+            var failed = 0;
+            for (var index = 0; index < pending.Length; index++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (!_storageSessions.Matches(session.SourceIdentity, session.CardRoot)
+                    || !_storageSessions.Matches(destinationIdentity, destination))
+                {
+                    return Blocked(
+                        "Source or destination storage changed during copying.",
+                        summary with { Copied = copied, Failed = pending.Length - index });
+                }
+
+                var source = pending[index];
+                var kind = _classifier.Classify(source);
+                if (kind is null)
+                {
+                    failed++;
+                    errors.Add($"{source}: file became unsupported unexpectedly.");
+                    continue;
+                }
+
+                progress?.Report(new ImportProgress(
+                    ImportProgressPhase.Copying,
+                    index,
+                    pending.Length,
+                    $"Copying {index}/{pending.Length}"));
+
+                var result = await _copyService.CopyAsync(
+                    source,
+                    Path.Combine(basePath, MediaClassifier.FolderName(kind.Value)),
+                    cancellationToken).ConfigureAwait(false);
+
+                if (result.Status == CopyStatus.Failed)
+                {
+                    failed++;
+                    errors.Add($"{source}: {result.Error ?? "copy failed"}");
+                }
+                else if (result.Status == CopyStatus.Copied)
+                {
+                    copied++;
+                }
+                else
+                {
+                    skipped++;
+                }
+            }
+
+            summary = summary with
+            {
+                Copied = copied,
+                SkippedAlreadyBackedUp = skipped,
+                Failed = failed
+            };
+
+            progress?.Report(new ImportProgress(
+                ImportProgressPhase.Copying,
+                pending.Length,
+                pending.Length,
+                "Copy processing complete; camera-card reuse is not approved yet."));
+
+            if (failed > 0)
+            {
+                return Blocked("One or more supported media files failed to copy. Do not reuse the card.", summary);
+            }
+
+            if (!_storageSessions.Matches(session.SourceIdentity, session.CardRoot)
+                || !_storageSessions.Matches(destinationIdentity, destination))
+            {
+                return Blocked("Source or destination storage changed after copying.", summary);
+            }
+
+            progress?.Report(new ImportProgress(
+                ImportProgressPhase.Rescanning,
+                0,
+                initialFiles.Count,
+                "Rescanning the complete camera card."));
+
+            var rescan = _scanner.Scan(session.CardRoot);
+
+            if (!_storageSessions.Matches(session.SourceIdentity, session.CardRoot)
+                || !_storageSessions.Matches(destinationIdentity, destination))
+            {
+                return Blocked("Source or destination storage changed during the post-import rescan.", summary);
+            }
+
+            if (!rescan.IsComplete)
+            {
+                errors.AddRange(rescan.Errors);
+                return Blocked("Post-import camera-card scan was incomplete. Do not reuse the card.", summary);
+            }
+
+            if (rescan.Files.Count == 0)
+            {
+                return Blocked("No supported media was visible during the post-import rescan.", summary);
+            }
+
+            var rescanned = rescan.Files.Select(Path.GetFullPath).ToHashSet(PathComparer.Instance);
+            if (!initialFiles.IsSubsetOf(rescanned))
+            {
+                return Blocked("Supported media visible before import is missing from the post-import rescan.", summary);
+            }
+
+            progress?.Report(new ImportProgress(
+                ImportProgressPhase.Verifying,
+                0,
+                rescan.Files.Count,
+                "Verifying destination bytes with SHA-256."));
+
+            var verification = await _verifier
+                .VerifyAsync(rescan.Files, destination, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!_storageSessions.Matches(session.SourceIdentity, session.CardRoot)
+                || !_storageSessions.Matches(destinationIdentity, destination))
+            {
+                return Blocked("Source or destination storage changed during final byte verification.", summary, verification);
+            }
+
+            if (!verification.IsSafe)
+            {
+                errors.AddRange(verification.Errors);
+                return Blocked(
+                    $"Only {verification.Verified} of {verification.Total} supported file(s) were verified in the destination. Do not reuse the card.",
+                    summary,
+                    verification);
+            }
+
+            progress?.Report(new ImportProgress(
+                ImportProgressPhase.Verifying,
+                verification.Verified,
+                verification.Total,
+                "Destination copies verified; camera card may be reused."));
+
+            return new ImportRunResult(
+                ImportSafetyStatus.SafeToReuse,
+                $"Verified {verification.Verified} supported file(s) by size and SHA-256. Camera card may be reused.",
+                summary,
+                verification);
+        }
+        catch (OperationCanceledException)
+        {
+            return Blocked("Import was cancelled before final verification. Do not reuse the card.", summary);
+        }
+        catch (Exception ex)
+        {
+            errors.Add(ex.Message);
+            return Blocked("Import failed before final verification. Do not reuse the card.", summary);
+        }
+    }
+
+    public static string SanitizeEventName(string name)
+    {
+        var invalid = Path.GetInvalidFileNameChars()
+            .Concat(['/', '\\', ':', '*', '?', '"', '<', '>', '|'])
+            .ToHashSet();
+        var sanitized = new string(name.Select(ch => invalid.Contains(ch) ? '_' : ch).ToArray());
+        return sanitized.Trim();
+    }
+
+    private static long? TryGetAvailableBytes(string volumeRoot)
+    {
+        try
+        {
+            return new DriveInfo(volumeRoot).AvailableFreeSpace;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static ScanSessionResult BlockedScan(string message) =>
+        new(ImportSafetyStatus.Blocked, null, message, []);
+
+    private static ImportRunResult Blocked(
+        string message,
+        ImportSummary summary,
+        FormatVerificationResult? verification = null) =>
+        new(ImportSafetyStatus.Blocked, message, summary, verification);
+}

--- a/src/PhotoOrganizer.Core/MediaDateResolver.cs
+++ b/src/PhotoOrganizer.Core/MediaDateResolver.cs
@@ -1,0 +1,56 @@
+using MetadataExtractor;
+using MetadataExtractor.Formats.Exif;
+
+namespace PhotoOrganizer.Core;
+
+public sealed class MediaDateResolver
+{
+    public DateTime ResolveDate(string path)
+    {
+        var exif = TryReadExifDate(path);
+        if (exif is not null) return exif.Value;
+
+        try
+        {
+            return File.GetLastWriteTime(path);
+        }
+        catch
+        {
+            return DateTime.Now;
+        }
+    }
+
+    public string ResolveDateKey(IEnumerable<string> files)
+    {
+        var dates = files.Select(ResolveDate).OrderBy(date => date).ToArray();
+        return (dates.Length == 0 ? DateTime.Now : dates[0]).ToString("yyyy-MM-dd");
+    }
+
+    public IReadOnlyList<string> ResolveDateKeys(IEnumerable<string> files)
+    {
+        return files
+            .Select(path => ResolveDate(path).ToString("yyyy-MM-dd"))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(key => key, StringComparer.Ordinal)
+            .ToArray();
+    }
+
+    private static DateTime? TryReadExifDate(string path)
+    {
+        try
+        {
+            var directories = ImageMetadataReader.ReadMetadata(path);
+            var exif = directories.OfType<ExifSubIfdDirectory>().FirstOrDefault();
+            if (exif is null) return null;
+
+            if (exif.TryGetDateTime(ExifDirectoryBase.TagDateTimeOriginal, out var original)) return original;
+            if (exif.TryGetDateTime(ExifDirectoryBase.TagDateTimeDigitized, out var digitized)) return digitized;
+        }
+        catch
+        {
+            // Unsupported RAW/video metadata falls back to the filesystem timestamp.
+        }
+
+        return null;
+    }
+}

--- a/src/PhotoOrganizer.Core/MediaScanner.cs
+++ b/src/PhotoOrganizer.Core/MediaScanner.cs
@@ -5,8 +5,17 @@ public sealed record MediaScanResult(IReadOnlyList<string> Files, IReadOnlyList<
     public bool IsComplete => Errors.Count == 0;
 }
 
-public sealed class MediaScanner(MediaClassifier classifier)
+public sealed class MediaScanner
 {
+    private readonly MediaClassifier _classifier;
+    private readonly IStorageVolumeProvider? _volumeProvider;
+
+    public MediaScanner(MediaClassifier classifier, IStorageVolumeProvider? volumeProvider = null)
+    {
+        _classifier = classifier;
+        _volumeProvider = volumeProvider;
+    }
+
     public MediaScanResult Scan(string root)
     {
         var files = new List<string>();
@@ -17,8 +26,19 @@ public sealed class MediaScanner(MediaClassifier classifier)
             return new MediaScanResult([], ["Scan root does not exist or is not a directory."]);
         }
 
+        var scanRoot = Path.GetFullPath(root);
+        VolumeTraversalGuard guard;
+        try
+        {
+            guard = VolumeTraversalGuard.Create(scanRoot, _volumeProvider);
+        }
+        catch (Exception ex)
+        {
+            return new MediaScanResult([], [$"Unable to establish scan volume boundary: {ex.Message}"]);
+        }
+
         var stack = new Stack<string>();
-        stack.Push(Path.GetFullPath(root));
+        stack.Push(scanRoot);
 
         while (stack.Count > 0)
         {
@@ -52,11 +72,16 @@ public sealed class MediaScanner(MediaClassifier classifier)
                             continue;
                         }
 
+                        if (guard.IsNestedMountedVolume(entry.FullName))
+                        {
+                            continue;
+                        }
+
                         stack.Push(entry.FullName);
                         continue;
                     }
 
-                    if (entry is not FileInfo file || !classifier.IsSupported(file.FullName))
+                    if (entry is not FileInfo file || !_classifier.IsSupported(file.FullName))
                     {
                         continue;
                     }

--- a/src/PhotoOrganizer.Core/PhotoOrganizer.Core.csproj
+++ b/src/PhotoOrganizer.Core/PhotoOrganizer.Core.csproj
@@ -3,4 +3,8 @@
     <AssemblyName>PhotoOrganizer.Core</AssemblyName>
     <RootNamespace>PhotoOrganizer.Core</RootNamespace>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MetadataExtractor" Version="2.9.0" />
+  </ItemGroup>
 </Project>

--- a/src/PhotoOrganizer.Core/StorageIdentity.cs
+++ b/src/PhotoOrganizer.Core/StorageIdentity.cs
@@ -73,6 +73,8 @@ public sealed class StorageSessionTracker
                 : StringComparer.Ordinal);
     }
 
+    public StringComparison PathComparison => _provider.PathComparison;
+
     public event Action<string>? VolumeMounted;
     public event Action<string>? VolumeRemoved;
 

--- a/src/PhotoOrganizer.Core/VolumeTraversalGuard.cs
+++ b/src/PhotoOrganizer.Core/VolumeTraversalGuard.cs
@@ -1,0 +1,39 @@
+namespace PhotoOrganizer.Core;
+
+internal sealed class VolumeTraversalGuard
+{
+    private readonly string[] _nestedMountRoots;
+    private readonly StringComparison _comparison;
+
+    private VolumeTraversalGuard(string[] nestedMountRoots, StringComparison comparison)
+    {
+        _nestedMountRoots = nestedMountRoots;
+        _comparison = comparison;
+    }
+
+    public static VolumeTraversalGuard Create(string traversalRoot, IStorageVolumeProvider? provider)
+    {
+        if (provider is null) return new VolumeTraversalGuard([], OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+
+        var root = PathSafety.Normalize(traversalRoot);
+        var nested = provider.GetMountedVolumes()
+            .Select(v => PathSafety.Normalize(v.RootPath))
+            .Where(mount => !string.Equals(mount, root, provider.PathComparison))
+            .Where(mount => PathSafety.IsSameOrDescendant(mount, root, provider.PathComparison))
+            .Distinct(provider.PathComparison == StringComparison.OrdinalIgnoreCase
+                ? StringComparer.OrdinalIgnoreCase
+                : StringComparer.Ordinal)
+            .OrderByDescending(path => path.Length)
+            .ToArray();
+
+        return new VolumeTraversalGuard(nested, provider.PathComparison);
+    }
+
+    public bool IsNestedMountedVolume(string path)
+    {
+        var normalized = PathSafety.Normalize(path);
+        return _nestedMountRoots.Any(root =>
+            string.Equals(normalized, root, _comparison)
+            || PathSafety.IsSameOrDescendant(normalized, root, _comparison));
+    }
+}

--- a/tests/PhotoOrganizer.Core.Tests/ImportCoordinatorTests.cs
+++ b/tests/PhotoOrganizer.Core.Tests/ImportCoordinatorTests.cs
@@ -1,0 +1,334 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PhotoOrganizer.Core;
+
+namespace PhotoOrganizer.Core.Tests;
+
+[TestClass]
+public sealed class ImportCoordinatorTests
+{
+    [TestMethod]
+    public async Task SuccessfulImport_IsSafeOnlyAfterFreshRescanAndByteVerification()
+    {
+        using var env = TestEnvironment.Create();
+        var source = env.AddCameraFile("DCIM/100NIKON/DSC_0001.jpg", "camera-bytes", new DateTime(2026, 1, 2, 10, 0, 0));
+        var sourceBefore = File.ReadAllBytes(source);
+        var coordinator = env.CreateCoordinator();
+        var scan = coordinator.ScanCard(Path.GetDirectoryName(source)!);
+
+        Assert.IsTrue(scan.IsReady);
+        var result = await coordinator.ImportAsync(scan.Session!, env.DestinationRoot, "Tokyo");
+
+        Assert.IsTrue(result.IsSafeToReuse, result.Message);
+        Assert.AreEqual(1, result.Summary.Copied);
+        var copied = Path.Combine(env.DestinationRoot, "2026", "2026-01-02_Tokyo", "JPG", "DSC_0001.jpg");
+        Assert.IsTrue(File.Exists(copied));
+        CollectionAssert.AreEqual(sourceBefore, File.ReadAllBytes(source));
+        CollectionAssert.AreEqual(sourceBefore, File.ReadAllBytes(copied));
+    }
+
+    [TestMethod]
+    public async Task ExistingDifferentFile_IsNeverOverwrittenAndUsesCollisionSuffix()
+    {
+        using var env = TestEnvironment.Create();
+        var source = env.AddCameraFile("DCIM/DSC_0001.jpg", "NEW1", new DateTime(2026, 2, 3));
+        var expectedFolder = Path.Combine(env.DestinationRoot, "2026", "2026-02-03_Event", "JPG");
+        Directory.CreateDirectory(expectedFolder);
+        var existing = Path.Combine(expectedFolder, "DSC_0001.jpg");
+        File.WriteAllText(existing, "OLD1");
+        var coordinator = env.CreateCoordinator();
+        var scan = coordinator.ScanCard(env.CardRoot);
+
+        var result = await coordinator.ImportAsync(scan.Session!, env.DestinationRoot, "Event");
+
+        Assert.IsTrue(result.IsSafeToReuse, result.Message);
+        Assert.AreEqual("OLD1", File.ReadAllText(existing));
+        Assert.AreEqual("NEW1", File.ReadAllText(Path.Combine(expectedFolder, "DSC_0001_2.jpg")));
+        Assert.AreEqual("NEW1", File.ReadAllText(source));
+    }
+
+    [TestMethod]
+    public async Task DuplicateOnlySecondRun_DoesNotCreateEmptyEventFolder()
+    {
+        using var env = TestEnvironment.Create();
+        env.AddCameraFile("DCIM/photo.jpg", "same-data", new DateTime(2026, 3, 4));
+        var coordinator = env.CreateCoordinator();
+        var scan = coordinator.ScanCard(env.CardRoot);
+        var first = await coordinator.ImportAsync(scan.Session!, env.DestinationRoot, "First");
+        Assert.IsTrue(first.IsSafeToReuse);
+
+        var secondScan = coordinator.ScanCard(env.CardRoot);
+        var second = await coordinator.ImportAsync(secondScan.Session!, env.DestinationRoot, "Second");
+
+        Assert.IsTrue(second.IsSafeToReuse, second.Message);
+        Assert.AreEqual(0, second.Summary.Copied);
+        Assert.AreEqual(1, second.Summary.SkippedAlreadyBackedUp);
+        Assert.IsFalse(Directory.Exists(Path.Combine(env.DestinationRoot, "2026", "2026-03-04_Second")));
+    }
+
+    [TestMethod]
+    public async Task DestinationInsideCard_IsRejectedBeforeCopy()
+    {
+        using var env = TestEnvironment.Create();
+        env.AddCameraFile("DCIM/photo.jpg", "camera-data", new DateTime(2026, 4, 5));
+        var coordinator = env.CreateCoordinator();
+        var scan = coordinator.ScanCard(env.CardRoot);
+        var invalidDestination = Path.Combine(env.CardRoot, "Backup");
+
+        var result = await coordinator.ImportAsync(scan.Session!, invalidDestination, "Event");
+
+        Assert.AreEqual(ImportSafetyStatus.Blocked, result.Status);
+        Assert.IsFalse(Directory.Exists(invalidDestination));
+    }
+
+    [TestMethod]
+    public async Task RemovalAndReinsertAfterScan_InvalidatesSession()
+    {
+        using var env = TestEnvironment.Create();
+        env.AddCameraFile("DCIM/photo.jpg", "camera-data", new DateTime(2026, 5, 6));
+        var coordinator = env.CreateCoordinator();
+        var scan = coordinator.ScanCard(env.CardRoot);
+        Assert.IsTrue(scan.IsReady);
+
+        env.Provider.SetMounted(env.CardRoot, false);
+        env.Tracker.Refresh();
+        env.Provider.SetMounted(env.CardRoot, true);
+        env.Tracker.Refresh();
+
+        var result = await coordinator.ImportAsync(scan.Session!, env.DestinationRoot, "Event");
+
+        Assert.AreEqual(ImportSafetyStatus.Blocked, result.Status);
+        StringAssert.Contains(result.Message, "changed");
+    }
+
+    [TestMethod]
+    public async Task SamePathReplacementAfterScan_IsBlocked()
+    {
+        using var env = TestEnvironment.Create();
+        env.AddCameraFile("DCIM/photo.jpg", "camera-data", new DateTime(2026, 6, 7));
+        var coordinator = env.CreateCoordinator();
+        var scan = coordinator.ScanCard(env.CardRoot);
+
+        env.Provider.SetFingerprint(env.CardRoot, "replacement-card");
+        env.Tracker.Refresh();
+        var result = await coordinator.ImportAsync(scan.Session!, env.DestinationRoot, "Event");
+
+        Assert.AreEqual(ImportSafetyStatus.Blocked, result.Status);
+        Assert.IsFalse(result.IsSafeToReuse);
+    }
+
+    [TestMethod]
+    public async Task NewSupportedFileAppearingAfterCopy_BlocksReuseEvenThoughCopyCompleted()
+    {
+        using var env = TestEnvironment.Create();
+        env.AddCameraFile("DCIM/photo.jpg", "original-data", new DateTime(2026, 7, 8));
+        var coordinator = env.CreateCoordinator();
+        var scan = coordinator.ScanCard(env.CardRoot);
+        var sawCopyComplete = false;
+        var progress = new InlineProgress(update =>
+        {
+            if (update.Phase == ImportProgressPhase.Copying && update.Message.Contains("complete", StringComparison.OrdinalIgnoreCase))
+            {
+                sawCopyComplete = true;
+            }
+
+            if (update.Phase == ImportProgressPhase.Rescanning)
+            {
+                env.AddCameraFile("DCIM/new-photo.jpg", "new-after-copy", new DateTime(2026, 7, 8));
+            }
+        });
+
+        var result = await coordinator.ImportAsync(scan.Session!, env.DestinationRoot, "Event", progress);
+
+        Assert.IsTrue(sawCopyComplete);
+        Assert.AreEqual(ImportSafetyStatus.Blocked, result.Status);
+        Assert.IsFalse(result.IsSafeToReuse);
+        Assert.IsNotNull(result.Verification);
+        Assert.AreEqual(2, result.Verification.Total);
+        Assert.AreEqual(1, result.Verification.Verified);
+    }
+
+    [TestMethod]
+    public async Task InitiallyObservedFileMissingAtRescan_BlocksReuse()
+    {
+        using var env = TestEnvironment.Create();
+        var source = env.AddCameraFile("DCIM/photo.jpg", "original-data", new DateTime(2026, 8, 9));
+        var coordinator = env.CreateCoordinator();
+        var scan = coordinator.ScanCard(env.CardRoot);
+        var progress = new InlineProgress(update =>
+        {
+            if (update.Phase == ImportProgressPhase.Rescanning && File.Exists(source))
+            {
+                File.Delete(source);
+            }
+        });
+
+        var result = await coordinator.ImportAsync(scan.Session!, env.DestinationRoot, "Event", progress);
+
+        Assert.AreEqual(ImportSafetyStatus.Blocked, result.Status);
+        Assert.IsFalse(result.IsSafeToReuse);
+    }
+
+    [TestMethod]
+    public async Task DestinationReplacementDuringCopy_BlocksFinalApproval()
+    {
+        using var env = TestEnvironment.Create();
+        env.AddCameraFile("DCIM/photo.jpg", "original-data", new DateTime(2026, 9, 10));
+        var coordinator = env.CreateCoordinator();
+        var scan = coordinator.ScanCard(env.CardRoot);
+        var changed = false;
+        var progress = new InlineProgress(update =>
+        {
+            if (!changed && update.Phase == ImportProgressPhase.Copying)
+            {
+                changed = true;
+                env.Provider.SetFingerprint(env.DestinationRoot, "replacement-destination");
+                env.Tracker.Refresh();
+            }
+        });
+
+        var result = await coordinator.ImportAsync(scan.Session!, env.DestinationRoot, "Event", progress);
+
+        Assert.AreEqual(ImportSafetyStatus.Blocked, result.Status);
+        Assert.IsFalse(result.IsSafeToReuse);
+    }
+
+    [TestMethod]
+    public async Task UnsupportedSidecars_DoNotBlockSupportedMediaReuseApproval()
+    {
+        using var env = TestEnvironment.Create();
+        env.AddCameraFile("DCIM/photo.jpg", "camera-data", new DateTime(2026, 10, 11));
+        env.AddCameraFile("DCIM/photo.xmp", "sidecar-data", new DateTime(2026, 10, 11));
+        var coordinator = env.CreateCoordinator();
+        var scan = coordinator.ScanCard(env.CardRoot);
+
+        var result = await coordinator.ImportAsync(scan.Session!, env.DestinationRoot, "Event");
+
+        Assert.IsTrue(result.IsSafeToReuse, result.Message);
+        Assert.AreEqual(1, result.Summary.TotalSupported);
+    }
+
+    private sealed class InlineProgress(Action<ImportProgress> callback) : IProgress<ImportProgress>
+    {
+        public void Report(ImportProgress value) => callback(value);
+    }
+
+    private sealed class TestEnvironment : IDisposable
+    {
+        private readonly string _root;
+
+        private TestEnvironment(string root, string cardRoot, string destinationRoot, FakeVolumeProvider provider)
+        {
+            _root = root;
+            CardRoot = cardRoot;
+            DestinationRoot = destinationRoot;
+            Provider = provider;
+            Tracker = new StorageSessionTracker(provider);
+        }
+
+        public string CardRoot { get; }
+        public string DestinationRoot { get; }
+        public FakeVolumeProvider Provider { get; }
+        public StorageSessionTracker Tracker { get; }
+
+        public static TestEnvironment Create()
+        {
+            var root = Path.Combine(Path.GetTempPath(), $"PhotoOrganizerImportTests-{Guid.NewGuid():N}");
+            var card = Path.Combine(root, "card");
+            var destination = Path.Combine(root, "destination");
+            Directory.CreateDirectory(Path.Combine(card, "DCIM"));
+            Directory.CreateDirectory(destination);
+            var provider = new FakeVolumeProvider([
+                new MutableVolume(card, "camera-card", true, false, true),
+                new MutableVolume(destination, "destination-volume", false, false, true)
+            ]);
+            return new TestEnvironment(root, card, destination, provider);
+        }
+
+        public string AddCameraFile(string relativePath, string content, DateTime timestamp)
+        {
+            var path = Path.Combine(CardRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, content);
+            File.SetLastWriteTime(path, timestamp);
+            return path;
+        }
+
+        public ImportCoordinator CreateCoordinator()
+        {
+            var classifier = new MediaClassifier();
+            return new ImportCoordinator(
+                classifier,
+                Tracker,
+                new CameraCardRootResolver(Provider),
+                Provider);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(_root, recursive: true); } catch { }
+        }
+    }
+
+    private sealed record MutableVolume(
+        string RootPath,
+        string Fingerprint,
+        bool IsRemovable,
+        bool IsSystem,
+        bool Mounted);
+
+    private sealed class FakeVolumeProvider : IStorageVolumeProvider
+    {
+        private readonly List<MutableVolume> _volumes;
+
+        public FakeVolumeProvider(IEnumerable<MutableVolume> volumes)
+        {
+            _volumes = volumes
+                .Select(v => v with { RootPath = PathSafety.Normalize(v.RootPath) })
+                .ToList();
+        }
+
+        public StringComparison PathComparison => OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        public IReadOnlyList<MountedVolumeInfo> GetMountedVolumes() => _volumes
+            .Where(v => v.Mounted)
+            .Select(v => new MountedVolumeInfo(v.RootPath, v.Fingerprint, v.IsRemovable, v.IsSystem))
+            .ToArray();
+
+        public MountedVolumeInfo? ResolveVolumeForPath(string path)
+        {
+            var current = PathSafety.Normalize(path);
+            while (!File.Exists(current) && !Directory.Exists(current))
+            {
+                var parent = Directory.GetParent(current)?.FullName;
+                if (string.IsNullOrWhiteSpace(parent) || string.Equals(parent, current, PathComparison)) break;
+                current = parent;
+            }
+
+            var volume = _volumes
+                .Where(v => v.Mounted)
+                .Where(v => PathSafety.IsSameOrDescendant(current, v.RootPath, PathComparison))
+                .OrderByDescending(v => v.RootPath.Length)
+                .FirstOrDefault();
+
+            return volume is null
+                ? null
+                : new MountedVolumeInfo(volume.RootPath, volume.Fingerprint, volume.IsRemovable, volume.IsSystem);
+        }
+
+        public void SetMounted(string root, bool mounted)
+        {
+            var normalized = PathSafety.Normalize(root);
+            var index = _volumes.FindIndex(v => string.Equals(v.RootPath, normalized, PathComparison));
+            if (index >= 0) _volumes[index] = _volumes[index] with { Mounted = mounted };
+        }
+
+        public void SetFingerprint(string root, string fingerprint)
+        {
+            var normalized = PathSafety.Normalize(root);
+            var index = _volumes.FindIndex(v => string.Equals(v.RootPath, normalized, PathComparison));
+            if (index >= 0) _volumes[index] = _volumes[index] with { Fingerprint = fingerprint };
+        }
+    }
+}

--- a/tests/PhotoOrganizer.Core.Tests/VolumeTraversalSafetyTests.cs
+++ b/tests/PhotoOrganizer.Core.Tests/VolumeTraversalSafetyTests.cs
@@ -1,0 +1,90 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PhotoOrganizer.Core;
+
+namespace PhotoOrganizer.Core.Tests;
+
+[TestClass]
+public sealed class VolumeTraversalSafetyTests
+{
+    [TestMethod]
+    public void CameraScan_DoesNotDescendIntoNestedMountedVolume()
+    {
+        using var temp = new TempDirectory();
+        var card = Path.Combine(temp.Path, "card");
+        var nested = Path.Combine(card, "OTHER_VOLUME");
+        Directory.CreateDirectory(Path.Combine(card, "DCIM"));
+        Directory.CreateDirectory(nested);
+        var expected = Path.Combine(card, "DCIM", "photo.jpg");
+        var excluded = Path.Combine(nested, "other.jpg");
+        File.WriteAllText(expected, "card-data");
+        File.WriteAllText(excluded, "other-volume-data");
+
+        var provider = new BoundaryProvider([
+            new MountedVolumeInfo(card, "card", true, false),
+            new MountedVolumeInfo(nested, "nested", true, false)
+        ]);
+
+        var result = new MediaScanner(new MediaClassifier(), provider).Scan(card);
+
+        Assert.IsTrue(result.IsComplete);
+        Assert.AreEqual(1, result.Files.Count);
+        Assert.AreEqual(Path.GetFullPath(expected), result.Files.Single());
+    }
+
+    [TestMethod]
+    public async Task NestedMountedVolumeCannotProveDestinationBackup()
+    {
+        using var temp = new TempDirectory();
+        var sourceRoot = Path.Combine(temp.Path, "source");
+        var destination = Path.Combine(temp.Path, "destination");
+        var nested = Path.Combine(destination, "MOUNTED_CAMERA");
+        Directory.CreateDirectory(sourceRoot);
+        Directory.CreateDirectory(nested);
+        var source = Path.Combine(sourceRoot, "photo.jpg");
+        var falseProof = Path.Combine(nested, "photo.jpg");
+        File.WriteAllText(source, "same-bytes");
+        File.WriteAllText(falseProof, "same-bytes");
+
+        var provider = new BoundaryProvider([
+            new MountedVolumeInfo(destination, "destination", false, false),
+            new MountedVolumeInfo(nested, "nested-camera", true, false)
+        ]);
+
+        var result = await new FormatSafetyVerifier(new MediaClassifier(), provider)
+            .VerifyAsync([source], destination);
+
+        Assert.IsFalse(result.IsSafe);
+        Assert.AreEqual(0, result.Verified);
+        CollectionAssert.Contains(result.UnverifiedFiles.ToList(), Path.GetFullPath(source));
+    }
+
+    private sealed class BoundaryProvider(IReadOnlyList<MountedVolumeInfo> volumes) : IStorageVolumeProvider
+    {
+        public StringComparison PathComparison => OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        public IReadOnlyList<MountedVolumeInfo> GetMountedVolumes() => volumes;
+
+        public MountedVolumeInfo? ResolveVolumeForPath(string path) => volumes
+            .Where(v => PathSafety.IsSameOrDescendant(path, v.RootPath, PathComparison))
+            .OrderByDescending(v => PathSafety.Normalize(v.RootPath).Length)
+            .FirstOrDefault();
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"PhotoOrganizerBoundaryTests-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Path, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Closes #3

Moves the hardened import lifecycle into one cross-platform Core path so Windows and macOS cannot drift on data-safety behavior.

Key behavior:
- complete camera-card scan bound to a mount-session identity
- destination identity and source/destination separation before copy
- destination-wide size + SHA-256 already-imported lookup
- pending-only capacity/event-date calculation
- collision-safe verified `.partial-*` copies through `SafeCopyService`
- copy-complete is explicitly not reuse approval
- complete post-import camera-card rescan
- all initially observed supported paths must still exist
- newly appearing supported media is included in final verification
- fresh destination size + SHA-256 verification over all current supported media
- source and destination mount-session identity rechecks throughout and after hashing
- only the complete success path returns `SafeToReuse`
- cancellation/error/storage replacement fail closed
- duplicate-only runs create no empty event folder
- scans/library lookup/final verification do not traverse nested mounted volumes

Regression coverage includes normal import, collision safety, duplicate-only repeat, destination-on-card rejection, remount/replacement after scan, new media appearing after copy, missing initial media, destination replacement, and unsupported sidecars.