### PR TITLE
Replace bootstrap UI with unified production workflow

### DIFF
--- a/src/PhotoOrganizer.App/App.axaml.cs
+++ b/src/PhotoOrganizer.App/App.axaml.cs
@@ -30,8 +30,14 @@ public sealed partial class App : Application
         {
             _storageMonitor = new StorageMonitor(StorageSessions);
             _storageMonitor.Start();
-            desktop.Exit += (_, _) => _storageMonitor.Dispose();
-            desktop.MainWindow = new MainWindow();
+
+            var viewModel = new MainWindowViewModel(
+                StorageProvider,
+                StorageSessions,
+                CameraCardRoots);
+
+            desktop.MainWindow = new MainWindow(viewModel);
+            desktop.Exit += (_, _) => _storageMonitor?.Dispose();
         }
 
         base.OnFrameworkInitializationCompleted();

--- a/src/PhotoOrganizer.App/AppPreferences.cs
+++ b/src/PhotoOrganizer.App/AppPreferences.cs
@@ -1,0 +1,69 @@
+using System.Text.Json;
+
+namespace PhotoOrganizer.App;
+
+public sealed record AppPreferences(
+    string DestinationPath,
+    string[] RawExtensions,
+    bool AutoStart)
+{
+    public static AppPreferences Default => new(
+        Environment.GetFolderPath(Environment.SpecialFolder.MyPictures),
+        [".arw", ".cr2", ".cr3", ".nef", ".dng", ".raf", ".rw2", ".orf", ".pef"],
+        false);
+}
+
+public sealed class AppPreferencesStore
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+    private readonly string _path;
+
+    public AppPreferencesStore()
+    {
+        var directory = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "PhotoOrganizer");
+        _path = Path.Combine(directory, "settings.json");
+    }
+
+    public AppPreferences Load()
+    {
+        try
+        {
+            if (!File.Exists(_path)) return AppPreferences.Default;
+            var loaded = JsonSerializer.Deserialize<AppPreferences>(File.ReadAllText(_path));
+            if (loaded is null) return AppPreferences.Default;
+
+            var destination = string.IsNullOrWhiteSpace(loaded.DestinationPath)
+                ? AppPreferences.Default.DestinationPath
+                : loaded.DestinationPath;
+            var raw = loaded.RawExtensions is { Length: > 0 }
+                ? loaded.RawExtensions
+                : AppPreferences.Default.RawExtensions;
+            return loaded with { DestinationPath = destination, RawExtensions = raw };
+        }
+        catch
+        {
+            return AppPreferences.Default;
+        }
+    }
+
+    public bool Save(AppPreferences preferences, out string? error)
+    {
+        try
+        {
+            var directory = Path.GetDirectoryName(_path)!;
+            Directory.CreateDirectory(directory);
+            var temporary = _path + ".tmp-" + Guid.NewGuid().ToString("N");
+            File.WriteAllText(temporary, JsonSerializer.Serialize(preferences, JsonOptions));
+            File.Move(temporary, _path, overwrite: true);
+            error = null;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+            return false;
+        }
+    }
+}

--- a/src/PhotoOrganizer.App/MainWindow.axaml
+++ b/src/PhotoOrganizer.App/MainWindow.axaml
@@ -1,6 +1,8 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="using:PhotoOrganizer.App"
         x:Class="PhotoOrganizer.App.MainWindow"
+        x:DataType="vm:MainWindowViewModel"
         Title="Photo Organizer"
         Width="920"
         Height="760"
@@ -19,7 +21,7 @@
         <TextBox Grid.Row="0" Grid.Column="1"
                  Text="{Binding DestinationPath, Mode=TwoWay}"
                  IsEnabled="{Binding !IsBusy}"
-                 Watermark="写真ライブラリの保存先" />
+                 PlaceholderText="写真ライブラリの保存先" />
         <Button Grid.Row="0" Grid.Column="2" Content="選択..." Click="SelectDestination_Click"
                 IsEnabled="{Binding !IsBusy}" />
 
@@ -27,13 +29,13 @@
         <TextBox Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2"
                  Text="{Binding EventName, Mode=TwoWay}"
                  IsEnabled="{Binding !IsBusy}"
-                 Watermark="例: 旅行、運動会、撮影会" />
+                 PlaceholderText="例: 旅行、運動会、撮影会" />
 
         <TextBlock Grid.Row="2" Grid.Column="0" Text="選択中のSD" VerticalAlignment="Center" />
         <TextBox Grid.Row="2" Grid.Column="1"
                  Text="{Binding SelectedSdPath}"
                  IsReadOnly="True"
-                 Watermark="カメラカード未選択" />
+                 PlaceholderText="カメラカード未選択" />
         <Button Grid.Row="2" Grid.Column="2" Content="SDカード選択" Click="SelectSd_Click"
                 IsEnabled="{Binding !IsBusy}" />
 
@@ -51,7 +53,7 @@
         <TextBox Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2"
                  Text="{Binding RawExtensionsText, Mode=TwoWay}"
                  IsEnabled="{Binding !IsBusy}"
-                 Watermark=".arw, .cr3, .nef, ..." />
+                 PlaceholderText=".arw, .cr3, .nef, ..." />
 
         <TextBlock Grid.Row="1" Grid.Column="0" Text="起動設定" VerticalAlignment="Center" />
         <CheckBox Grid.Row="1" Grid.Column="1"
@@ -96,8 +98,8 @@
              IsReadOnly="True"
              AcceptsReturn="True"
              TextWrapping="NoWrap"
-             VerticalScrollBarVisibility="Auto"
-             HorizontalScrollBarVisibility="Auto"
+             ScrollViewer.VerticalScrollBarVisibility="Auto"
+             ScrollViewer.HorizontalScrollBarVisibility="Auto"
              FontFamily="monospace" />
   </Grid>
 </Window>

--- a/src/PhotoOrganizer.App/MainWindow.axaml
+++ b/src/PhotoOrganizer.App/MainWindow.axaml
@@ -2,33 +2,102 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         x:Class="PhotoOrganizer.App.MainWindow"
         Title="Photo Organizer"
-        Width="760"
-        Height="560"
-        MinWidth="640"
-        MinHeight="480">
-  <ScrollViewer>
-    <StackPanel Margin="32" Spacing="18">
-      <TextBlock Text="Photo Organizer" FontSize="30" FontWeight="SemiBold" />
-      <TextBlock Text="Windows / macOS unified edition" FontSize="16" Opacity="0.72" />
-
-      <Border Padding="18" CornerRadius="10" BorderThickness="1">
-        <StackPanel Spacing="8">
-          <TextBlock Text="Migration foundation" FontSize="18" FontWeight="SemiBold" />
-          <TextBlock TextWrapping="Wrap"
-                     Text="The shared data-safety core is active. SD-card detection, platform storage identity, import orchestration, and production release packaging are being migrated from the existing Windows and macOS applications." />
-        </StackPanel>
-      </Border>
-
-      <Border Padding="18" CornerRadius="10" BorderThickness="1">
-        <StackPanel Spacing="8">
-          <TextBlock Text="Data-safety contract" FontSize="18" FontWeight="SemiBold" />
-          <TextBlock TextWrapping="Wrap"
-                     Text="Source media is never overwritten, moved, renamed, modified, or deleted. Copy completion alone must never authorize SD-card reuse. Reuse requires a complete scan and fresh byte-for-byte destination verification." />
-        </StackPanel>
-      </Border>
-
-      <TextBlock TextWrapping="Wrap" Opacity="0.72"
-                 Text="This bootstrap build is not yet a production release. Existing PhotoOrganizer-win and PhotoOrganizer-mac remain the operational references until migration acceptance is complete." />
+        Width="920"
+        Height="760"
+        MinWidth="760"
+        MinHeight="680">
+  <Grid Margin="20" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,*" RowSpacing="12">
+    <StackPanel Grid.Row="0" Spacing="3">
+      <TextBlock Text="Photo Organizer" FontSize="28" FontWeight="SemiBold" />
+      <TextBlock Text="Windows / macOS 共通版 — SDカードの撮影データを安全に整理・検証します"
+                 Opacity="0.7" />
     </StackPanel>
-  </ScrollViewer>
+
+    <Border Grid.Row="1" Padding="14" CornerRadius="8" BorderThickness="1">
+      <Grid RowDefinitions="Auto,Auto,Auto,Auto" ColumnDefinitions="130,*,Auto" RowSpacing="9" ColumnSpacing="8">
+        <TextBlock Grid.Row="0" Grid.Column="0" Text="保存先" VerticalAlignment="Center" />
+        <TextBox Grid.Row="0" Grid.Column="1"
+                 Text="{Binding DestinationPath, Mode=TwoWay}"
+                 IsEnabled="{Binding !IsBusy}"
+                 Watermark="写真ライブラリの保存先" />
+        <Button Grid.Row="0" Grid.Column="2" Content="選択..." Click="SelectDestination_Click"
+                IsEnabled="{Binding !IsBusy}" />
+
+        <TextBlock Grid.Row="1" Grid.Column="0" Text="イベント名" VerticalAlignment="Center" />
+        <TextBox Grid.Row="1" Grid.Column="1" Grid.ColumnSpan="2"
+                 Text="{Binding EventName, Mode=TwoWay}"
+                 IsEnabled="{Binding !IsBusy}"
+                 Watermark="例: 旅行、運動会、撮影会" />
+
+        <TextBlock Grid.Row="2" Grid.Column="0" Text="選択中のSD" VerticalAlignment="Center" />
+        <TextBox Grid.Row="2" Grid.Column="1"
+                 Text="{Binding SelectedSdPath}"
+                 IsReadOnly="True"
+                 Watermark="カメラカード未選択" />
+        <Button Grid.Row="2" Grid.Column="2" Content="SDカード選択" Click="SelectSd_Click"
+                IsEnabled="{Binding !IsBusy}" />
+
+        <TextBlock Grid.Row="3" Grid.Column="0" Text="検出メディア" VerticalAlignment="Center" />
+        <StackPanel Grid.Row="3" Grid.Column="1" Grid.ColumnSpan="2" Orientation="Horizontal" Spacing="14">
+          <TextBlock Text="{Binding CountLabel}" FontWeight="SemiBold" />
+          <TextBlock Text="{Binding PendingSdText}" Opacity="0.7" />
+        </StackPanel>
+      </Grid>
+    </Border>
+
+    <Border Grid.Row="2" Padding="14" CornerRadius="8" BorderThickness="1">
+      <Grid ColumnDefinitions="130,*,Auto" RowDefinitions="Auto,Auto" RowSpacing="8" ColumnSpacing="8">
+        <TextBlock Grid.Row="0" Grid.Column="0" Text="RAW拡張子" VerticalAlignment="Center" />
+        <TextBox Grid.Row="0" Grid.Column="1" Grid.ColumnSpan="2"
+                 Text="{Binding RawExtensionsText, Mode=TwoWay}"
+                 IsEnabled="{Binding !IsBusy}"
+                 Watermark=".arw, .cr3, .nef, ..." />
+
+        <TextBlock Grid.Row="1" Grid.Column="0" Text="起動設定" VerticalAlignment="Center" />
+        <CheckBox Grid.Row="1" Grid.Column="1"
+                  Content="ログイン時に自動起動"
+                  IsChecked="{Binding AutoStart, Mode=TwoWay}"
+                  IsEnabled="{Binding AutoStartSupported}" />
+        <TextBlock Grid.Row="1" Grid.Column="2" Text="安全判定は再起動後に引き継ぎません" Opacity="0.65" />
+      </Grid>
+    </Border>
+
+    <Grid Grid.Row="3" ColumnDefinitions="Auto,Auto,*,Auto" ColumnSpacing="10">
+      <Button Grid.Column="0" Content="取り込み開始" Click="Import_Click"
+              IsEnabled="{Binding CanImport}" MinWidth="120" />
+      <Button Grid.Column="1" Content="キャンセル" Click="Cancel_Click"
+              IsEnabled="{Binding CanCancel}" />
+      <TextBlock Grid.Column="2" Text="{Binding ProgressLabel}" VerticalAlignment="Center" Opacity="0.75" />
+      <TextBlock Grid.Column="3" Text="対象: JPG/JPEG・設定済みRAW・MOV/MP4"
+                 VerticalAlignment="Center" Opacity="0.65" />
+    </Grid>
+
+    <Border Grid.Row="4" Padding="14" CornerRadius="8" BorderThickness="2"
+            BorderBrush="{Binding SafetyBrush}">
+      <StackPanel Spacing="5">
+        <TextBlock Text="SDカード再利用の安全確認" FontSize="16" FontWeight="SemiBold" />
+        <TextBlock Text="{Binding SafetyHeadline}" FontSize="17" FontWeight="SemiBold"
+                   Foreground="{Binding SafetyBrush}" TextWrapping="Wrap" />
+        <TextBlock Text="{Binding SafetyDetail}" TextWrapping="Wrap" />
+        <TextBlock Text="緑表示は指定保存先1か所への実ファイル検証を意味します。別媒体への二重バックアップ済みという意味ではありません。"
+                   Opacity="0.65" TextWrapping="Wrap" />
+      </StackPanel>
+    </Border>
+
+    <Border Grid.Row="5" Padding="10" CornerRadius="6" BorderThickness="1">
+      <TextBlock TextWrapping="Wrap"
+                 Text="重要: コピー処理が完了しただけではSDカードを再利用しないでください。取り込み後のカード全体再スキャンと保存先のサイズ・SHA-256照合が完了した場合だけ再利用可能になります。" />
+    </Border>
+
+    <TextBlock Grid.Row="6" Text="ログ" FontWeight="SemiBold" />
+
+    <TextBox Grid.Row="7"
+             Text="{Binding LogText}"
+             IsReadOnly="True"
+             AcceptsReturn="True"
+             TextWrapping="NoWrap"
+             VerticalScrollBarVisibility="Auto"
+             HorizontalScrollBarVisibility="Auto"
+             FontFamily="monospace" />
+  </Grid>
 </Window>

--- a/src/PhotoOrganizer.App/MainWindow.axaml.cs
+++ b/src/PhotoOrganizer.App/MainWindow.axaml.cs
@@ -1,11 +1,91 @@
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Interactivity;
+using Avalonia.Platform.Storage;
 
 namespace PhotoOrganizer.App;
 
 public sealed partial class MainWindow : Window
 {
+    private readonly MainWindowViewModel? _viewModel;
+
     public MainWindow()
     {
         InitializeComponent();
+    }
+
+    public MainWindow(MainWindowViewModel viewModel) : this()
+    {
+        _viewModel = viewModel;
+        DataContext = viewModel;
+        viewModel.RequestShowWindow += ShowAndActivate;
+
+        Opened += OnOpened;
+        Closing += OnClosing;
+        Closed += OnClosed;
+    }
+
+    private async void OnOpened(object? sender, EventArgs e)
+    {
+        if (_viewModel is null) return;
+        await _viewModel.InitializeAsync();
+    }
+
+    private void OnClosing(object? sender, WindowClosingEventArgs e)
+    {
+        if (_viewModel is null) return;
+        if (!_viewModel.CanCloseWindow()) e.Cancel = true;
+    }
+
+    private void OnClosed(object? sender, EventArgs e)
+    {
+        if (_viewModel is null) return;
+        _viewModel.RequestShowWindow -= ShowAndActivate;
+        _viewModel.Dispose();
+    }
+
+    private async void SelectDestination_Click(object? sender, RoutedEventArgs e)
+    {
+        if (_viewModel is null || !StorageProvider.CanPickFolder) return;
+
+        var folders = await StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = "写真の保存先を選択",
+            AllowMultiple = false
+        });
+
+        var path = folders.FirstOrDefault()?.TryGetLocalPath();
+        if (!string.IsNullOrWhiteSpace(path)) _viewModel.SetDestinationFromPicker(path);
+    }
+
+    private async void SelectSd_Click(object? sender, RoutedEventArgs e)
+    {
+        if (_viewModel is null || !StorageProvider.CanPickFolder) return;
+
+        var folders = await StorageProvider.OpenFolderPickerAsync(new FolderPickerOpenOptions
+        {
+            Title = "SDカードを選択（DCIM/PRIVATE内のフォルダを選択してもカード全体を検証します）",
+            AllowMultiple = false
+        });
+
+        var path = folders.FirstOrDefault()?.TryGetLocalPath();
+        if (!string.IsNullOrWhiteSpace(path)) await _viewModel.ScanCardAsync(path);
+    }
+
+    private async void Import_Click(object? sender, RoutedEventArgs e)
+    {
+        if (_viewModel is not null) await _viewModel.StartImportAsync();
+    }
+
+    private void Cancel_Click(object? sender, RoutedEventArgs e)
+    {
+        _viewModel?.CancelImport();
+    }
+
+    private void ShowAndActivate()
+    {
+        if (!IsVisible) Show();
+        WindowState = WindowState.Normal;
+        Activate();
     }
 }

--- a/src/PhotoOrganizer.App/MainWindowViewModel.cs
+++ b/src/PhotoOrganizer.App/MainWindowViewModel.cs
@@ -1,0 +1,535 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Avalonia.Media;
+using Avalonia.Threading;
+using PhotoOrganizer.Core;
+
+namespace PhotoOrganizer.App;
+
+public sealed class MainWindowViewModel : INotifyPropertyChanged, IDisposable
+{
+    private readonly IStorageVolumeProvider _volumeProvider;
+    private readonly StorageSessionTracker _storageSessions;
+    private readonly CameraCardRootResolver _cardRoots;
+    private readonly AppPreferencesStore _preferencesStore = new();
+    private readonly IStartupRegistrationService _startupRegistration = new StartupRegistrationService();
+    private readonly List<string> _logLines = [];
+    private readonly List<string> _pendingCards = [];
+
+    private MediaClassifier _classifier;
+    private ImportCoordinator _coordinator;
+    private ImportScanSession? _scanSession;
+    private CancellationTokenSource? _importCancellation;
+    private bool _isScanning;
+    private bool _isProcessing;
+    private bool _changingAutoStart;
+
+    private string _destinationPath;
+    private string _eventName = string.Empty;
+    private string _selectedSdPath = string.Empty;
+    private string _rawExtensionsText;
+    private string _countLabel = "RAW:0 / JPG:0 / MP4:0";
+    private string _progressLabel = "待機中";
+    private string _logText = string.Empty;
+    private string _safetyHeadline = "未検証 — 最終確認が完了するまでSDカードを再利用しないでください";
+    private string _safetyDetail = "判定対象: JPG/JPEG・設定済みRAW・MOV/MP4。その他の形式は取り込み・判定対象外です。";
+    private IBrush _safetyBrush = Brushes.DarkOrange;
+    private bool _autoStart;
+
+    public MainWindowViewModel(
+        IStorageVolumeProvider volumeProvider,
+        StorageSessionTracker storageSessions,
+        CameraCardRootResolver cardRoots)
+    {
+        _volumeProvider = volumeProvider;
+        _storageSessions = storageSessions;
+        _cardRoots = cardRoots;
+
+        var preferences = _preferencesStore.Load();
+        _destinationPath = preferences.DestinationPath;
+        _rawExtensionsText = string.Join(", ", preferences.RawExtensions);
+        _autoStart = _startupRegistration.IsEnabled();
+        _classifier = new MediaClassifier(ParseRawExtensions(_rawExtensionsText));
+        _coordinator = CreateCoordinator();
+
+        _storageSessions.VolumeMounted += OnVolumeMounted;
+        _storageSessions.VolumeRemoved += OnVolumeRemoved;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    public event Action? RequestShowWindow;
+
+    public string DestinationPath
+    {
+        get => _destinationPath;
+        set
+        {
+            if (!SetField(ref _destinationPath, value)) return;
+            InvalidateSafety("保存先が変更されました。次の取り込み後に再検証が必要です。");
+            SavePreferences();
+            RaiseCommandState();
+        }
+    }
+
+    public string EventName
+    {
+        get => _eventName;
+        set
+        {
+            if (!SetField(ref _eventName, value)) return;
+            RaiseCommandState();
+        }
+    }
+
+    public string SelectedSdPath
+    {
+        get => _selectedSdPath;
+        private set => SetField(ref _selectedSdPath, value);
+    }
+
+    public string RawExtensionsText
+    {
+        get => _rawExtensionsText;
+        set
+        {
+            if (!SetField(ref _rawExtensionsText, value)) return;
+            if (!IsBusy)
+            {
+                RebuildCoordinator();
+                ClearScanSession();
+                InvalidateSafety("RAW拡張子設定が変更されました。SDカードを再スキャンしてください。");
+            }
+            SavePreferences();
+            RaiseCommandState();
+        }
+    }
+
+    public string CountLabel
+    {
+        get => _countLabel;
+        private set => SetField(ref _countLabel, value);
+    }
+
+    public string ProgressLabel
+    {
+        get => _progressLabel;
+        private set => SetField(ref _progressLabel, value);
+    }
+
+    public string LogText
+    {
+        get => _logText;
+        private set => SetField(ref _logText, value);
+    }
+
+    public string SafetyHeadline
+    {
+        get => _safetyHeadline;
+        private set => SetField(ref _safetyHeadline, value);
+    }
+
+    public string SafetyDetail
+    {
+        get => _safetyDetail;
+        private set => SetField(ref _safetyDetail, value);
+    }
+
+    public IBrush SafetyBrush
+    {
+        get => _safetyBrush;
+        private set => SetField(ref _safetyBrush, value);
+    }
+
+    public bool AutoStart
+    {
+        get => _autoStart;
+        set
+        {
+            if (_changingAutoStart || value == _autoStart) return;
+
+            if (_startupRegistration.SetEnabled(value, out var error))
+            {
+                SetField(ref _autoStart, value);
+                AppendLog(value ? "ログイン時自動起動を有効にしました。" : "ログイン時自動起動を無効にしました。");
+                SavePreferences();
+                return;
+            }
+
+            AppendLog($"ログイン時自動起動の設定に失敗しました: {error}");
+            _changingAutoStart = true;
+            SetField(ref _autoStart, _startupRegistration.IsEnabled());
+            _changingAutoStart = false;
+        }
+    }
+
+    public bool AutoStartSupported => _startupRegistration.IsSupported;
+    public bool IsBusy => _isScanning || _isProcessing;
+    public bool IsProcessing => _isProcessing;
+    public bool CanImport => !IsBusy
+        && _scanSession is not null
+        && !string.IsNullOrWhiteSpace(DestinationPath)
+        && !string.IsNullOrWhiteSpace(EventName);
+    public bool CanCancel => _isProcessing;
+    public int PendingSdCount => _pendingCards.Count;
+    public string PendingSdText => PendingSdCount == 0
+        ? string.Empty
+        : $"待機中のSDカード: {PendingSdCount} 枚 — 現在のカードを切り替えず保持しています";
+
+    public async Task InitializeAsync()
+    {
+        var candidates = _cardRoots.GetCandidateRoots();
+        if (candidates.Count == 0) return;
+
+        await ScanCardAsync(candidates[0], autoDetected: true).ConfigureAwait(true);
+        foreach (var candidate in candidates.Skip(1)) QueueCard(candidate);
+    }
+
+    public async Task ScanCardAsync(string path, bool autoDetected = false)
+    {
+        if (string.IsNullOrWhiteSpace(path)) return;
+        if (IsBusy)
+        {
+            QueueCard(path);
+            return;
+        }
+
+        _isScanning = true;
+        RaiseCommandState();
+        ClearScanSession();
+        InvalidateSafety("SDカードをスキャン中です。再利用しないでください。");
+        ProgressLabel = "SDカードをスキャン中...";
+        AppendLog($"スキャン開始: {path}");
+
+        try
+        {
+            RebuildCoordinator();
+            var result = await Task.Run(() => _coordinator.ScanCard(path)).ConfigureAwait(true);
+            if (!result.IsReady)
+            {
+                if (autoDetected && result.Message.Contains("No supported media", StringComparison.OrdinalIgnoreCase))
+                {
+                    AppendLog($"自動選択スキップ（対象メディアなし）: {path}");
+                    ProgressLabel = "待機中";
+                    return;
+                }
+
+                SetBlocked(result.Message);
+                ProgressLabel = "スキャン失敗";
+                AppendLog($"スキャン失敗: {result.Message}");
+                foreach (var error in result.Errors.Take(5)) AppendLog($"  {error}");
+                return;
+            }
+
+            _scanSession = result.Session;
+            SelectedSdPath = result.Session!.CardRoot;
+            RemoveQueuedCard(result.Session.CardRoot);
+            UpdateCounts(result.Session.Files);
+            SetNotVerified("完全スキャン済み。取り込みと保存先実ファイル検証が完了するまでSDカードを再利用しないでください。");
+            ProgressLabel = "取り込み準備完了";
+            AppendLog($"スキャン完了: {result.Session.Files.Count} 件 / {CountLabel}");
+            RequestShowWindow?.Invoke();
+        }
+        finally
+        {
+            _isScanning = false;
+            RaiseCommandState();
+        }
+    }
+
+    public async Task StartImportAsync()
+    {
+        if (!CanImport || _scanSession is null) return;
+
+        var session = _scanSession;
+        var destination = DestinationPath;
+        var eventName = EventName.Trim();
+        _isProcessing = true;
+        _importCancellation = new CancellationTokenSource();
+        RaiseCommandState();
+        SetNotVerified("コピー処理中です。最終検証が完了するまでSDカードを再利用しないでください。");
+        ProgressLabel = "コピー準備中...";
+        AppendLog("取り込み開始。コピー完了だけではSDカード再利用可能とは判定しません。");
+
+        try
+        {
+            var progress = new Progress<ImportProgress>(update =>
+            {
+                ProgressLabel = update.Message;
+                if (update.Phase == ImportProgressPhase.Verifying)
+                {
+                    SafetyHeadline = "保存先コピーを検証中 — SDカードを再利用しないでください";
+                    SafetyBrush = Brushes.DarkOrange;
+                }
+                if (update.Phase == ImportProgressPhase.Rescanning)
+                {
+                    AppendLog("コピー処理完了。SDカード全体の再スキャンと実bytes検証を開始します。");
+                }
+            });
+
+            var result = await _coordinator.ImportAsync(
+                session,
+                destination,
+                eventName,
+                progress,
+                _importCancellation.Token).ConfigureAwait(true);
+
+            AppendLog($"処理結果: コピー {result.Summary.Copied} / 既存一致 {result.Summary.SkippedAlreadyBackedUp} / 失敗 {result.Summary.Failed}");
+            if (!string.IsNullOrWhiteSpace(result.Summary.BasePath)) AppendLog($"保存先: {result.Summary.BasePath}");
+            foreach (var warning in result.Summary.Warnings.Take(5)) AppendLog($"警告: {warning}");
+            foreach (var error in result.Summary.Errors.Take(5)) AppendLog($"エラー: {error}");
+
+            if (result.IsSafeToReuse)
+            {
+                var verified = result.Verification?.Verified ?? 0;
+                SafetyHeadline = "保存先コピー検証済み — SDカード再利用可能";
+                SafetyDetail = $"対象メディア {verified} 件について、取り込み後のSD再スキャンと保存先実ファイルのサイズ・SHA-256一致を確認済みです。これは指定保存先1か所へのコピー検証であり、二重バックアップ済みという意味ではありません。";
+                SafetyBrush = Brushes.ForestGreen;
+                ProgressLabel = "保存先コピー検証済み";
+                AppendLog($"最終確認完了: {verified} 件を実ファイルとSHA-256照合しました。SDカードを再利用できます。");
+            }
+            else
+            {
+                SetBlocked(result.Message);
+                ProgressLabel = result.Summary.Failed > 0 ? "一部失敗" : "要確認";
+                AppendLog($"最終確認失敗: {result.Message}");
+            }
+        }
+        finally
+        {
+            _importCancellation.Dispose();
+            _importCancellation = null;
+            _isProcessing = false;
+            RaiseCommandState();
+
+            if (_scanSession is null)
+            {
+                await ScanNextPendingIfPossibleAsync().ConfigureAwait(true);
+            }
+        }
+    }
+
+    public void CancelImport()
+    {
+        if (!_isProcessing) return;
+        AppendLog("キャンセル要求: 最終検証が完了しないためSDカードは再利用不可のままです。");
+        _importCancellation?.Cancel();
+    }
+
+    public void SetDestinationFromPicker(string path)
+    {
+        if (!IsBusy) DestinationPath = path;
+    }
+
+    public bool CanCloseWindow()
+    {
+        if (!_isProcessing) return true;
+        AppendLog("処理中の通常終了を抑止しました。必要ならキャンセルして処理終了後に閉じてください。");
+        return false;
+    }
+
+    private ImportCoordinator CreateCoordinator() => new(
+        _classifier,
+        _storageSessions,
+        _cardRoots,
+        _volumeProvider);
+
+    private void RebuildCoordinator()
+    {
+        _classifier = new MediaClassifier(ParseRawExtensions(RawExtensionsText));
+        _coordinator = CreateCoordinator();
+    }
+
+    private static string[] ParseRawExtensions(string text) => text
+        .Split([',', ';', ' ', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+        .Select(extension => extension.StartsWith('.') ? extension.ToLowerInvariant() : "." + extension.ToLowerInvariant())
+        .Distinct(StringComparer.OrdinalIgnoreCase)
+        .ToArray();
+
+    private void UpdateCounts(IEnumerable<string> files)
+    {
+        var raw = 0;
+        var jpg = 0;
+        var video = 0;
+        foreach (var file in files)
+        {
+            switch (_classifier.Classify(file))
+            {
+                case MediaKind.Raw: raw++; break;
+                case MediaKind.Jpeg: jpg++; break;
+                case MediaKind.Video: video++; break;
+            }
+        }
+        CountLabel = $"RAW:{raw} / JPG:{jpg} / MP4:{video}";
+    }
+
+    private void SetBlocked(string message)
+    {
+        SafetyHeadline = "SDカードを再利用しないでください";
+        SafetyDetail = message;
+        SafetyBrush = Brushes.IndianRed;
+    }
+
+    private void SetNotVerified(string detail)
+    {
+        SafetyHeadline = "未検証 — 最終確認が完了するまでSDカードを再利用しないでください";
+        SafetyDetail = detail;
+        SafetyBrush = Brushes.DarkOrange;
+    }
+
+    private void InvalidateSafety(string detail) => SetNotVerified(detail);
+
+    private void ClearScanSession()
+    {
+        _scanSession = null;
+        SelectedSdPath = string.Empty;
+        CountLabel = "RAW:0 / JPG:0 / MP4:0";
+        RaiseCommandState();
+    }
+
+    private void OnVolumeMounted(string root)
+    {
+        Dispatcher.UIThread.Post(() => _ = HandleVolumeMountedAsync(root));
+    }
+
+    private async Task HandleVolumeMountedAsync(string root)
+    {
+        string? candidate = null;
+        for (var attempt = 0; attempt < 5 && candidate is null; attempt++)
+        {
+            candidate = _cardRoots.Resolve(root);
+            if (candidate is null) await Task.Delay(300).ConfigureAwait(true);
+        }
+        if (candidate is null) return;
+
+        AppendLog($"カメラカード検出: {candidate}");
+        if (_scanSession is not null || IsBusy)
+        {
+            QueueCard(candidate);
+            RequestShowWindow?.Invoke();
+            return;
+        }
+
+        await ScanCardAsync(candidate, autoDetected: true).ConfigureAwait(true);
+    }
+
+    private void OnVolumeRemoved(string root)
+    {
+        Dispatcher.UIThread.Post(() => _ = HandleVolumeRemovedAsync(root));
+    }
+
+    private async Task HandleVolumeRemovedAsync(string root)
+    {
+        RemoveQueuedCard(root, volumeRemoval: true);
+        var selectedRemoved = _scanSession is not null
+            && PathSafety.IsSameOrDescendant(_scanSession.CardRoot, root, _storageSessions.PathComparison);
+        var destinationRemoved = !string.IsNullOrWhiteSpace(DestinationPath)
+            && PathSafety.IsSameOrDescendant(DestinationPath, root, _storageSessions.PathComparison);
+
+        if (selectedRemoved)
+        {
+            ClearScanSession();
+            SetBlocked("選択中のSDカードが取り外されました。再スキャンと最終検証なしに再利用可能とは判定しません。");
+            AppendLog("SDカード取り外し: スキャン結果と安全確認状態をリセットしました。");
+        }
+
+        if (destinationRemoved)
+        {
+            SetBlocked("保存先ボリュームが取り外されました。保存先を再確認して取り込み・検証をやり直してください。");
+            AppendLog("保存先ボリューム取り外し: 安全確認状態をリセットしました。");
+        }
+
+        if ((selectedRemoved || destinationRemoved) && _isProcessing)
+        {
+            AppendLog("警告: 処理中に使用ストレージが取り外されました。最終判定はfail-closedになります。");
+        }
+
+        if (selectedRemoved && !IsBusy)
+        {
+            await ScanNextPendingIfPossibleAsync().ConfigureAwait(true);
+        }
+    }
+
+    private void QueueCard(string path)
+    {
+        var normalized = PathSafety.Normalize(path);
+        if (_scanSession is not null
+            && string.Equals(_scanSession.CardRoot, normalized, _storageSessions.PathComparison)) return;
+        if (_pendingCards.Any(item => string.Equals(item, normalized, _storageSessions.PathComparison))) return;
+        _pendingCards.Add(normalized);
+        RaisePendingState();
+        AppendLog($"SDカード待機: {normalized}");
+    }
+
+    private void RemoveQueuedCard(string path, bool volumeRemoval = false)
+    {
+        var normalized = PathSafety.Normalize(path);
+        _pendingCards.RemoveAll(candidate => volumeRemoval
+            ? PathSafety.IsSameOrDescendant(candidate, normalized, _storageSessions.PathComparison)
+            : string.Equals(candidate, normalized, _storageSessions.PathComparison));
+        RaisePendingState();
+    }
+
+    private async Task ScanNextPendingIfPossibleAsync()
+    {
+        if (IsBusy || _scanSession is not null) return;
+        while (_pendingCards.Count > 0)
+        {
+            var next = _pendingCards[0];
+            _pendingCards.RemoveAt(0);
+            RaisePendingState();
+            if (!Directory.Exists(next)) continue;
+            await ScanCardAsync(next, autoDetected: true).ConfigureAwait(true);
+            if (_scanSession is not null) return;
+        }
+    }
+
+    private void AppendLog(string message)
+    {
+        var timestamp = DateTime.Now.ToString("HH:mm:ss");
+        _logLines.Add($"{timestamp} {message}");
+        if (_logLines.Count > 1000) _logLines.RemoveRange(0, _logLines.Count - 1000);
+        LogText = string.Join(Environment.NewLine, _logLines);
+    }
+
+    private void SavePreferences()
+    {
+        var preferences = new AppPreferences(DestinationPath, ParseRawExtensions(RawExtensionsText), AutoStart);
+        if (!_preferencesStore.Save(preferences, out var error) && !string.IsNullOrWhiteSpace(error))
+        {
+            AppendLog($"設定保存失敗: {error}");
+        }
+    }
+
+    private void RaiseCommandState()
+    {
+        OnPropertyChanged(nameof(IsBusy));
+        OnPropertyChanged(nameof(IsProcessing));
+        OnPropertyChanged(nameof(CanImport));
+        OnPropertyChanged(nameof(CanCancel));
+    }
+
+    private void RaisePendingState()
+    {
+        OnPropertyChanged(nameof(PendingSdCount));
+        OnPropertyChanged(nameof(PendingSdText));
+    }
+
+    private bool SetField<T>(ref T field, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(field, value)) return false;
+        field = value;
+        OnPropertyChanged(propertyName);
+        return true;
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+
+    public void Dispose()
+    {
+        _storageSessions.VolumeMounted -= OnVolumeMounted;
+        _storageSessions.VolumeRemoved -= OnVolumeRemoved;
+        _importCancellation?.Cancel();
+        _importCancellation?.Dispose();
+    }
+}

--- a/src/PhotoOrganizer.App/StartupRegistrationService.cs
+++ b/src/PhotoOrganizer.App/StartupRegistrationService.cs
@@ -1,0 +1,188 @@
+using System.Diagnostics;
+using System.Security;
+using Microsoft.Win32;
+
+namespace PhotoOrganizer.App;
+
+public interface IStartupRegistrationService
+{
+    bool IsSupported { get; }
+    bool IsEnabled();
+    bool SetEnabled(bool enabled, out string? error);
+}
+
+public sealed class StartupRegistrationService : IStartupRegistrationService
+{
+    private const string WindowsRunKey = @"Software\Microsoft\Windows\CurrentVersion\Run";
+    private const string WindowsValueName = "PhotoOrganizer";
+    private const string MacLabel = "com.peachgumi.photoorganizer";
+
+    public bool IsSupported => OperatingSystem.IsWindows() || OperatingSystem.IsMacOS();
+
+    public bool IsEnabled()
+    {
+        try
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                using var key = Registry.CurrentUser.OpenSubKey(WindowsRunKey, writable: false);
+                return key?.GetValue(WindowsValueName) is string value && !string.IsNullOrWhiteSpace(value);
+            }
+
+            if (OperatingSystem.IsMacOS()) return File.Exists(GetMacPlistPath());
+        }
+        catch
+        {
+            // Settings UI must fail closed rather than claiming startup is enabled.
+        }
+
+        return false;
+    }
+
+    public bool SetEnabled(bool enabled, out string? error)
+    {
+        try
+        {
+            if (OperatingSystem.IsWindows()) return SetWindows(enabled, out error);
+            if (OperatingSystem.IsMacOS()) return SetMac(enabled, out error);
+            error = "Login startup is not supported on this operating system.";
+            return false;
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+            return false;
+        }
+    }
+
+    private static bool SetWindows(bool enabled, out string? error)
+    {
+        using var key = Registry.CurrentUser.CreateSubKey(WindowsRunKey, writable: true);
+        if (key is null)
+        {
+            error = "Unable to open the Windows login startup registry key.";
+            return false;
+        }
+
+        if (!enabled)
+        {
+            key.DeleteValue(WindowsValueName, throwOnMissingValue: false);
+            error = null;
+            return true;
+        }
+
+        var executable = GetRunnableExecutable();
+        if (executable is null)
+        {
+            error = "The packaged application executable could not be identified.";
+            return false;
+        }
+
+        key.SetValue(WindowsValueName, $"\"{executable}\" --background", RegistryValueKind.String);
+        error = null;
+        return true;
+    }
+
+    private static bool SetMac(bool enabled, out string? error)
+    {
+        var plistPath = GetMacPlistPath();
+        if (!enabled)
+        {
+            TryBootout(plistPath);
+            if (File.Exists(plistPath)) File.Delete(plistPath);
+            error = null;
+            return true;
+        }
+
+        var executable = GetRunnableExecutable();
+        if (executable is null)
+        {
+            error = "The packaged application executable could not be identified.";
+            return false;
+        }
+
+        var directory = Path.GetDirectoryName(plistPath)!;
+        Directory.CreateDirectory(directory);
+        var escapedExecutable = SecurityElement.Escape(executable) ?? executable;
+        var plist = $"""<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>{MacLabel}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>{escapedExecutable}</string>
+    <string>--background</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+</dict>
+</plist>
+""";
+
+        var temporary = plistPath + ".tmp-" + Guid.NewGuid().ToString("N");
+        File.WriteAllText(temporary, plist);
+        File.Move(temporary, plistPath, overwrite: true);
+        TryBootstrap(plistPath);
+        error = null;
+        return true;
+    }
+
+    private static string? GetRunnableExecutable()
+    {
+        var executable = Environment.ProcessPath;
+        if (string.IsNullOrWhiteSpace(executable) || !File.Exists(executable)) return null;
+        if (string.Equals(Path.GetFileNameWithoutExtension(executable), "dotnet", StringComparison.OrdinalIgnoreCase)) return null;
+        return executable;
+    }
+
+    private static string GetMacPlistPath() => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        "Library",
+        "LaunchAgents",
+        MacLabel + ".plist");
+
+    private static void TryBootstrap(string plistPath)
+    {
+        RunLaunchctl("bootstrap", $"gui/{GetEffectiveUserId()}", plistPath);
+    }
+
+    private static void TryBootout(string plistPath)
+    {
+        RunLaunchctl("bootout", $"gui/{GetEffectiveUserId()}", plistPath);
+    }
+
+    private static void RunLaunchctl(params string[] arguments)
+    {
+        if (!OperatingSystem.IsMacOS() || !File.Exists("/bin/launchctl")) return;
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "/bin/launchctl",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true
+                }
+            };
+            foreach (var argument in arguments) process.StartInfo.ArgumentList.Add(argument);
+            if (!process.Start()) return;
+            process.WaitForExit(3000);
+        }
+        catch
+        {
+            // The LaunchAgent file still controls the next-login state.
+        }
+    }
+
+    private static uint GetEffectiveUserId()
+    {
+        if (!OperatingSystem.IsMacOS()) return 0;
+        return geteuid();
+    }
+
+    [System.Runtime.InteropServices.DllImport("libSystem.B.dylib")]
+    private static extern uint geteuid();
+}

--- a/src/PhotoOrganizer.App/StartupRegistrationService.cs
+++ b/src/PhotoOrganizer.App/StartupRegistrationService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.Versioning;
 using System.Security;
 using Microsoft.Win32;
 
@@ -23,12 +24,7 @@ public sealed class StartupRegistrationService : IStartupRegistrationService
     {
         try
         {
-            if (OperatingSystem.IsWindows())
-            {
-                using var key = Registry.CurrentUser.OpenSubKey(WindowsRunKey, writable: false);
-                return key?.GetValue(WindowsValueName) is string value && !string.IsNullOrWhiteSpace(value);
-            }
-
+            if (OperatingSystem.IsWindows()) return IsWindowsEnabled();
             if (OperatingSystem.IsMacOS()) return File.Exists(GetMacPlistPath());
         }
         catch
@@ -55,6 +51,14 @@ public sealed class StartupRegistrationService : IStartupRegistrationService
         }
     }
 
+    [SupportedOSPlatform("windows")]
+    private static bool IsWindowsEnabled()
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(WindowsRunKey, writable: false);
+        return key?.GetValue(WindowsValueName) is string value && !string.IsNullOrWhiteSpace(value);
+    }
+
+    [SupportedOSPlatform("windows")]
     private static bool SetWindows(bool enabled, out string? error)
     {
         using var key = Registry.CurrentUser.CreateSubKey(WindowsRunKey, writable: true);
@@ -78,11 +82,12 @@ public sealed class StartupRegistrationService : IStartupRegistrationService
             return false;
         }
 
-        key.SetValue(WindowsValueName, $"\"{executable}\" --background", RegistryValueKind.String);
+        key.SetValue(WindowsValueName, $"\"{executable}\"", RegistryValueKind.String);
         error = null;
         return true;
     }
 
+    [SupportedOSPlatform("macos")]
     private static bool SetMac(bool enabled, out string? error)
     {
         var plistPath = GetMacPlistPath();
@@ -112,7 +117,6 @@ public sealed class StartupRegistrationService : IStartupRegistrationService
   <key>ProgramArguments</key>
   <array>
     <string>{escapedExecutable}</string>
-    <string>--background</string>
   </array>
   <key>RunAtLoad</key><true/>
 </dict>
@@ -141,19 +145,16 @@ public sealed class StartupRegistrationService : IStartupRegistrationService
         "LaunchAgents",
         MacLabel + ".plist");
 
-    private static void TryBootstrap(string plistPath)
-    {
-        RunLaunchctl("bootstrap", $"gui/{GetEffectiveUserId()}", plistPath);
-    }
+    [SupportedOSPlatform("macos")]
+    private static void TryBootstrap(string plistPath) => RunLaunchctl("bootstrap", $"gui/{geteuid()}", plistPath);
 
-    private static void TryBootout(string plistPath)
-    {
-        RunLaunchctl("bootout", $"gui/{GetEffectiveUserId()}", plistPath);
-    }
+    [SupportedOSPlatform("macos")]
+    private static void TryBootout(string plistPath) => RunLaunchctl("bootout", $"gui/{geteuid()}", plistPath);
 
+    [SupportedOSPlatform("macos")]
     private static void RunLaunchctl(params string[] arguments)
     {
-        if (!OperatingSystem.IsMacOS() || !File.Exists("/bin/launchctl")) return;
+        if (!File.Exists("/bin/launchctl")) return;
         try
         {
             using var process = new Process
@@ -177,12 +178,7 @@ public sealed class StartupRegistrationService : IStartupRegistrationService
         }
     }
 
-    private static uint GetEffectiveUserId()
-    {
-        if (!OperatingSystem.IsMacOS()) return 0;
-        return geteuid();
-    }
-
-    [System.Runtime.InteropServices.DllImport("libSystem.B.dylib")]
+    [DllImport("libSystem.B.dylib")]
+    [SupportedOSPlatform("macos")]
     private static extern uint geteuid();
 }

--- a/src/PhotoOrganizer.App/StartupRegistrationService.cs
+++ b/src/PhotoOrganizer.App/StartupRegistrationService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Security;
 using Microsoft.Win32;
@@ -109,19 +110,20 @@ public sealed class StartupRegistrationService : IStartupRegistrationService
         var directory = Path.GetDirectoryName(plistPath)!;
         Directory.CreateDirectory(directory);
         var escapedExecutable = SecurityElement.Escape(executable) ?? executable;
-        var plist = $"""<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key><string>{MacLabel}</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>{escapedExecutable}</string>
-  </array>
-  <key>RunAtLoad</key><true/>
-</dict>
-</plist>
-""";
+        var plist = string.Join('\n',
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+            "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">",
+            "<plist version=\"1.0\">",
+            "<dict>",
+            $"  <key>Label</key><string>{MacLabel}</string>",
+            "  <key>ProgramArguments</key>",
+            "  <array>",
+            $"    <string>{escapedExecutable}</string>",
+            "  </array>",
+            "  <key>RunAtLoad</key><true/>",
+            "</dict>",
+            "</plist>",
+            string.Empty);
 
         var temporary = plistPath + ".tmp-" + Guid.NewGuid().ToString("N");
         File.WriteAllText(temporary, plist);


### PR DESCRIPTION
Closes #4

Replaces the bootstrap window with the shared Windows/macOS Avalonia workflow and wires all user actions through the shared fail-closed `ImportCoordinator`.

- destination picker and event-name input
- manual camera-card selection plus automatic detected-card handling
- supported-media counts and queued second-card status
- RAW extension settings shared by both platforms
- platform login-startup adapter
- import/cancel controls
- explicit separation of copy completion from verified safe-to-reuse state
- green reuse state only after the shared Core returns `SafeToReuse`
- storage removal immediately invalidates the visible safety state
- normal window close is blocked while an import is active
- settings persist, but safety approval never persists across app restarts
- file/folder selection uses Avalonia 12 StorageProvider APIs

The view layer contains no alternate copy or verification implementation; Windows and macOS use the same Core state machine.