### PR TITLE
Update CodeQL actions together to 4.37.8

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
           dotnet-version: 10.0.400
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           languages: csharp
           build-mode: manual
@@ -36,4 +36,4 @@ jobs:
         run: dotnet build src/PhotoOrganizer.App/PhotoOrganizer.App.csproj --configuration Release
 
       - name: Analyze
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8


### PR DESCRIPTION
Supersedes #9 and #10.

Dependabot split the CodeQL update into separate `init` and `analyze` PRs. Updating either half alone makes CodeQL fail because all `github/codeql-action` steps in one workflow must use the same version.

This PR updates `init` and `analyze` atomically from 4.37.3 to 4.37.8 using the same pinned SHA (`db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28`) on top of the current main, which already includes checkout 7.0.1 and the two-stage release-acceptance gate.