### PR TITLE
Gate stable releases on recorded real-device acceptance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml')"
+          ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); YAML.load_file('.github/workflows/promote-release.yml')"
           python3 - <<'PY'
           import xml.etree.ElementTree as ET
           ET.parse('packaging/macos/PhotoOrganizer.entitlements')
@@ -72,6 +72,7 @@ jobs:
         run: |
           set -euo pipefail
           workflow=.github/workflows/release.yml
+          promotion=.github/workflows/promote-release.yml
           for secret in \
             WINDOWS_CERTIFICATE WINDOWS_CERTIFICATE_PASSWORD \
             MACOS_CERTIFICATE MACOS_CERTIFICATE_PASSWORD DEVELOPER_ID_APPLICATION \
@@ -85,6 +86,22 @@ jobs:
           grep -q 'sha256sum -c' "$workflow"
           grep -q 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' "$workflow"
           grep -q 'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c' "$workflow"
+
+          # Signed artifacts are acceptance candidates first. The build workflow must
+          # never make them the public stable/latest release on its own.
+          grep -q -- '--prerelease' "$workflow"
+          if grep -q -- '--latest' "$workflow"; then
+            echo 'release.yml must not promote an unaccepted candidate to latest.'
+            exit 1
+          fi
+
+          # Stable promotion requires an explicit real-device acceptance record.
+          grep -q 'acceptance_confirmed' "$promotion"
+          grep -q 'candidate_commit' "$promotion"
+          grep -q 'ACCEPTANCE_EVIDENCE' "$promotion"
+          grep -q 'prerelease.*true' "$promotion"
+          grep -q 'make_latest.*true' "$promotion"
+          grep -q 'RELEASE_ACCEPTANCE.md' "$promotion"
 
   required:
     name: required

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,0 +1,138 @@
+name: Promote accepted release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Accepted release tag (for example v1.0.0)'
+        required: true
+        type: string
+      candidate_commit:
+        description: 'Exact commit SHA recorded during acceptance'
+        required: true
+        type: string
+      acceptance_confirmed:
+        description: 'I confirm docs/RELEASE_ACCEPTANCE.md passed for this exact candidate'
+        required: true
+        type: boolean
+        default: false
+      evidence:
+        description: 'Acceptance evidence reference (issue/comment/document URL or durable record)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: promote-release-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Promote verified acceptance candidate
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ inputs.version }}
+      EXPECTED_COMMIT: ${{ inputs.candidate_commit }}
+      ACCEPTANCE_CONFIRMED: ${{ inputs.acceptance_confirmed }}
+      ACCEPTANCE_EVIDENCE: ${{ inputs.evidence }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Require explicit acceptance record
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$RELEASE_TAG" != v* ]] || [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag must match vMAJOR.MINOR.PATCH: $RELEASE_TAG"
+            exit 1
+          fi
+          if [[ "$ACCEPTANCE_CONFIRMED" != "true" ]]; then
+            echo "::error::Real-device acceptance must be explicitly confirmed."
+            exit 1
+          fi
+          if [[ ! "$EXPECTED_COMMIT" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "::error::candidate_commit must be an exact 40-character commit SHA."
+            exit 1
+          fi
+          if [[ -z "${ACCEPTANCE_EVIDENCE//[[:space:]]/}" ]]; then
+            echo "::error::A durable acceptance evidence reference is required."
+            exit 1
+          fi
+
+      - name: Verify candidate release identity and complete artifact set
+        id: candidate
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_json="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG")"
+
+          draft="$(jq -r '.draft' <<< "$release_json")"
+          prerelease="$(jq -r '.prerelease' <<< "$release_json")"
+          target="$(jq -r '.target_commitish' <<< "$release_json")"
+          release_id="$(jq -r '.id' <<< "$release_json")"
+
+          if [[ "$draft" != "false" || "$prerelease" != "true" ]]; then
+            echo "::error::The release must exist as a published prerelease acceptance candidate."
+            exit 1
+          fi
+          if [[ "$target" != "$EXPECTED_COMMIT" ]]; then
+            echo "::error::Candidate release target $target does not match accepted commit $EXPECTED_COMMIT."
+            exit 1
+          fi
+
+          version="${RELEASE_TAG#v}"
+          required=(
+            "PhotoOrganizer-Windows-x64-$version.zip"
+            "PhotoOrganizer-Windows-x64-$version.zip.sha256"
+            "PhotoOrganizer-Windows-arm64-$version.zip"
+            "PhotoOrganizer-Windows-arm64-$version.zip.sha256"
+            "PhotoOrganizer-macOS-arm64-$version.dmg"
+            "PhotoOrganizer-macOS-arm64-$version.dmg.sha256"
+            "PhotoOrganizer-macOS-x64-$version.dmg"
+            "PhotoOrganizer-macOS-x64-$version.dmg.sha256"
+          )
+          asset_names="$(jq -r '.assets[].name' <<< "$release_json")"
+          for artifact in "${required[@]}"; do
+            if ! grep -Fxq "$artifact" <<< "$asset_names"; then
+              echo "::error::Acceptance candidate is missing required asset: $artifact"
+              exit 1
+            fi
+          done
+
+          body="$(jq -r '.body // ""' <<< "$release_json")"
+          delimiter="acceptance_$(date +%s)_$RANDOM"
+          echo "release_id=$release_id" >> "$GITHUB_OUTPUT"
+          echo "body<<$delimiter" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$body" >> "$GITHUB_OUTPUT"
+          echo "$delimiter" >> "$GITHUB_OUTPUT"
+
+      - name: Promote prerelease to latest stable with acceptance evidence
+        shell: bash
+        env:
+          RELEASE_ID: ${{ steps.candidate.outputs.release_id }}
+          CURRENT_BODY: ${{ steps.candidate.outputs.body }}
+        run: |
+          set -euo pipefail
+          promoted_body="$CURRENT_BODY
+
+          ---
+          Production acceptance completed for commit $EXPECTED_COMMIT.
+          Acceptance evidence: $ACCEPTANCE_EVIDENCE"
+
+          jq -n \
+            --arg body "$promoted_body" \
+            '{prerelease: false, make_latest: "true", body: $body}' \
+            | gh api --method PATCH \
+                "repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID" \
+                --input - >/dev/null
+
+      - name: Verify stable promotion
+        shell: bash
+        run: |
+          set -euo pipefail
+          release_json="$(gh api "repos/$GITHUB_REPOSITORY/releases/tags/$RELEASE_TAG")"
+          test "$(jq -r '.draft' <<< "$release_json")" = "false"
+          test "$(jq -r '.prerelease' <<< "$release_json")" = "false"
+          test "$(jq -r '.target_commitish' <<< "$release_json")" = "$EXPECTED_COMMIT"
+          echo "Promoted $RELEASE_TAG to the accepted stable release."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -369,7 +369,7 @@ jobs:
           security delete-keychain "$RUNNER_TEMP/photo-organizer-signing.keychain-db" 2>/dev/null || true
 
   publish:
-    name: Publish complete cross-platform release
+    name: Publish complete cross-platform acceptance candidate
     needs: [preflight, windows, macos]
     runs-on: ubuntu-latest
     env:
@@ -401,7 +401,7 @@ jobs:
             sha256sum -c "$artifact.sha256"
           done
 
-      - name: Publish GitHub Release only after both platforms succeeded
+      - name: Publish prerelease acceptance candidate only after both platforms succeeded
         shell: bash
         run: |
           set -euo pipefail
@@ -412,6 +412,6 @@ jobs:
           gh release create "$RELEASE_TAG" release-assets/* \
             --repo "$GITHUB_REPOSITORY" \
             --target "$GITHUB_SHA" \
-            --title "Photo Organizer $VERSION" \
+            --title "Photo Organizer $VERSION — acceptance candidate" \
             --generate-notes \
-            --latest
+            --prerelease

--- a/README.md
+++ b/README.md
@@ -76,13 +76,15 @@ CI executes shared safety tests and builds the unified desktop app on both Windo
 
 ## Production release
 
-The release workflow produces signed Windows x64/ARM64 packages and Developer ID signed/notarized macOS Apple Silicon/Intel DMGs from the same version and exact commit. No GitHub Release is created unless both platform signing pipelines succeed and every published artifact passes its SHA-256 verification.
+The signing workflow produces Windows x64/ARM64 packages and Developer ID signed/notarized macOS Apple Silicon/Intel DMGs from the same exact commit. Both platforms and every SHA-256 check must succeed before the artifacts are published, and they are published **only as a Prerelease acceptance candidate**.
 
-See [`docs/RELEASE.md`](docs/RELEASE.md) for signing setup and [`docs/RELEASE_ACCEPTANCE.md`](docs/RELEASE_ACCEPTANCE.md) for the mandatory real-device acceptance checklist.
+The candidate becomes Latest/stable only through the separate manual promotion workflow after the exact candidate has passed the documented clean-machine and real-camera-card acceptance checklist and a durable evidence reference is supplied. A successful signing workflow alone is never treated as production approval.
+
+See [`docs/RELEASE.md`](docs/RELEASE.md) for the two-stage release process and [`docs/RELEASE_ACCEPTANCE.md`](docs/RELEASE_ACCEPTANCE.md) for the mandatory real-device acceptance checklist.
 
 ## Migration status
 
-This repository is the canonical source for new Windows/macOS development. The shared safety Core, unified production workflow, release pipeline, and shared resident UI are migrated. The legacy applications remain available as references until the unified signed artifacts pass real-device acceptance.
+This repository is the canonical source for new Windows/macOS development. The shared safety Core, unified production workflow, release pipeline, and shared resident UI are migrated. The legacy applications remain available as references until a unified signed candidate passes real-device acceptance and is explicitly promoted to stable.
 
 Deliberate behavior differences from the legacy implementations, including removal of unsafe overwrite/timestamp-only duplicate behavior and silent file retry, are documented in [`docs/MIGRATION_PLAN.md`](docs/MIGRATION_PLAN.md).
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,6 +1,6 @@
 # Production release
 
-Photo Organizer publishes one version for Windows and macOS from one exact commit. A production release is intentionally fail-closed: if any required signing credential or platform build fails, no GitHub Release is created.
+Photo Organizer publishes one version for Windows and macOS from one exact commit. Release is intentionally fail-closed: if any required signing credential or platform build fails, no candidate is published. A signed CI candidate is still **not** a production-ready stable release until the real-device acceptance checklist passes and a separate promotion workflow records that approval.
 
 ## Canonical artifacts
 
@@ -34,17 +34,50 @@ macOS:
 
 Do not commit any certificate, private key, password, or app-specific password. On a trusted local machine, `bash Scripts/configure_release_secrets.sh` sends values to `gh secret set` through stdin without deliberately printing the values.
 
-## Release flow
+## Stage 1 — signed acceptance candidate
 
-1. Ensure `main` CI and CodeQL are green and the release acceptance checklist has no unresolved code blocker.
+1. Ensure `main` CI and CodeQL are green and no unresolved code blocker remains.
 2. Configure all signing secrets.
 3. Create or fast-forward `release/vX.Y.Z` to the exact approved `main` commit, or push tag `vX.Y.Z`.
 4. The `Signing preflight` job validates the semantic version and requires every Windows and Apple signing secret before platform release jobs run.
 5. Windows and macOS independently run the shared safety tests from the same commit, produce signed packages, verify signatures, and upload short-lived workflow artifacts.
-6. Only after both platform jobs succeed does `Publish complete cross-platform release` download the complete set, verify every SHA-256 checksum, and create the GitHub Release.
-7. Run and record the real-device acceptance checklist in `docs/RELEASE_ACCEPTANCE.md` before describing the build as production-ready.
+6. Only after both platform jobs succeed does the publish job download the complete set, verify every SHA-256 checksum, and create a **GitHub Prerelease acceptance candidate**.
+7. The candidate is intentionally not marked Latest or stable. Use these exact candidate bytes for clean-machine and real-camera-card acceptance.
 
-A successful copy/build job, an unsigned local build, or a partially successful platform release is never a production release.
+The release workflow must never promote its own output to stable. This separation prevents a successful signing/build run from being mistaken for evidence that the real workflow is safe on physical machines and cards.
+
+## Stage 2 — explicit stable promotion
+
+After every applicable item in `docs/RELEASE_ACCEPTANCE.md` has passed for the exact prerelease candidate, run `.github/workflows/promote-release.yml` manually.
+
+The promotion workflow requires:
+
+- `version` — the exact `vMAJOR.MINOR.PATCH` candidate tag;
+- `candidate_commit` — the exact 40-character commit SHA recorded during acceptance;
+- `acceptance_confirmed=true` — an explicit human confirmation that the checklist passed;
+- `evidence` — a durable reference to the recorded acceptance evidence (for example a GitHub issue/comment or controlled test record).
+
+Before promotion it verifies that:
+
+- the release exists and is a published prerelease, not a draft;
+- its target commit exactly equals `candidate_commit`;
+- all four expected Windows/macOS artifacts are present;
+- all four corresponding SHA-256 files are present.
+
+Only then does it clear the prerelease flag, mark the release as Latest, and append the accepted commit and evidence reference to the release notes.
+
+If any of these checks fail, the candidate remains a prerelease and customer-facing stable distribution must not point to it as the approved production release.
+
+## What does not count as production-ready
+
+None of the following is sufficient on its own:
+
+- a successful normal CI run;
+- a successful signing/notarization workflow;
+- an unsigned local build;
+- only one platform succeeding;
+- a prerelease candidate that has not completed the real-device checklist;
+- a release whose accepted commit or evidence record cannot be identified.
 
 ## SmartScreen and Gatekeeper
 

--- a/docs/RELEASE_ACCEPTANCE.md
+++ b/docs/RELEASE_ACCEPTANCE.md
@@ -1,10 +1,11 @@
 # Release acceptance checklist
 
-A workflow success is necessary but not sufficient for a production-ready Photo Organizer release. Complete this checklist against the exact signed artifacts from the candidate GitHub Release and retain evidence (release tag/SHA, OS version, machine architecture, card/filesystem, counts, relevant screenshots/logs, and checksums).
+A workflow success is necessary but not sufficient for a production-ready Photo Organizer release. Complete this checklist against the exact signed **GitHub Prerelease acceptance candidate** and retain evidence (release tag/SHA, OS version, machine architecture, card/filesystem, counts, relevant screenshots/logs, and checksums). Do not promote the candidate to Latest/stable until every applicable item is complete.
 
-## Build provenance and signatures
+## Candidate provenance and signatures
 
-- [ ] Candidate tag/version maps to the intended `main` commit.
+- [ ] Candidate exists as a GitHub Prerelease, not as Latest/stable.
+- [ ] Candidate tag/version maps to the intended exact `main` commit and that 40-character SHA is recorded.
 - [ ] Windows x64 ZIP SHA-256 matches its published checksum.
 - [ ] Windows arm64 ZIP SHA-256 matches its published checksum.
 - [ ] macOS arm64 DMG SHA-256 matches its published checksum.
@@ -85,11 +86,23 @@ For every cycle:
 - [ ] Make an initially scanned supported file disappear before final verification: reuse is blocked.
 - [ ] Force-kill the process during import, relaunch it, and confirm no previous reuse-safe state is restored.
 
+## Stable promotion record
+
+After every applicable check above passes:
+
+- [ ] Store a durable evidence reference containing the tested tag, exact candidate commit, OS/hardware/card details and outcomes.
+- [ ] Run `Promote accepted release` with the exact candidate tag and 40-character accepted commit SHA.
+- [ ] Set `acceptance_confirmed=true` only after the checklist is complete.
+- [ ] Supply the durable evidence reference to the promotion workflow.
+- [ ] Confirm the workflow refuses a wrong commit, a non-prerelease release, or an incomplete artifact set.
+- [ ] Confirm successful promotion clears the Prerelease flag, marks the same release Latest/stable, preserves the exact artifacts, and appends the accepted commit/evidence reference to its release notes.
+
 ## Retirement gate for legacy repositories
 
 Do not archive or label `PhotoOrganizer-win` / `PhotoOrganizer-mac` as superseded for production until:
 
 - [ ] all applicable acceptance checks above are recorded for a signed unified candidate;
+- [ ] that exact candidate has been promoted through the explicit acceptance workflow;
 - [ ] no open P0/P1 migration defect remains;
-- [ ] the chosen customer download/distribution path is documented;
+- [ ] the chosen customer download/distribution path points to the promoted stable release;
 - [ ] rollback instructions point to the last known-good legacy release if the unified version has a release-blocking regression.


### PR DESCRIPTION
Closes #19

Fixes the release lifecycle so signed CI output cannot become the public Latest release before physical acceptance.

Stage 1:
- the existing all-or-nothing Windows/macOS signing workflow still requires every signing secret, both platform jobs, complete artifacts and SHA-256 verification;
- its GitHub Release is now always a published **Prerelease acceptance candidate**;
- the signing workflow has no path that marks its own candidate Latest/stable.

Stage 2:
- new manual `Promote accepted release` workflow;
- requires exact `vMAJOR.MINOR.PATCH`, exact 40-character accepted candidate commit, `acceptance_confirmed=true`, and a non-empty durable evidence reference;
- verifies candidate exists, is a published prerelease, targets the exact accepted commit, and contains all four Windows/macOS artifacts plus all four checksum files;
- only then clears prerelease, marks that same release Latest, and appends accepted commit/evidence to release notes.

Normal CI parses both workflows and statically rejects release-contract regressions such as reintroducing `--latest` into the signing workflow or removing the explicit acceptance fields.

README, release documentation, and real-device acceptance checklist now describe the two-stage gate.