### PR TITLE
Add fail-closed signed Windows/macOS release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,16 +46,57 @@ jobs:
       - name: Build unified desktop app
         run: dotnet build src/PhotoOrganizer.App/PhotoOrganizer.App.csproj --configuration Release --no-restore
 
+  release-contract:
+    name: Release contract
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      - name: Parse workflow YAML and packaging XML
+        shell: bash
+        run: |
+          set -euo pipefail
+          ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml')"
+          python3 - <<'PY'
+          import xml.etree.ElementTree as ET
+          ET.parse('packaging/macos/PhotoOrganizer.entitlements')
+          PY
+
+      - name: Validate release helper syntax
+        shell: bash
+        run: bash -n Scripts/configure_release_secrets.sh
+
+      - name: Enforce fail-closed release contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          workflow=.github/workflows/release.yml
+          for secret in \
+            WINDOWS_CERTIFICATE WINDOWS_CERTIFICATE_PASSWORD \
+            MACOS_CERTIFICATE MACOS_CERTIFICATE_PASSWORD DEVELOPER_ID_APPLICATION \
+            APPLE_ID APPLE_TEAM_ID APPLE_APP_SPECIFIC_PASSWORD; do
+            grep -q "$secret" "$workflow"
+          done
+          grep -q 'needs: \[preflight, windows, macos\]' "$workflow"
+          grep -q 'signtool' "$workflow"
+          grep -q 'notarytool submit' "$workflow"
+          grep -q 'stapler validate' "$workflow"
+          grep -q 'sha256sum -c' "$workflow"
+          grep -q 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' "$workflow"
+          grep -q 'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c' "$workflow"
+
   required:
     name: required
     if: always()
-    needs: test-and-build
+    needs: [test-and-build, release-contract]
     runs-on: ubuntu-latest
     steps:
-      - name: Require every platform job
+      - name: Require every platform and release-contract job
         shell: bash
         run: |
-          if [ "${{ needs.test-and-build.result }}" != "success" ]; then
-            echo "At least one required Windows/macOS CI job failed."
+          if [ "${{ needs.test-and-build.result }}" != "success" ] || \
+             [ "${{ needs.release-contract.result }}" != "success" ]; then
+            echo "At least one required Windows/macOS/release-contract job failed."
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,417 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - 'release/v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release tag (for example v1.0.0)'
+        required: true
+        default: 'v1.0.0'
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  DOTNET_VERSION: 10.0.400
+
+jobs:
+  preflight:
+    name: Signing preflight
+    runs-on: ubuntu-latest
+    outputs:
+      release_tag: ${{ steps.version.outputs.release_tag }}
+      version: ${{ steps.version.outputs.version }}
+    env:
+      WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+      WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+      MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+      MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+      DEVELOPER_ID_APPLICATION: ${{ secrets.DEVELOPER_ID_APPLICATION }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+    steps:
+      - name: Resolve release version
+        id: version
+        shell: bash
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            RELEASE_TAG="$GITHUB_REF_NAME"
+          elif [[ "$GITHUB_REF_NAME" == release/v* ]]; then
+            RELEASE_TAG="${GITHUB_REF_NAME#release/}"
+          else
+            RELEASE_TAG="${DISPATCH_VERSION:-}"
+          fi
+
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag must match vMAJOR.MINOR.PATCH: $RELEASE_TAG"
+            exit 1
+          fi
+
+          VERSION="${RELEASE_TAG#v}"
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Release $RELEASE_TAG from exact commit $GITHUB_SHA"
+
+      - name: Require every production signing secret
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=0
+          for name in \
+            WINDOWS_CERTIFICATE WINDOWS_CERTIFICATE_PASSWORD \
+            MACOS_CERTIFICATE MACOS_CERTIFICATE_PASSWORD DEVELOPER_ID_APPLICATION \
+            APPLE_ID APPLE_TEAM_ID APPLE_APP_SPECIFIC_PASSWORD; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "::error::Missing required repository secret: $name"
+              missing=1
+            fi
+          done
+          if [[ "$missing" -ne 0 ]]; then
+            echo "::error::Production release aborted before any release artifact was built or published."
+            exit 1
+          fi
+
+  windows:
+    name: Signed Windows packages
+    needs: preflight
+    runs-on: windows-latest
+    timeout-minutes: 45
+    env:
+      VERSION: ${{ needs.preflight.outputs.version }}
+      WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+      WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+    steps:
+      - name: Checkout exact release commit
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Run shared safety tests from release commit
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          dotnet restore tests/PhotoOrganizer.Core.Tests/PhotoOrganizer.Core.Tests.csproj
+          dotnet test tests/PhotoOrganizer.Core.Tests/PhotoOrganizer.Core.Tests.csproj --configuration Release --no-restore
+
+      - name: Decode Windows signing certificate
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $encoded = ($env:WINDOWS_CERTIFICATE -replace '\s', '')
+          [IO.File]::WriteAllBytes("$env:RUNNER_TEMP\windows-signing.pfx", [Convert]::FromBase64String($encoded))
+
+      - name: Locate SignTool
+        id: signtool
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $tool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\x64\signtool.exe" |
+            Sort-Object FullName -Descending |
+            Select-Object -First 1
+          if (-not $tool) { throw 'signtool.exe was not found on the GitHub-hosted Windows runner.' }
+          "path=$($tool.FullName)" >> $env:GITHUB_OUTPUT
+
+      - name: Publish, Authenticode-sign, verify and package Windows builds
+        shell: pwsh
+        env:
+          SIGNTOOL: ${{ steps.signtool.outputs.path }}
+        run: |
+          $ErrorActionPreference = 'Stop'
+          New-Item -ItemType Directory -Force -Path release-assets | Out-Null
+
+          foreach ($arch in @('x64', 'arm64')) {
+            $rid = "win-$arch"
+            $publish = "build\$rid\publish"
+            dotnet publish src/PhotoOrganizer.App/PhotoOrganizer.App.csproj `
+              --configuration Release `
+              --runtime $rid `
+              --self-contained true `
+              -p:Version=$env:VERSION `
+              -p:ContinuousIntegrationBuild=true `
+              --output $publish
+
+            foreach ($file in @(
+              "$publish\PhotoOrganizer.exe",
+              "$publish\PhotoOrganizer.dll",
+              "$publish\PhotoOrganizer.Core.dll"
+            )) {
+              if (-not (Test-Path $file)) { throw "Required release binary missing: $file" }
+              & $env:SIGNTOOL sign /f "$env:RUNNER_TEMP\windows-signing.pfx" `
+                /p $env:WINDOWS_CERTIFICATE_PASSWORD `
+                /fd SHA256 `
+                /tr https://timestamp.digicert.com `
+                /td SHA256 `
+                /d "Photo Organizer" `
+                $file
+              if ($LASTEXITCODE -ne 0) { throw "Signing failed: $file" }
+              & $env:SIGNTOOL verify /pa /all /v $file
+              if ($LASTEXITCODE -ne 0) { throw "Signature verification failed: $file" }
+            }
+
+            Copy-Item LICENSE "$publish\LICENSE.txt"
+            $zip = "release-assets\PhotoOrganizer-Windows-$arch-$env:VERSION.zip"
+            if (Test-Path $zip) { Remove-Item $zip -Force }
+            Compress-Archive -Path "$publish\*" -DestinationPath $zip -CompressionLevel Optimal
+            $hash = (Get-FileHash -Algorithm SHA256 $zip).Hash.ToLowerInvariant()
+            $name = [IO.Path]::GetFileName($zip)
+            "$hash  $name" | Set-Content -NoNewline "$zip.sha256"
+          }
+
+      - name: Upload signed Windows release assets
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: windows-release
+          path: release-assets/*
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Remove Windows signing material
+        if: always()
+        shell: pwsh
+        run: Remove-Item "$env:RUNNER_TEMP\windows-signing.pfx" -Force -ErrorAction SilentlyContinue
+
+  macos:
+    name: Signed and notarized macOS packages
+    needs: preflight
+    runs-on: macos-15
+    timeout-minutes: 120
+    env:
+      VERSION: ${{ needs.preflight.outputs.version }}
+      MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+      MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
+      DEVELOPER_ID_APPLICATION: ${{ secrets.DEVELOPER_ID_APPLICATION }}
+      APPLE_ID: ${{ secrets.APPLE_ID }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+    steps:
+      - name: Checkout exact release commit
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Run shared safety tests from release commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          dotnet restore tests/PhotoOrganizer.Core.Tests/PhotoOrganizer.Core.Tests.csproj
+          dotnet test tests/PhotoOrganizer.Core.Tests/PhotoOrganizer.Core.Tests.csproj --configuration Release --no-restore
+          plutil -lint packaging/macos/PhotoOrganizer.entitlements
+
+      - name: Import Developer ID Application certificate
+        shell: bash
+        run: |
+          set -euo pipefail
+          CERTIFICATE_PATH="$RUNNER_TEMP/developer-id.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/photo-organizer-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -hex 32)"
+          export CERTIFICATE_PATH KEYCHAIN_PATH
+
+          python3 - <<'PY'
+          import base64
+          import os
+          from pathlib import Path
+          encoded = "".join(os.environ["MACOS_CERTIFICATE"].split())
+          Path(os.environ["CERTIFICATE_PATH"]).write_bytes(base64.b64decode(encoded, validate=True))
+          PY
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERTIFICATE_PATH" -P "$MACOS_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain-db
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -F "$DEVELOPER_ID_APPLICATION"
+
+      - name: Publish, sign, notarize and package native macOS builds
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets build
+
+          for arch in arm64 x64; do
+            rid="osx-$arch"
+            publish="$PWD/build/$rid/publish"
+            app="$PWD/build/$rid/Photo Organizer.app"
+            contents="$app/Contents"
+            macos="$contents/MacOS"
+            resources="$contents/Resources"
+
+            dotnet publish src/PhotoOrganizer.App/PhotoOrganizer.App.csproj \
+              --configuration Release \
+              --runtime "$rid" \
+              --self-contained true \
+              -p:Version="$VERSION" \
+              -p:ContinuousIntegrationBuild=true \
+              --output "$publish"
+
+            rm -rf "$app"
+            mkdir -p "$macos" "$resources"
+            ditto "$publish" "$macos"
+            chmod +x "$macos/PhotoOrganizer"
+            cp LICENSE "$resources/LICENSE.txt"
+
+            cat > "$contents/Info.plist" <<PLIST
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>CFBundleDevelopmentRegion</key><string>en</string>
+            <key>CFBundleDisplayName</key><string>Photo Organizer</string>
+            <key>CFBundleExecutable</key><string>PhotoOrganizer</string>
+            <key>CFBundleIdentifier</key><string>com.peachgumi.photoorganizer</string>
+            <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+            <key>CFBundleName</key><string>Photo Organizer</string>
+            <key>CFBundlePackageType</key><string>APPL</string>
+            <key>CFBundleShortVersionString</key><string>$VERSION</string>
+            <key>CFBundleVersion</key><string>${GITHUB_RUN_NUMBER}</string>
+            <key>LSMinimumSystemVersion</key><string>13.0</string>
+            <key>NSHighResolutionCapable</key><true/>
+          </dict>
+          </plist>
+          PLIST
+            plutil -lint "$contents/Info.plist"
+
+            main_executable="$macos/PhotoOrganizer"
+            while IFS= read -r -d '' candidate; do
+              if [[ "$candidate" == "$main_executable" ]]; then
+                continue
+              fi
+              if file "$candidate" | grep -q 'Mach-O'; then
+                codesign --force --timestamp --options runtime \
+                  --sign "$DEVELOPER_ID_APPLICATION" "$candidate"
+              fi
+            done < <(find "$app" -type f -print0)
+
+            codesign --force --timestamp --options runtime \
+              --entitlements packaging/macos/PhotoOrganizer.entitlements \
+              --sign "$DEVELOPER_ID_APPLICATION" "$main_executable"
+            codesign --force --timestamp --options runtime \
+              --entitlements packaging/macos/PhotoOrganizer.entitlements \
+              --sign "$DEVELOPER_ID_APPLICATION" "$app"
+            codesign --verify --deep --strict --verbose=2 "$app"
+            codesign -dv --verbose=4 "$app"
+
+            app_zip="$RUNNER_TEMP/PhotoOrganizer-$arch.zip"
+            ditto -c -k --keepParent "$app" "$app_zip"
+            xcrun notarytool submit "$app_zip" \
+              --apple-id "$APPLE_ID" \
+              --team-id "$APPLE_TEAM_ID" \
+              --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+              --wait
+            xcrun stapler staple "$app"
+            xcrun stapler validate "$app"
+            spctl -a -t exec -vv "$app"
+
+            dmg_stage="$PWD/build/$rid/dmg"
+            rm -rf "$dmg_stage"
+            mkdir -p "$dmg_stage"
+            ditto "$app" "$dmg_stage/Photo Organizer.app"
+            ln -s /Applications "$dmg_stage/Applications"
+            cp LICENSE "$dmg_stage/LICENSE.txt"
+
+            dmg="$PWD/release-assets/PhotoOrganizer-macOS-$arch-$VERSION.dmg"
+            hdiutil create \
+              -volname "Photo Organizer" \
+              -srcfolder "$dmg_stage" \
+              -ov -format UDZO "$dmg"
+            hdiutil verify "$dmg"
+            codesign --force --timestamp --sign "$DEVELOPER_ID_APPLICATION" "$dmg"
+            codesign --verify --verbose=2 "$dmg"
+            xcrun notarytool submit "$dmg" \
+              --apple-id "$APPLE_ID" \
+              --team-id "$APPLE_TEAM_ID" \
+              --password "$APPLE_APP_SPECIFIC_PASSWORD" \
+              --wait
+            xcrun stapler staple "$dmg"
+            xcrun stapler validate "$dmg"
+            spctl -a -t open --context context:primary-signature -vvv "$dmg"
+
+            (
+              cd release-assets
+              shasum -a 256 "$(basename "$dmg")" > "$(basename "$dmg").sha256"
+              shasum -a 256 -c "$(basename "$dmg").sha256"
+            )
+          done
+
+      - name: Upload signed macOS release assets
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: macos-release
+          path: release-assets/*
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Remove temporary Apple signing material
+        if: always()
+        shell: bash
+        run: |
+          rm -f "$RUNNER_TEMP/developer-id.p12" "$RUNNER_TEMP"/PhotoOrganizer-*.zip
+          security delete-keychain "$RUNNER_TEMP/photo-organizer-signing.keychain-db" 2>/dev/null || true
+
+  publish:
+    name: Publish complete cross-platform release
+    needs: [preflight, windows, macos]
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ needs.preflight.outputs.release_tag }}
+      VERSION: ${{ needs.preflight.outputs.version }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Download all signed platform artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: '*-release'
+          path: release-assets
+          merge-multiple: true
+
+      - name: Verify complete artifact set and checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd release-assets
+          required=(
+            "PhotoOrganizer-Windows-x64-$VERSION.zip"
+            "PhotoOrganizer-Windows-arm64-$VERSION.zip"
+            "PhotoOrganizer-macOS-arm64-$VERSION.dmg"
+            "PhotoOrganizer-macOS-x64-$VERSION.dmg"
+          )
+          for artifact in "${required[@]}"; do
+            test -s "$artifact" || { echo "::error::Missing release artifact: $artifact"; exit 1; }
+            test -s "$artifact.sha256" || { echo "::error::Missing checksum: $artifact.sha256"; exit 1; }
+            sha256sum -c "$artifact.sha256"
+          done
+
+      - name: Publish GitHub Release only after both platforms succeeded
+        shell: bash
+        run: |
+          set -euo pipefail
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "::error::Release already exists: $RELEASE_TAG"
+            exit 1
+          fi
+          gh release create "$RELEASE_TAG" release-assets/* \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "Photo Organizer $VERSION" \
+            --generate-notes \
+            --latest

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Photo Organizer is the unified Windows/macOS desktop application for safely impo
 It consolidates the product behavior and lessons learned from the original repositories:
 
 - `PeachGumi/PhotoOrganizer-win` — original Windows implementation and Windows integration reference
-- `PeachGumi/PhotoOrganizer-mac` — current data-safety reference implementation
+- `PeachGumi/PhotoOrganizer-mac` — hardened data-safety reference implementation
 
 ## Architecture
 
@@ -16,7 +16,7 @@ The unified product uses:
 - Avalonia desktop UI
 - thin Windows/macOS platform adapters for storage detection, mounted-volume identity, startup integration, lifecycle handling, signing and packaging
 
-Most future fixes should land once in `PhotoOrganizer.Core` and apply to both operating systems.
+The import, duplicate detection, copy integrity and SD-reuse safety state machine live in `PhotoOrganizer.Core` and are shared by both operating systems.
 
 ```text
 src/
@@ -31,7 +31,7 @@ tests/
 
 Photo Organizer must never delete, move, rename, modify, or overwrite source media on the camera card.
 
-Copy completion is **not** equivalent to SD-card reuse approval. Reuse approval requires a fresh complete card scan, storage-identity checks, and byte-for-byte destination verification.
+Copy completion is **not** equivalent to SD-card reuse approval. Reuse approval requires a fresh complete card scan, mount-session storage-identity checks, and byte-for-byte destination verification with file size and SHA-256.
 
 Supported import/reuse-verification scope:
 
@@ -43,6 +43,21 @@ Unsupported sidecars and miscellaneous camera files are intentionally outside th
 
 The normative rules are in [`docs/DATA_SAFETY.md`](docs/DATA_SAFETY.md).
 
+## Unified workflow
+
+The Avalonia application now provides one Windows/macOS workflow for:
+
+- automatic and manual camera-card detection;
+- complete-card scanning even when a nested `DCIM`/`PRIVATE` folder is selected;
+- destination and event-name selection;
+- RAW extension settings;
+- queued second-card handling without changing the active card;
+- copy/cancel progress;
+- explicit blocked/unverified/verified SD-reuse state;
+- platform login-startup integration.
+
+A green `保存先コピー検証済み — SDカード再利用可能` state is produced only by the shared Core after final post-import verification. It is never persisted across application restarts.
+
 ## Development
 
 Required SDK: .NET 10.0.400 or a compatible later feature band selected by `global.json`.
@@ -53,12 +68,18 @@ dotnet test tests/PhotoOrganizer.Core.Tests/PhotoOrganizer.Core.Tests.csproj -c 
 dotnet build src/PhotoOrganizer.App/PhotoOrganizer.App.csproj -c Release
 ```
 
-CI executes shared safety tests and builds the unified desktop app on both Windows and macOS. CodeQL and Dependabot are configured in-repository.
+CI executes shared safety tests and builds the unified desktop app on both Windows and macOS. It also validates the fail-closed release contract. CodeQL and Dependabot are configured in-repository.
+
+## Production release
+
+The release workflow produces signed Windows x64/ARM64 packages and Developer ID signed/notarized macOS Apple Silicon/Intel DMGs from the same version and exact commit. No GitHub Release is created unless both platform signing pipelines succeed and every published artifact passes its SHA-256 verification.
+
+See [`docs/RELEASE.md`](docs/RELEASE.md) for signing setup and [`docs/RELEASE_ACCEPTANCE.md`](docs/RELEASE_ACCEPTANCE.md) for the mandatory real-device acceptance checklist.
 
 ## Migration status
 
-This repository is now the canonical target for new cross-platform development, but it is **not yet a production replacement** for the two legacy applications.
+This repository is the canonical source for new Windows/macOS development. The shared safety Core and unified production workflow have been migrated, but the legacy applications remain available as references until the unified signed artifacts pass real-device acceptance.
 
-The migration stages and retirement criteria are documented in [`docs/MIGRATION_PLAN.md`](docs/MIGRATION_PLAN.md). Existing repositories remain available as references until real-device and signed-release acceptance is complete.
+The migration stages and retirement criteria are documented in [`docs/MIGRATION_PLAN.md`](docs/MIGRATION_PLAN.md).
 
-See also [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) and [`SECURITY.md`](SECURITY.md).
+See also [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md), [`docs/DATA_SAFETY.md`](docs/DATA_SAFETY.md), and [`SECURITY.md`](SECURITY.md).

--- a/Scripts/configure_release_secrets.sh
+++ b/Scripts/configure_release_secrets.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo="${1:-PeachGumi/PhotoOrganizer}"
+
+command -v gh >/dev/null 2>&1 || { echo "GitHub CLI (gh) is required." >&2; exit 1; }
+gh auth status >/dev/null
+
+read -r -p "Windows code-signing PFX path: " windows_pfx
+read -r -s -p "Windows PFX password: " windows_password
+echo
+read -r -p "macOS Developer ID P12 path: " mac_p12
+read -r -s -p "macOS P12 password: " mac_password
+echo
+read -r -p "Developer ID Application identity (exact security find-identity text): " developer_id
+read -r -p "Apple ID used for notarization: " apple_id
+read -r -p "Apple Team ID: " apple_team_id
+read -r -s -p "Apple app-specific password: " apple_app_password
+echo
+
+[[ -f "$windows_pfx" ]] || { echo "Windows PFX not found." >&2; exit 1; }
+[[ -f "$mac_p12" ]] || { echo "macOS P12 not found." >&2; exit 1; }
+[[ -n "$windows_password" && -n "$mac_password" && -n "$developer_id" && -n "$apple_id" && -n "$apple_team_id" && -n "$apple_app_password" ]] || {
+  echo "All release credentials are required." >&2
+  exit 1
+}
+
+set_secret() {
+  local name="$1"
+  gh secret set "$name" --repo "$repo"
+  echo "Configured $name"
+}
+
+base64 < "$windows_pfx" | tr -d '\n' | set_secret WINDOWS_CERTIFICATE
+printf '%s' "$windows_password" | set_secret WINDOWS_CERTIFICATE_PASSWORD
+base64 < "$mac_p12" | tr -d '\n' | set_secret MACOS_CERTIFICATE
+printf '%s' "$mac_password" | set_secret MACOS_CERTIFICATE_PASSWORD
+printf '%s' "$developer_id" | set_secret DEVELOPER_ID_APPLICATION
+printf '%s' "$apple_id" | set_secret APPLE_ID
+printf '%s' "$apple_team_id" | set_secret APPLE_TEAM_ID
+printf '%s' "$apple_app_password" | set_secret APPLE_APP_SPECIFIC_PASSWORD
+
+unset windows_password mac_password apple_app_password
+
+echo "Release secrets configured for $repo. Values were sent to GitHub through stdin and were not printed by this script."

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,53 @@
+# Production release
+
+Photo Organizer publishes one version for Windows and macOS from one exact commit. A production release is intentionally fail-closed: if any required signing credential or platform build fails, no GitHub Release is created.
+
+## Canonical artifacts
+
+For version `1.0.0`, the release workflow produces:
+
+- `PhotoOrganizer-Windows-x64-1.0.0.zip`
+- `PhotoOrganizer-Windows-arm64-1.0.0.zip`
+- `PhotoOrganizer-macOS-arm64-1.0.0.dmg`
+- `PhotoOrganizer-macOS-x64-1.0.0.dmg`
+- one `.sha256` file for each artifact
+
+Windows packages are self-contained .NET applications. The Photo Organizer executable and application assemblies are Authenticode-signed with SHA-256 and an RFC 3161 SHA-256 timestamp before the ZIP is created.
+
+macOS packages contain a self-contained Avalonia `.app`. Mach-O components and the app are signed with Developer ID Application and Hardened Runtime. The app and DMG are notarized with `notarytool`, stapled, and verified with `codesign`, `stapler`, and Gatekeeper (`spctl`). Apple Silicon and Intel are released separately because a self-contained .NET application contains architecture-specific runtime files; merely using `lipo` on the app host would not make the entire runtime universal.
+
+## Required GitHub Actions secrets
+
+Windows:
+
+- `WINDOWS_CERTIFICATE` — base64 of the production PFX
+- `WINDOWS_CERTIFICATE_PASSWORD`
+
+macOS:
+
+- `MACOS_CERTIFICATE` — base64 of the Developer ID `.p12`
+- `MACOS_CERTIFICATE_PASSWORD`
+- `DEVELOPER_ID_APPLICATION` — exact Developer ID Application signing identity
+- `APPLE_ID`
+- `APPLE_TEAM_ID`
+- `APPLE_APP_SPECIFIC_PASSWORD`
+
+Do not commit any certificate, private key, password, or app-specific password. On a trusted local machine, `bash Scripts/configure_release_secrets.sh` sends values to `gh secret set` through stdin without deliberately printing the values.
+
+## Release flow
+
+1. Ensure `main` CI and CodeQL are green and the release acceptance checklist has no unresolved code blocker.
+2. Configure all signing secrets.
+3. Create or fast-forward `release/vX.Y.Z` to the exact approved `main` commit, or push tag `vX.Y.Z`.
+4. The `Signing preflight` job validates the semantic version and requires every Windows and Apple signing secret before platform release jobs run.
+5. Windows and macOS independently run the shared safety tests from the same commit, produce signed packages, verify signatures, and upload short-lived workflow artifacts.
+6. Only after both platform jobs succeed does `Publish complete cross-platform release` download the complete set, verify every SHA-256 checksum, and create the GitHub Release.
+7. Run and record the real-device acceptance checklist in `docs/RELEASE_ACCEPTANCE.md` before describing the build as production-ready.
+
+A successful copy/build job, an unsigned local build, or a partially successful platform release is never a production release.
+
+## SmartScreen and Gatekeeper
+
+Authenticode signature validity can be verified in CI. Windows SmartScreen reputation is reputation-based and must also be checked on a clean Windows environment as part of release acceptance; valid signing does not guarantee an established SmartScreen reputation for a new certificate/application.
+
+On macOS, CI verifies Developer ID signatures, notarization tickets, stapling, and Gatekeeper assessment. A clean-machine launch remains part of real-device acceptance.

--- a/docs/RELEASE_ACCEPTANCE.md
+++ b/docs/RELEASE_ACCEPTANCE.md
@@ -1,0 +1,82 @@
+# Release acceptance checklist
+
+A workflow success is necessary but not sufficient for a production-ready Photo Organizer release. Complete this checklist against the exact signed artifacts from the candidate GitHub Release and retain evidence (release tag/SHA, OS version, machine architecture, card/filesystem, counts, relevant screenshots/logs, and checksums).
+
+## Build provenance and signatures
+
+- [ ] Candidate tag/version maps to the intended `main` commit.
+- [ ] Windows x64 ZIP SHA-256 matches its published checksum.
+- [ ] Windows arm64 ZIP SHA-256 matches its published checksum.
+- [ ] macOS arm64 DMG SHA-256 matches its published checksum.
+- [ ] macOS x64 DMG SHA-256 matches its published checksum.
+- [ ] Windows `PhotoOrganizer.exe`, `PhotoOrganizer.dll`, and `PhotoOrganizer.Core.dll` pass Authenticode verification.
+- [ ] macOS `.app` passes `codesign --verify --deep --strict` and `spctl -a -t exec`.
+- [ ] macOS DMG passes `stapler validate` and Gatekeeper assessment.
+- [ ] No unsigned substitute artifact is present in the Release.
+
+## Clean-machine install and launch
+
+- [ ] Windows x64 package launches on a clean supported x64 Windows machine without a .NET runtime preinstall.
+- [ ] Windows arm64 package launches on a clean supported ARM64 Windows machine when hardware is available.
+- [ ] Record SmartScreen behavior; investigate unexpected unsigned/unrecognized-publisher warnings. New-certificate reputation warnings must not be confused with signature failure.
+- [ ] macOS arm64 DMG opens and app launches on Apple Silicon with Gatekeeper enabled.
+- [ ] macOS x64 DMG opens and app launches on Intel macOS when hardware is available.
+- [ ] Login-startup enable/disable survives a real logout/login cycle on each tested platform.
+- [ ] Application restart always returns SD reuse safety to an unverified state; a previous green state is never restored from settings.
+
+## Real camera-card data safety
+
+Use disposable/test media with independent ground-truth copies. Do not begin acceptance with irreplaceable photographs.
+
+- [ ] Insert a camera-formatted card containing JPG/JPEG, configured RAW, and MOV/MP4; automatic detection scans the complete card.
+- [ ] Manually select a nested folder such as `DCIM/100NIKON`; the app expands to and verifies the complete camera-card root.
+- [ ] Arbitrary non-camera folders are rejected as camera-card roots.
+- [ ] Unsupported XMP/XML/TXT sidecars are not copied and do not block supported-media reuse verification.
+- [ ] A zero-byte supported JPG/RAW/video makes the scan incomplete/blocked.
+- [ ] Destination on the camera card, or a parent/child path overlapping the card, is rejected before copying.
+- [ ] Destination on another folder of the same physical volume is rejected.
+- [ ] After import, every source file remains byte-identical and at the same source path; the app has not deleted, moved, renamed, modified, or overwritten any source media.
+- [ ] Existing destination file with the same name but different bytes is preserved; imported data receives `_2`, `_3`, etc.
+- [ ] Same-name identical bytes are treated as an already-backed-up duplicate and no unnecessary collision copy is created.
+- [ ] Reusing a camera filename with the same size but different bytes is never mistaken for an old import.
+- [ ] Copy completion does not show the green reuse state before the post-import rescan and SHA-256 verification finish.
+- [ ] Green `保存先コピー検証済み — SDカード再利用可能` appears only after every currently supported file on the card has an independent destination size+SHA-256 match.
+
+## Repeated shooting workflow
+
+Run at least three real cycles using the same card:
+
+1. shoot/test files → insert → import → wait for verified green;
+2. reuse/format card in camera as intended → shoot again → import;
+3. repeat once more, including filename-number reuse if the camera permits it.
+
+For every cycle:
+
+- [ ] Historical files still present on the card and already byte-identical in the destination are skipped safely.
+- [ ] Only genuinely new bytes consume new destination space.
+- [ ] Duplicate-only import does not create an empty event folder.
+- [ ] Event date is based on pending/new media when present.
+- [ ] Final verification covers all supported media currently visible on the card.
+
+## Failure and race scenarios
+
+- [ ] Remove the source card during scan: scan/import is blocked and no reuse-safe state appears.
+- [ ] Remove the source card during copy: operation fails closed; no reuse-safe state appears.
+- [ ] Remove the destination during copy/final verification: operation fails closed; no reuse-safe state appears.
+- [ ] Cancel during copy: source remains untouched and reuse remains blocked/unverified.
+- [ ] Attempt normal application close during an active import: close is prevented until processing/cancellation resolves.
+- [ ] Mount a different card/device at the same path after a successful scan: the old scan session is rejected.
+- [ ] Unmount and remount the same card in the same app session: the previous mount-session approval is invalidated and a fresh scan is required.
+- [ ] Insert a second camera card while the first is being scanned/imported: active target does not switch and the second card is queued.
+- [ ] Remove a queued second card before it becomes active: it is removed from the queue and is not scanned from stale state.
+- [ ] Add a new supported file to the card between initial scan and final verification: final rescan includes it, and reuse cannot become safe unless that file also exists byte-identically in the destination.
+- [ ] Make an initially scanned supported file disappear before final verification: reuse is blocked.
+
+## Retirement gate for legacy repositories
+
+Do not archive or label `PhotoOrganizer-win` / `PhotoOrganizer-mac` as superseded for production until:
+
+- [ ] all applicable acceptance checks above are recorded for a signed unified candidate;
+- [ ] no open P0/P1 migration defect remains;
+- [ ] the chosen customer download/distribution path is documented;
+- [ ] rollback instructions point to the last known-good legacy release if the unified version has a release-blocking regression.

--- a/packaging/macos/PhotoOrganizer.entitlements
+++ b/packaging/macos/PhotoOrganizer.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
Closes #5 after the pipeline itself is merged; actual production readiness still requires signing secrets and the real-device acceptance tracked in #7.

Adds one cross-platform production release workflow with a hard all-or-nothing publication gate.

Windows:
- self-contained x64 and ARM64 packages
- SHA-256 Authenticode signing of Photo Organizer binaries
- RFC 3161 SHA-256 timestamp
- `signtool verify` before packaging
- ZIP + SHA-256 assets

macOS:
- separate Apple Silicon and Intel self-contained app bundles
- Developer ID Application signing and Hardened Runtime
- .NET JIT entitlement
- app notarization/stapling/Gatekeeper verification
- signed/notarized/stapled DMG + SHA-256 assets

Shared release guarantees:
- strict `vMAJOR.MINOR.PATCH`
- all Windows and Apple signing secrets required by the first preflight job
- same exact commit and version on both platforms
- shared safety tests re-run in both signing jobs
- final GitHub Release job requires both signed platform jobs
- complete expected artifact set and checksums verified before release creation
- no unsigned or half-platform production Release fallback
- pinned upload/download artifact actions
- secure local secret-configuration helper
- release and real-device acceptance documentation
- normal CI statically validates the release contract.