### PR TITLE
Measure and lock safe SHA-256 I/O optimizations

### DIFF
--- a/.github/workflows/io-benchmark.yml
+++ b/.github/workflows/io-benchmark.yml
@@ -1,0 +1,60 @@
+name: I/O Benchmark
+
+on:
+  workflow_dispatch:
+    inputs:
+      files:
+        description: 'Synthetic source file count'
+        required: false
+        default: '120'
+        type: string
+      size_kib:
+        description: 'Synthetic source file size in KiB'
+        required: false
+        default: '128'
+        type: string
+      noise:
+        description: 'Different-size destination library noise files'
+        required: false
+        default: '300'
+        type: string
+  pull_request:
+    paths:
+      - 'src/PhotoOrganizer.Core/**'
+      - 'tests/PhotoOrganizer.Core.Tests/**'
+      - 'tools/PhotoOrganizer.IoBenchmark/**'
+      - '.github/workflows/io-benchmark.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  benchmark:
+    name: SHA-256 I/O benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: 10.0.400
+
+      - name: Run safety regression tests
+        run: dotnet test tests/PhotoOrganizer.Core.Tests/PhotoOrganizer.Core.Tests.csproj --configuration Release
+
+      - name: Run measured I/O benchmark
+        shell: bash
+        env:
+          INPUT_FILES: ${{ inputs.files }}
+          INPUT_SIZE_KIB: ${{ inputs.size_kib }}
+          INPUT_NOISE: ${{ inputs.noise }}
+        run: |
+          set -euo pipefail
+          files="${INPUT_FILES:-120}"
+          size_kib="${INPUT_SIZE_KIB:-128}"
+          noise="${INPUT_NOISE:-300}"
+          dotnet run --project tools/PhotoOrganizer.IoBenchmark/PhotoOrganizer.IoBenchmark.csproj \
+            --configuration Release -- \
+            "--files=$files" "--size-kib=$size_kib" "--noise=$noise"

--- a/src/PhotoOrganizer.Core/DestinationLibrary.cs
+++ b/src/PhotoOrganizer.Core/DestinationLibrary.cs
@@ -7,10 +7,14 @@ public sealed record BackupLookupResult(
 public sealed class DestinationLibrary
 {
     private readonly IStorageVolumeProvider? _volumeProvider;
+    private readonly IFileHasher _hasher;
 
-    public DestinationLibrary(IStorageVolumeProvider? volumeProvider = null)
+    public DestinationLibrary(
+        IStorageVolumeProvider? volumeProvider = null,
+        IFileHasher? hasher = null)
     {
         _volumeProvider = volumeProvider;
+        _hasher = hasher ?? new Sha256FileHasher();
     }
 
     public async Task<BackupLookupResult> FindVerifiedBackupsAsync(
@@ -31,20 +35,26 @@ public sealed class DestinationLibrary
             {
                 var sourceInfo = new FileInfo(source);
                 if (!sourceInfo.Exists || sourceInfo.Length <= 0) continue;
+
+                // Size is only a cheap prefilter. If no destination file has the same
+                // size there is no possible byte-identical backup, so avoid reading the
+                // source solely to compute a SHA-256 that cannot match anything.
                 if (!index.FilesBySize.TryGetValue(sourceInfo.Length, out var candidates)) continue;
 
-                // Avoid hashing a source when the library has no same-size candidate.
-                var sourceHash = await Hashing.Sha256Async(source, cancellationToken).ConfigureAwait(false);
+                var sourceHash = await _hasher.Sha256Async(source, cancellationToken).ConfigureAwait(false);
 
                 foreach (var candidate in candidates)
                 {
                     if (PathComparer.Instance.Equals(Path.GetFullPath(candidate), source)) continue;
 
+                    // A destination file may be compared with several source files in
+                    // one lookup. Cache its real SHA-256 only for this operation; the
+                    // cache is never persisted and never reused by final reuse approval.
                     if (!destinationHashCache.TryGetValue(candidate, out var candidateHash))
                     {
                         try
                         {
-                            candidateHash = await Hashing.Sha256Async(candidate, cancellationToken).ConfigureAwait(false);
+                            candidateHash = await _hasher.Sha256Async(candidate, cancellationToken).ConfigureAwait(false);
                             destinationHashCache[candidate] = candidateHash;
                         }
                         catch (Exception ex) when (ex is not OperationCanceledException)

--- a/src/PhotoOrganizer.Core/FileHasher.cs
+++ b/src/PhotoOrganizer.Core/FileHasher.cs
@@ -1,0 +1,12 @@
+namespace PhotoOrganizer.Core;
+
+public interface IFileHasher
+{
+    Task<string> Sha256Async(string path, CancellationToken cancellationToken = default);
+}
+
+public sealed class Sha256FileHasher : IFileHasher
+{
+    public Task<string> Sha256Async(string path, CancellationToken cancellationToken = default) =>
+        Hashing.Sha256Async(path, cancellationToken);
+}

--- a/src/PhotoOrganizer.Core/FormatSafetyVerifier.cs
+++ b/src/PhotoOrganizer.Core/FormatSafetyVerifier.cs
@@ -13,11 +13,16 @@ public sealed class FormatSafetyVerifier
 {
     private readonly MediaClassifier _classifier;
     private readonly IStorageVolumeProvider? _volumeProvider;
+    private readonly IFileHasher _hasher;
 
-    public FormatSafetyVerifier(MediaClassifier classifier, IStorageVolumeProvider? volumeProvider = null)
+    public FormatSafetyVerifier(
+        MediaClassifier classifier,
+        IStorageVolumeProvider? volumeProvider = null,
+        IFileHasher? hasher = null)
     {
         _classifier = classifier;
         _volumeProvider = volumeProvider;
+        _hasher = hasher ?? new Sha256FileHasher();
     }
 
     public async Task<FormatVerificationResult> VerifyAsync(
@@ -50,6 +55,11 @@ public sealed class FormatSafetyVerifier
         var unverified = new List<string>();
         var errors = new List<string>();
         var verified = 0;
+
+        // This cache exists only for this one *fresh* verification invocation. It
+        // prevents rereading a destination candidate for multiple source files but
+        // is discarded immediately afterward. A later reuse decision always hashes
+        // destination bytes again from disk.
         var destinationHashCache = new Dictionary<string, string>(PathComparer.Instance);
 
         foreach (var source in supported)
@@ -65,13 +75,15 @@ public sealed class FormatSafetyVerifier
                     continue;
                 }
 
+                // No same-size candidate means no byte-identical destination can
+                // exist, so do not read/hash the source unnecessarily.
                 if (!destinationIndex.FilesBySize.TryGetValue(sourceInfo.Length, out var candidates))
                 {
                     unverified.Add(source);
                     continue;
                 }
 
-                var sourceHash = await Hashing.Sha256Async(source, cancellationToken).ConfigureAwait(false);
+                var sourceHash = await _hasher.Sha256Async(source, cancellationToken).ConfigureAwait(false);
                 var matched = false;
 
                 foreach (var candidate in candidates)
@@ -86,7 +98,7 @@ public sealed class FormatSafetyVerifier
                     {
                         if (!destinationHashCache.TryGetValue(candidate, out var destinationHash))
                         {
-                            destinationHash = await Hashing.Sha256Async(candidate, cancellationToken).ConfigureAwait(false);
+                            destinationHash = await _hasher.Sha256Async(candidate, cancellationToken).ConfigureAwait(false);
                             destinationHashCache[candidate] = destinationHash;
                         }
 

--- a/tests/PhotoOrganizer.Core.Tests/IoOptimizationTests.cs
+++ b/tests/PhotoOrganizer.Core.Tests/IoOptimizationTests.cs
@@ -1,0 +1,124 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PhotoOrganizer.Core.Tests;
+
+[TestClass]
+public sealed class IoOptimizationTests
+{
+    [TestMethod]
+    public async Task DuplicateLookupDoesNotHashSourceWithoutSameSizeCandidate()
+    {
+        using var temp = new TempDirectory();
+        var source = Path.Combine(temp.Source, "photo.jpg");
+        var differentSize = Path.Combine(temp.Destination, "other.jpg");
+        File.WriteAllText(source, "source-bytes");
+        File.WriteAllText(differentSize, "different-size-destination-bytes");
+
+        var hasher = new CountingHasher();
+        var result = await new DestinationLibrary(hasher: hasher)
+            .FindVerifiedBackupsAsync([source], temp.Destination);
+
+        Assert.AreEqual(0, result.MatchedSources.Count);
+        Assert.AreEqual(0, hasher.CallCount(source));
+        Assert.AreEqual(0L, hasher.BytesRead);
+    }
+
+    [TestMethod]
+    public async Task DuplicateLookupHashesSharedDestinationCandidateOnlyOncePerOperation()
+    {
+        using var temp = new TempDirectory();
+        var source1 = Path.Combine(temp.Source, "one.jpg");
+        var source2 = Path.Combine(temp.Source, "two.jpg");
+        var destination = Path.Combine(temp.Destination, "existing.jpg");
+        File.WriteAllText(source1, "same-payload");
+        File.WriteAllText(source2, "same-payload");
+        File.WriteAllText(destination, "same-payload");
+
+        var hasher = new CountingHasher();
+        var result = await new DestinationLibrary(hasher: hasher)
+            .FindVerifiedBackupsAsync([source1, source2], temp.Destination);
+
+        Assert.AreEqual(2, result.MatchedSources.Count);
+        Assert.AreEqual(1, hasher.CallCount(source1));
+        Assert.AreEqual(1, hasher.CallCount(source2));
+        Assert.AreEqual(1, hasher.CallCount(destination));
+    }
+
+    [TestMethod]
+    public async Task FinalVerifierDoesNotHashSourceWithoutSameSizeCandidate()
+    {
+        using var temp = new TempDirectory();
+        var source = Path.Combine(temp.Source, "photo.jpg");
+        var differentSize = Path.Combine(temp.Destination, "other.jpg");
+        File.WriteAllText(source, "source-bytes");
+        File.WriteAllText(differentSize, "different-size-destination-bytes");
+
+        var hasher = new CountingHasher();
+        var result = await new FormatSafetyVerifier(new MediaClassifier(), hasher: hasher)
+            .VerifyAsync([source], temp.Destination);
+
+        Assert.IsFalse(result.IsSafe);
+        Assert.AreEqual(0, hasher.CallCount(source));
+        Assert.AreEqual(0L, hasher.BytesRead);
+    }
+
+    [TestMethod]
+    public async Task FinalVerifierCacheIsDiscardedBetweenFreshVerificationRuns()
+    {
+        using var temp = new TempDirectory();
+        var source1 = Path.Combine(temp.Source, "one.jpg");
+        var source2 = Path.Combine(temp.Source, "two.jpg");
+        var destination = Path.Combine(temp.Destination, "existing.jpg");
+        File.WriteAllText(source1, "same-payload");
+        File.WriteAllText(source2, "same-payload");
+        File.WriteAllText(destination, "same-payload");
+
+        var hasher = new CountingHasher();
+        var verifier = new FormatSafetyVerifier(new MediaClassifier(), hasher: hasher);
+
+        var first = await verifier.VerifyAsync([source1, source2], temp.Destination);
+        var second = await verifier.VerifyAsync([source1, source2], temp.Destination);
+
+        Assert.IsTrue(first.IsSafe);
+        Assert.IsTrue(second.IsSafe);
+        Assert.AreEqual(2, hasher.CallCount(destination),
+            "Destination bytes must be freshly hashed on every reuse-verification invocation.");
+    }
+
+    private sealed class CountingHasher : IFileHasher
+    {
+        private readonly Dictionary<string, int> _calls = new(StringComparer.OrdinalIgnoreCase);
+
+        public long BytesRead { get; private set; }
+
+        public int CallCount(string path) =>
+            _calls.TryGetValue(Path.GetFullPath(path), out var count) ? count : 0;
+
+        public async Task<string> Sha256Async(string path, CancellationToken cancellationToken = default)
+        {
+            var full = Path.GetFullPath(path);
+            _calls[full] = CallCount(full) + 1;
+            BytesRead += new FileInfo(full).Length;
+            return await Hashing.Sha256Async(full, cancellationToken);
+        }
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Root = Path.Combine(Path.GetTempPath(), "PhotoOrganizerIoTests-" + Guid.NewGuid().ToString("N"));
+            Source = Directory.CreateDirectory(Path.Combine(Root, "source")).FullName;
+            Destination = Directory.CreateDirectory(Path.Combine(Root, "destination")).FullName;
+        }
+
+        public string Root { get; }
+        public string Source { get; }
+        public string Destination { get; }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Root, recursive: true); } catch { }
+        }
+    }
+}

--- a/tools/PhotoOrganizer.IoBenchmark/PhotoOrganizer.IoBenchmark.csproj
+++ b/tools/PhotoOrganizer.IoBenchmark/PhotoOrganizer.IoBenchmark.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>PhotoOrganizer.IoBenchmark</AssemblyName>
+    <RootNamespace>PhotoOrganizer.IoBenchmark</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/PhotoOrganizer.Core/PhotoOrganizer.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/PhotoOrganizer.IoBenchmark/Program.cs
+++ b/tools/PhotoOrganizer.IoBenchmark/Program.cs
@@ -1,0 +1,151 @@
+using System.Diagnostics;
+using PhotoOrganizer.Core;
+
+var fileCount = ReadInt(args, "--files", 120);
+var sizeKiB = ReadInt(args, "--size-kib", 128);
+var noiseCount = ReadInt(args, "--noise", 300);
+var fileSize = checked(sizeKiB * 1024);
+
+var root = Path.Combine(Path.GetTempPath(), "PhotoOrganizerIoBenchmark-" + Guid.NewGuid().ToString("N"));
+var sourceRoot = Directory.CreateDirectory(Path.Combine(root, "source")).FullName;
+var destinationRoot = Directory.CreateDirectory(Path.Combine(root, "destination")).FullName;
+
+try
+{
+    var sources = new List<string>(fileCount);
+    for (var i = 0; i < fileCount; i++)
+    {
+        var path = Path.Combine(sourceRoot, $"IMG_{i:D5}.jpg");
+        WriteDeterministicFile(path, fileSize, seed: i + 1);
+        sources.Add(path);
+    }
+
+    for (var i = 0; i < noiseCount; i++)
+    {
+        // Deliberately avoid the source size so this large metadata library has no
+        // possible byte-identical candidate and therefore requires zero hashing.
+        var path = Path.Combine(destinationRoot, $"noise_{i:D5}.bin");
+        WriteDeterministicFile(path, fileSize + 1 + (i % 7), seed: 100_000 + i);
+    }
+
+    Console.WriteLine($"Photo Organizer I/O benchmark: files={fileCount}, fileSize={fileSize:N0} bytes, libraryNoise={noiseCount}");
+    await RunNoCandidateScenario(sources, destinationRoot);
+
+    Directory.Delete(destinationRoot, recursive: true);
+    Directory.CreateDirectory(destinationRoot);
+
+    var matchingSources = new List<string>();
+    for (var i = 0; i < sources.Count; i += 10)
+    {
+        var target = Path.Combine(destinationRoot, $"existing_{i:D5}.jpg");
+        File.Copy(sources[i], target);
+        matchingSources.Add(sources[i]);
+    }
+
+    await RunCandidateCacheScenario(sources, matchingSources, destinationRoot, fileSize);
+
+    var process = Process.GetCurrentProcess();
+    Console.WriteLine($"peakWorkingSetBytes={process.PeakWorkingSet64:N0}");
+    Console.WriteLine($"managedHeapBytes={GC.GetTotalMemory(forceFullCollection: true):N0}");
+}
+finally
+{
+    try { Directory.Delete(root, recursive: true); } catch { }
+}
+
+static async Task RunNoCandidateScenario(IReadOnlyList<string> sources, string destinationRoot)
+{
+    var hasher = new CountingHasher();
+    var stopwatch = Stopwatch.StartNew();
+    var result = await new DestinationLibrary(hasher: hasher)
+        .FindVerifiedBackupsAsync(sources, destinationRoot);
+    stopwatch.Stop();
+
+    Console.WriteLine(
+        $"no-candidate: matched={result.MatchedSources.Count}, hashCalls={hasher.HashCalls}, " +
+        $"hashBytesRead={hasher.BytesRead:N0}, elapsedMs={stopwatch.Elapsed.TotalMilliseconds:F1}");
+
+    if (hasher.BytesRead != 0)
+    {
+        throw new InvalidOperationException("No-candidate lookup unexpectedly hashed file bytes.");
+    }
+}
+
+static async Task RunCandidateCacheScenario(
+    IReadOnlyList<string> allSources,
+    IReadOnlyList<string> matchingSources,
+    string destinationRoot,
+    int fileSize)
+{
+    var lookupHasher = new CountingHasher();
+    var stopwatch = Stopwatch.StartNew();
+    var lookup = await new DestinationLibrary(hasher: lookupHasher)
+        .FindVerifiedBackupsAsync(allSources, destinationRoot);
+    stopwatch.Stop();
+
+    var destinationCandidateCount = Directory.EnumerateFiles(destinationRoot).Count();
+    var maximumExpectedLookupBytes = (long)(allSources.Count + destinationCandidateCount) * fileSize;
+    Console.WriteLine(
+        $"candidate-cache: matched={lookup.MatchedSources.Count}, hashCalls={lookupHasher.HashCalls}, " +
+        $"hashBytesRead={lookupHasher.BytesRead:N0}, maxExpectedWithPer-operationCache={maximumExpectedLookupBytes:N0}, " +
+        $"elapsedMs={stopwatch.Elapsed.TotalMilliseconds:F1}");
+
+    if (lookupHasher.BytesRead > maximumExpectedLookupBytes)
+    {
+        throw new InvalidOperationException("A destination candidate appears to have been hashed more than once in one lookup.");
+    }
+
+    var verificationHasher = new CountingHasher();
+    stopwatch.Restart();
+    var verification = await new FormatSafetyVerifier(new MediaClassifier(), hasher: verificationHasher)
+        .VerifyAsync(matchingSources, destinationRoot);
+    stopwatch.Stop();
+
+    var maximumExpectedVerificationBytes = (long)(matchingSources.Count + destinationCandidateCount) * fileSize;
+    Console.WriteLine(
+        $"fresh-verification: safe={verification.IsSafe}, verified={verification.Verified}/{verification.Total}, " +
+        $"hashCalls={verificationHasher.HashCalls}, hashBytesRead={verificationHasher.BytesRead:N0}, " +
+        $"maxExpectedWithPer-operationCache={maximumExpectedVerificationBytes:N0}, " +
+        $"elapsedMs={stopwatch.Elapsed.TotalMilliseconds:F1}");
+
+    if (!verification.IsSafe)
+    {
+        throw new InvalidOperationException("Benchmark matching set failed real-byte verification.");
+    }
+
+    if (verificationHasher.BytesRead > maximumExpectedVerificationBytes)
+    {
+        throw new InvalidOperationException("A destination candidate appears to have been rehashed within one fresh verification.");
+    }
+}
+
+static void WriteDeterministicFile(string path, int size, int seed)
+{
+    var random = new Random(seed);
+    var buffer = new byte[size];
+    random.NextBytes(buffer);
+    File.WriteAllBytes(path, buffer);
+}
+
+static int ReadInt(string[] args, string key, int fallback)
+{
+    foreach (var argument in args)
+    {
+        if (!argument.StartsWith(key + "=", StringComparison.OrdinalIgnoreCase)) continue;
+        if (int.TryParse(argument[(key.Length + 1)..], out var value) && value > 0) return value;
+    }
+    return fallback;
+}
+
+sealed class CountingHasher : IFileHasher
+{
+    public long BytesRead { get; private set; }
+    public int HashCalls { get; private set; }
+
+    public async Task<string> Sha256Async(string path, CancellationToken cancellationToken = default)
+    {
+        BytesRead += new FileInfo(path).Length;
+        HashCalls++;
+        return await Hashing.Sha256Async(path, cancellationToken);
+    }
+}


### PR DESCRIPTION
Closes #6 after benchmark evidence is green.

Keeps size + SHA-256 as the only authoritative duplicate/reuse proof while making the existing safe I/O optimizations explicit, injectable and regression-tested.

- source bytes are not hashed when the destination library has no same-size candidate
- destination candidate SHA-256 values are cached only within one lookup/verification invocation
- final reuse verification still starts a fresh cache and rereads destination bytes on every invocation
- no persistent hash manifest can authorize a skip or reuse decision
- `IFileHasher` allows exact hash-call/byte-read assertions without changing production semantics
- tests prove no-candidate zero-byte hashing, within-operation destination caching, and fresh final verification
- repeatable benchmark reports logical SHA bytes read, elapsed time, peak working set and managed heap
- dedicated benchmark workflow runs safety regression tests before measurement