### PR TITLE
Wire product icons into desktop and signed packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,14 @@ jobs:
       - name: Build unified desktop app
         run: dotnet build src/PhotoOrganizer.App/PhotoOrganizer.App.csproj --configuration Release --no-restore
 
+      - name: Validate macOS product icon generation
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash Scripts/build_macos_icon.sh src/PhotoOrganizer.App/Assets/app-icon.ico "$RUNNER_TEMP/PhotoOrganizer.icns"
+          test -s "$RUNNER_TEMP/PhotoOrganizer.icns"
+
   release-contract:
     name: Release contract
     runs-on: ubuntu-latest
@@ -65,7 +73,9 @@ jobs:
 
       - name: Validate release helper syntax
         shell: bash
-        run: bash -n Scripts/configure_release_secrets.sh
+        run: |
+          bash -n Scripts/configure_release_secrets.sh
+          bash -n Scripts/build_macos_icon.sh
 
       - name: Enforce fail-closed release contract
         shell: bash
@@ -73,6 +83,8 @@ jobs:
           set -euo pipefail
           workflow=.github/workflows/release.yml
           promotion=.github/workflows/promote-release.yml
+          project=src/PhotoOrganizer.App/PhotoOrganizer.App.csproj
+          window=src/PhotoOrganizer.App/MainWindow.axaml
           for secret in \
             WINDOWS_CERTIFICATE WINDOWS_CERTIFICATE_PASSWORD \
             MACOS_CERTIFICATE MACOS_CERTIFICATE_PASSWORD DEVELOPER_ID_APPLICATION \
@@ -86,6 +98,14 @@ jobs:
           grep -q 'sha256sum -c' "$workflow"
           grep -q 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a' "$workflow"
           grep -q 'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c' "$workflow"
+
+          # Product identity must survive both desktop builds and signed packaging.
+          test -s src/PhotoOrganizer.App/Assets/app-icon.ico
+          grep -q '<ApplicationIcon>Assets/app-icon.ico</ApplicationIcon>' "$project"
+          grep -q 'Icon="/Assets/app-icon.ico"' "$window"
+          grep -q 'Scripts/build_macos_icon.sh' "$workflow"
+          grep -q 'CFBundleIconFile' "$workflow"
+          grep -q 'PhotoOrganizer.icns' "$workflow"
 
           # Signed artifacts are acceptance candidates first. The build workflow must
           # never make them the public stable/latest release on its own.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,6 +247,9 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p release-assets build
+          app_icon="$RUNNER_TEMP/PhotoOrganizer.icns"
+          bash Scripts/build_macos_icon.sh src/PhotoOrganizer.App/Assets/app-icon.ico "$app_icon"
+          test -s "$app_icon"
 
           for arch in arm64 x64; do
             rid="osx-$arch"
@@ -269,6 +272,8 @@ jobs:
             ditto "$publish" "$macos"
             chmod +x "$macos/PhotoOrganizer"
             cp LICENSE "$resources/LICENSE.txt"
+            cp "$app_icon" "$resources/PhotoOrganizer.icns"
+            test -s "$resources/PhotoOrganizer.icns"
 
             cat > "$contents/Info.plist" <<PLIST
           <?xml version="1.0" encoding="UTF-8"?>
@@ -278,6 +283,7 @@ jobs:
             <key>CFBundleDevelopmentRegion</key><string>en</string>
             <key>CFBundleDisplayName</key><string>Photo Organizer</string>
             <key>CFBundleExecutable</key><string>PhotoOrganizer</string>
+            <key>CFBundleIconFile</key><string>PhotoOrganizer.icns</string>
             <key>CFBundleIdentifier</key><string>com.peachgumi.photoorganizer</string>
             <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
             <key>CFBundleName</key><string>Photo Organizer</string>
@@ -365,7 +371,7 @@ jobs:
         if: always()
         shell: bash
         run: |
-          rm -f "$RUNNER_TEMP/developer-id.p12" "$RUNNER_TEMP"/PhotoOrganizer-*.zip
+          rm -f "$RUNNER_TEMP/developer-id.p12" "$RUNNER_TEMP"/PhotoOrganizer-*.zip "$RUNNER_TEMP/PhotoOrganizer.icns"
           security delete-keychain "$RUNNER_TEMP/photo-organizer-signing.keychain-db" 2>/dev/null || true
 
   publish:

--- a/Scripts/build_macos_icon.sh
+++ b/Scripts/build_macos_icon.sh
@@ -16,8 +16,10 @@ iconset="$workdir/PhotoOrganizer.iconset"
 mkdir -p "$iconset"
 
 # The repository icon is a multi-image ICO whose modern entries are PNG payloads.
-# Extract the largest embedded PNG using only Python's standard library so the
-# release process does not acquire an extra package-manager dependency.
+# Extract the largest structurally complete PNG using only Python's standard
+# library. Individual malformed ICO image entries are rejected rather than
+# making their bytes part of a signed bundle; the conversion fails if no valid
+# PNG-backed entry remains.
 python3 - "$SOURCE_ICO" "$source_png" <<'PY'
 import struct
 import sys
@@ -33,27 +35,65 @@ if reserved != 0 or kind != 1 or count < 1:
     raise SystemExit("Invalid ICO header")
 
 png_signature = b"\x89PNG\r\n\x1a\n"
+
+
+def is_complete_png(payload: bytes) -> bool:
+    if not payload.startswith(png_signature):
+        return False
+
+    position = len(png_signature)
+    saw_ihdr = False
+    while position + 12 <= len(payload):
+        length = struct.unpack_from(">I", payload, position)[0]
+        chunk_type = payload[position + 4 : position + 8]
+        end = position + 12 + length
+        if end > len(payload):
+            return False
+        if not saw_ihdr:
+            if chunk_type != b"IHDR" or length != 13:
+                return False
+            saw_ihdr = True
+        position = end
+        if chunk_type == b"IEND":
+            return length == 0 and position == len(payload)
+    return False
+
+
 entries = []
 for index in range(count):
     offset = 6 + (index * 16)
     if offset + 16 > len(data):
         raise SystemExit("ICO directory is truncated")
+
     width_raw, height_raw = data[offset], data[offset + 1]
     width = width_raw or 256
     height = height_raw or 256
     size, image_offset = struct.unpack_from("<II", data, offset + 8)
     end = image_offset + size
-    if image_offset < 0 or size <= 0 or end > len(data):
-        raise SystemExit("ICO image entry is out of bounds")
+
+    if size <= 0 or image_offset < 6 + (count * 16) or end > len(data):
+        print(
+            f"Skipping malformed ICO entry {index}: "
+            f"offset={image_offset} size={size} file_size={len(data)}",
+            file=sys.stderr,
+        )
+        continue
+
     payload = data[image_offset:end]
-    if payload.startswith(png_signature):
+    if is_complete_png(payload):
         entries.append((width * height, width, height, payload))
+    elif payload.startswith(png_signature):
+        print(
+            f"Skipping incomplete PNG-backed ICO entry {index}: {width}x{height}",
+            file=sys.stderr,
+        )
 
 if not entries:
-    raise SystemExit("ICO contains no PNG-backed image entry")
+    raise SystemExit("ICO contains no complete PNG-backed image entry")
+
 _, width, height, payload = max(entries, key=lambda item: item[0])
 out.write_bytes(payload)
-print(f"Extracted {width}x{height} PNG from {source}")
+print(f"Extracted complete {width}x{height} PNG from {source}")
 PY
 
 make_icon() {

--- a/Scripts/build_macos_icon.sh
+++ b/Scripts/build_macos_icon.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_ICO="${1:-src/PhotoOrganizer.App/Assets/app-icon.ico}"
+OUTPUT_ICNS="${2:-PhotoOrganizer.icns}"
+
+if [[ ! -s "$SOURCE_ICO" ]]; then
+  echo "Source icon not found or empty: $SOURCE_ICO" >&2
+  exit 1
+fi
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "$workdir"' EXIT
+source_png="$workdir/source.png"
+iconset="$workdir/PhotoOrganizer.iconset"
+mkdir -p "$iconset"
+
+# The repository icon is a multi-image ICO whose modern entries are PNG payloads.
+# Extract the largest embedded PNG using only Python's standard library so the
+# release process does not acquire an extra package-manager dependency.
+python3 - "$SOURCE_ICO" "$source_png" <<'PY'
+import struct
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1])
+out = Path(sys.argv[2])
+data = source.read_bytes()
+if len(data) < 6:
+    raise SystemExit("ICO header is truncated")
+reserved, kind, count = struct.unpack_from("<HHH", data, 0)
+if reserved != 0 or kind != 1 or count < 1:
+    raise SystemExit("Invalid ICO header")
+
+png_signature = b"\x89PNG\r\n\x1a\n"
+entries = []
+for index in range(count):
+    offset = 6 + (index * 16)
+    if offset + 16 > len(data):
+        raise SystemExit("ICO directory is truncated")
+    width_raw, height_raw = data[offset], data[offset + 1]
+    width = width_raw or 256
+    height = height_raw or 256
+    size, image_offset = struct.unpack_from("<II", data, offset + 8)
+    end = image_offset + size
+    if image_offset < 0 or size <= 0 or end > len(data):
+        raise SystemExit("ICO image entry is out of bounds")
+    payload = data[image_offset:end]
+    if payload.startswith(png_signature):
+        entries.append((width * height, width, height, payload))
+
+if not entries:
+    raise SystemExit("ICO contains no PNG-backed image entry")
+_, width, height, payload = max(entries, key=lambda item: item[0])
+out.write_bytes(payload)
+print(f"Extracted {width}x{height} PNG from {source}")
+PY
+
+make_icon() {
+  local pixels="$1"
+  local name="$2"
+  sips -z "$pixels" "$pixels" "$source_png" --out "$iconset/$name" >/dev/null
+  test -s "$iconset/$name"
+}
+
+make_icon 16 icon_16x16.png
+make_icon 32 icon_16x16@2x.png
+make_icon 32 icon_32x32.png
+make_icon 64 icon_32x32@2x.png
+make_icon 128 icon_128x128.png
+make_icon 256 icon_128x128@2x.png
+make_icon 256 icon_256x256.png
+make_icon 512 icon_256x256@2x.png
+make_icon 512 icon_512x512.png
+make_icon 1024 icon_512x512@2x.png
+
+mkdir -p "$(dirname "$OUTPUT_ICNS")"
+iconutil -c icns "$iconset" -o "$OUTPUT_ICNS"
+test -s "$OUTPUT_ICNS"
+echo "Created macOS icon: $OUTPUT_ICNS"

--- a/docs/RELEASE_ACCEPTANCE.md
+++ b/docs/RELEASE_ACCEPTANCE.md
@@ -19,9 +19,11 @@ A workflow success is necessary but not sufficient for a production-ready Photo 
 
 - [ ] Windows x64 package launches on a clean supported x64 Windows machine without a .NET runtime preinstall.
 - [ ] Windows arm64 package launches on a clean supported ARM64 Windows machine when hardware is available.
+- [ ] Windows Explorer, taskbar, and the main application window show the Photo Organizer product icon rather than a generic executable/window icon.
 - [ ] Record SmartScreen behavior; investigate unexpected unsigned/unrecognized-publisher warnings. New-certificate reputation warnings must not be confused with signature failure.
 - [ ] macOS arm64 DMG opens and app launches on Apple Silicon with Gatekeeper enabled.
 - [ ] macOS x64 DMG opens and app launches on Intel macOS when hardware is available.
+- [ ] macOS Finder and Dock show the Photo Organizer product icon from the signed app bundle rather than a generic application icon.
 - [ ] Windows shows a usable tray icon/menu and macOS shows a usable menu-bar item/menu.
 - [ ] Closing the main window while idle hides it but leaves camera-card monitoring active.
 - [ ] Tray/menu-bar `Photo Organizerを表示` restores and activates the workflow window.

--- a/src/PhotoOrganizer.App/MainWindow.axaml
+++ b/src/PhotoOrganizer.App/MainWindow.axaml
@@ -4,6 +4,7 @@
         x:Class="PhotoOrganizer.App.MainWindow"
         x:DataType="vm:MainWindowViewModel"
         Title="Photo Organizer"
+        Icon="/Assets/app-icon.ico"
         Width="920"
         Height="800"
         MinWidth="760"

--- a/src/PhotoOrganizer.App/PhotoOrganizer.App.csproj
+++ b/src/PhotoOrganizer.App/PhotoOrganizer.App.csproj
@@ -3,6 +3,7 @@
     <OutputType>WinExe</OutputType>
     <AssemblyName>PhotoOrganizer</AssemblyName>
     <RootNamespace>PhotoOrganizer.App</RootNamespace>
+    <ApplicationIcon>Assets/app-icon.ico</ApplicationIcon>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #22

Uses the existing multi-resolution `Assets/app-icon.ico` as the single product icon source across the unified app and release artifacts.

- embeds the ICO into the Windows executable via `ApplicationIcon`;
- assigns the same Avalonia resource to the main window;
- adds a dependency-free macOS icon generator that extracts the largest PNG-backed ICO image and builds an ICNS with the platform `sips`/`iconutil` tools;
- release packaging generates the ICNS before signing, copies it into `Contents/Resources`, and declares `CFBundleIconFile` in `Info.plist`;
- macOS CI actually runs icon generation;
- release-contract CI enforces Windows/window/macOS icon wiring;
- real-device acceptance now checks Explorer/taskbar and Finder/Dock product presentation.

The icon enters the macOS bundle before codesigning/notarization, so the signed candidate covers the exact icon resource customers receive.