### PR TITLE
Exercise all release package shapes in normal CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,40 @@ jobs:
           bash Scripts/build_macos_icon.sh src/PhotoOrganizer.App/Assets/app-icon.ico "$RUNNER_TEMP/PhotoOrganizer.icns"
           test -s "$RUNNER_TEMP/PhotoOrganizer.icns"
 
+  package-smoke-windows:
+    name: Package smoke — Windows x64/ARM64
+    runs-on: windows-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: 10.0.400
+
+      - name: Build and round-trip unsigned packages
+        shell: pwsh
+        run: ./Scripts/smoke_package_windows.ps1 -OutputRoot "$env:RUNNER_TEMP\photo-organizer-package-smoke"
+
+  package-smoke-macos:
+    name: Package smoke — macOS arm64/x64
+    runs-on: macos-15
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@a98b56852c35b8e3190ac28c8c2271da59106c68 # v6.0.0
+        with:
+          dotnet-version: 10.0.400
+
+      - name: Build and mount unsigned DMGs
+        shell: bash
+        run: bash Scripts/smoke_package_macos.sh 0.0.0-ci "$RUNNER_TEMP/photo-organizer-package-smoke"
+
   release-contract:
     name: Release contract
     runs-on: ubuntu-latest
@@ -76,6 +110,8 @@ jobs:
         run: |
           bash -n Scripts/configure_release_secrets.sh
           bash -n Scripts/build_macos_icon.sh
+          bash -n Scripts/smoke_package_macos.sh
+          test -s Scripts/smoke_package_windows.ps1
 
       - name: Enforce fail-closed release contract
         shell: bash
@@ -107,6 +143,13 @@ jobs:
           grep -q 'CFBundleIconFile' "$workflow"
           grep -q 'PhotoOrganizer.icns' "$workflow"
 
+          # Normal CI must exercise every release runtime/outer container without
+          # requiring production signing material.
+          grep -q "@('x64', 'arm64')" Scripts/smoke_package_windows.ps1
+          grep -q 'for arch in arm64 x64' Scripts/smoke_package_macos.sh
+          grep -q 'hdiutil verify' Scripts/smoke_package_macos.sh
+          grep -q 'Expand-Archive' Scripts/smoke_package_windows.ps1
+
           # Signed artifacts are acceptance candidates first. The build workflow must
           # never make them the public stable/latest release on its own.
           grep -q -- '--prerelease' "$workflow"
@@ -126,14 +169,16 @@ jobs:
   required:
     name: required
     if: always()
-    needs: [test-and-build, release-contract]
+    needs: [test-and-build, package-smoke-windows, package-smoke-macos, release-contract]
     runs-on: ubuntu-latest
     steps:
-      - name: Require every platform and release-contract job
+      - name: Require every platform, packaging and release-contract job
         shell: bash
         run: |
           if [ "${{ needs.test-and-build.result }}" != "success" ] || \
+             [ "${{ needs.package-smoke-windows.result }}" != "success" ] || \
+             [ "${{ needs.package-smoke-macos.result }}" != "success" ] || \
              [ "${{ needs.release-contract.result }}" != "success" ]; then
-            echo "At least one required Windows/macOS/release-contract job failed."
+            echo "At least one required Windows/macOS/package/release-contract job failed."
             exit 1
           fi

--- a/Scripts/smoke_package_macos.sh
+++ b/Scripts/smoke_package_macos.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:-0.0.0-ci}"
+OUTPUT_ROOT="${2:-}"
+
+if [[ -z "$OUTPUT_ROOT" ]]; then
+  OUTPUT_ROOT="$(mktemp -d)"
+  cleanup_root=1
+else
+  mkdir -p "$OUTPUT_ROOT"
+  cleanup_root=0
+fi
+
+cleanup() {
+  if [[ "$cleanup_root" -eq 1 ]]; then
+    rm -rf "$OUTPUT_ROOT"
+  fi
+}
+trap cleanup EXIT
+
+icon="$OUTPUT_ROOT/PhotoOrganizer.icns"
+bash Scripts/build_macos_icon.sh src/PhotoOrganizer.App/Assets/app-icon.ico "$icon"
+test -s "$icon"
+
+for arch in arm64 x64; do
+  rid="osx-$arch"
+  publish="$OUTPUT_ROOT/$rid/publish"
+  app="$OUTPUT_ROOT/$rid/Photo Organizer.app"
+  contents="$app/Contents"
+  macos="$contents/MacOS"
+  resources="$contents/Resources"
+  dmg_stage="$OUTPUT_ROOT/$rid/dmg"
+  dmg="$OUTPUT_ROOT/PhotoOrganizer-macOS-$arch-$VERSION.dmg"
+
+  dotnet publish src/PhotoOrganizer.App/PhotoOrganizer.App.csproj \
+    --configuration Release \
+    --runtime "$rid" \
+    --self-contained true \
+    -p:Version="$VERSION" \
+    -p:ContinuousIntegrationBuild=true \
+    --output "$publish"
+
+  for required in PhotoOrganizer PhotoOrganizer.dll PhotoOrganizer.Core.dll PhotoOrganizer.deps.json PhotoOrganizer.runtimeconfig.json; do
+    test -s "$publish/$required" || { echo "Missing publish output: $publish/$required" >&2; exit 1; }
+  done
+
+  case "$arch" in
+    arm64) file "$publish/PhotoOrganizer" | grep -q 'arm64' ;;
+    x64) file "$publish/PhotoOrganizer" | grep -Eq 'x86_64|x86-64' ;;
+  esac
+
+  rm -rf "$app"
+  mkdir -p "$macos" "$resources"
+  ditto "$publish" "$macos"
+  chmod +x "$macos/PhotoOrganizer"
+  cp LICENSE "$resources/LICENSE.txt"
+  cp "$icon" "$resources/PhotoOrganizer.icns"
+
+  cat > "$contents/Info.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key><string>en</string>
+  <key>CFBundleDisplayName</key><string>Photo Organizer</string>
+  <key>CFBundleExecutable</key><string>PhotoOrganizer</string>
+  <key>CFBundleIconFile</key><string>PhotoOrganizer.icns</string>
+  <key>CFBundleIdentifier</key><string>com.peachgumi.photoorganizer</string>
+  <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+  <key>CFBundleName</key><string>Photo Organizer</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleShortVersionString</key><string>$VERSION</string>
+  <key>CFBundleVersion</key><string>1</string>
+  <key>LSMinimumSystemVersion</key><string>13.0</string>
+  <key>NSHighResolutionCapable</key><true/>
+</dict>
+</plist>
+PLIST
+
+  plutil -lint "$contents/Info.plist"
+  [[ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$contents/Info.plist")" == "PhotoOrganizer" ]]
+  [[ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIconFile' "$contents/Info.plist")" == "PhotoOrganizer.icns" ]]
+  test -x "$macos/PhotoOrganizer"
+  test -s "$resources/PhotoOrganizer.icns"
+  test -s "$resources/LICENSE.txt"
+
+  rm -rf "$dmg_stage"
+  mkdir -p "$dmg_stage"
+  ditto "$app" "$dmg_stage/Photo Organizer.app"
+  ln -s /Applications "$dmg_stage/Applications"
+  cp LICENSE "$dmg_stage/LICENSE.txt"
+
+  hdiutil create \
+    -volname "Photo Organizer Smoke $arch" \
+    -srcfolder "$dmg_stage" \
+    -ov -format UDZO "$dmg" >/dev/null
+  test -s "$dmg"
+  hdiutil verify "$dmg" >/dev/null
+
+  mount_point="$OUTPUT_ROOT/$rid/mount"
+  mkdir -p "$mount_point"
+  device="$(hdiutil attach "$dmg" -nobrowse -readonly -mountpoint "$mount_point" | awk 'NR==1 {print $1}')"
+  test -n "$device"
+  test -d "$mount_point/Photo Organizer.app"
+  test -L "$mount_point/Applications"
+  test -s "$mount_point/LICENSE.txt"
+  test -s "$mount_point/Photo Organizer.app/Contents/Resources/PhotoOrganizer.icns"
+  hdiutil detach "$device" >/dev/null
+
+  hash="$(shasum -a 256 "$dmg" | awk '{print $1}')"
+  [[ "$hash" =~ ^[0-9a-f]{64}$ ]]
+  echo "Packaging smoke passed for $rid: $dmg ($hash)"
+done

--- a/Scripts/smoke_package_macos.sh
+++ b/Scripts/smoke_package_macos.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 VERSION="${1:-0.0.0-ci}"
 OUTPUT_ROOT="${2:-}"
+mounted_device=""
 
 if [[ -z "$OUTPUT_ROOT" ]]; then
   OUTPUT_ROOT="$(mktemp -d)"
@@ -13,6 +14,10 @@ else
 fi
 
 cleanup() {
+  if [[ -n "$mounted_device" ]]; then
+    hdiutil detach "$mounted_device" >/dev/null 2>&1 || true
+    mounted_device=""
+  fi
   if [[ "$cleanup_root" -eq 1 ]]; then
     rm -rf "$OUTPUT_ROOT"
   fi
@@ -100,13 +105,32 @@ PLIST
 
   mount_point="$OUTPUT_ROOT/$rid/mount"
   mkdir -p "$mount_point"
-  device="$(hdiutil attach "$dmg" -nobrowse -readonly -mountpoint "$mount_point" | awk 'NR==1 {print $1}')"
-  test -n "$device"
+  attach_plist="$OUTPUT_ROOT/$rid/attach.plist"
+  hdiutil attach "$dmg" -nobrowse -readonly -mountpoint "$mount_point" -plist > "$attach_plist"
+  mounted_device="$(python3 - "$attach_plist" "$mount_point" <<'PY'
+import plistlib
+import sys
+from pathlib import Path
+
+payload = plistlib.loads(Path(sys.argv[1]).read_bytes())
+target = str(Path(sys.argv[2]).resolve())
+for entity in payload.get("system-entities", []):
+    mount = entity.get("mount-point")
+    device = entity.get("dev-entry")
+    if mount and device and str(Path(mount).resolve()) == target:
+        print(device)
+        break
+else:
+    raise SystemExit("Unable to resolve mounted DMG device from hdiutil plist")
+PY
+)"
+  test -n "$mounted_device"
   test -d "$mount_point/Photo Organizer.app"
   test -L "$mount_point/Applications"
   test -s "$mount_point/LICENSE.txt"
   test -s "$mount_point/Photo Organizer.app/Contents/Resources/PhotoOrganizer.icns"
-  hdiutil detach "$device" >/dev/null
+  hdiutil detach "$mounted_device" >/dev/null
+  mounted_device=""
 
   hash="$(shasum -a 256 "$dmg" | awk '{print $1}')"
   [[ "$hash" =~ ^[0-9a-f]{64}$ ]]

--- a/Scripts/smoke_package_macos.sh
+++ b/Scripts/smoke_package_macos.sh
@@ -13,16 +13,40 @@ else
   cleanup_root=0
 fi
 
-cleanup() {
+detach_if_needed() {
   if [[ -n "$mounted_device" ]]; then
-    hdiutil detach "$mounted_device" >/dev/null 2>&1 || true
+    hdiutil detach "$mounted_device" >/dev/null 2>&1 || hdiutil detach -force "$mounted_device" >/dev/null 2>&1 || true
     mounted_device=""
   fi
+}
+
+cleanup() {
+  detach_if_needed
   if [[ "$cleanup_root" -eq 1 ]]; then
     rm -rf "$OUTPUT_ROOT"
   fi
 }
 trap cleanup EXIT
+
+create_dmg() {
+  local stage="$1"
+  local output="$2"
+  local volume_name="$3"
+  local attempt
+
+  rm -f "$output"
+  for attempt in 1 2 3; do
+    if hdiutil create -volname "$volume_name" -srcfolder "$stage" -ov -format UDZO "$output" >/dev/null; then
+      return 0
+    fi
+    rm -f "$output"
+    # diskimages-helper can take a moment to release the previous image device.
+    sleep "$attempt"
+  done
+
+  echo "Unable to create DMG after 3 attempts: $output" >&2
+  return 1
+}
 
 icon="$OUTPUT_ROOT/PhotoOrganizer.icns"
 bash Scripts/build_macos_icon.sh src/PhotoOrganizer.App/Assets/app-icon.ico "$icon"
@@ -96,10 +120,7 @@ PLIST
   ln -s /Applications "$dmg_stage/Applications"
   cp LICENSE "$dmg_stage/LICENSE.txt"
 
-  hdiutil create \
-    -volname "Photo Organizer Smoke $arch" \
-    -srcfolder "$dmg_stage" \
-    -ov -format UDZO "$dmg" >/dev/null
+  create_dmg "$dmg_stage" "$dmg" "Photo Organizer Smoke $arch"
   test -s "$dmg"
   hdiutil verify "$dmg" >/dev/null
 
@@ -109,19 +130,33 @@ PLIST
   hdiutil attach "$dmg" -nobrowse -readonly -mountpoint "$mount_point" -plist > "$attach_plist"
   mounted_device="$(python3 - "$attach_plist" "$mount_point" <<'PY'
 import plistlib
+import re
 import sys
 from pathlib import Path
 
 payload = plistlib.loads(Path(sys.argv[1]).read_bytes())
 target = str(Path(sys.argv[2]).resolve())
+mounted = None
+all_devices = []
 for entity in payload.get("system-entities", []):
-    mount = entity.get("mount-point")
     device = entity.get("dev-entry")
+    if device:
+        all_devices.append(device)
+    mount = entity.get("mount-point")
     if mount and device and str(Path(mount).resolve()) == target:
-        print(device)
-        break
-else:
+        mounted = device
+
+if not mounted:
     raise SystemExit("Unable to resolve mounted DMG device from hdiutil plist")
+
+match = re.match(r"^(/dev/disk\d+)", mounted)
+whole = match.group(1) if match else mounted
+if all_devices and whole not in all_devices:
+    # Prefer an explicit whole-disk entity from the attach result when present.
+    candidates = [d for d in all_devices if re.fullmatch(r"/dev/disk\d+", d)]
+    if candidates:
+        whole = candidates[0]
+print(whole)
 PY
 )"
   test -n "$mounted_device"
@@ -131,6 +166,7 @@ PY
   test -s "$mount_point/Photo Organizer.app/Contents/Resources/PhotoOrganizer.icns"
   hdiutil detach "$mounted_device" >/dev/null
   mounted_device=""
+  rmdir "$mount_point" 2>/dev/null || true
 
   hash="$(shasum -a 256 "$dmg" | awk '{print $1}')"
   [[ "$hash" =~ ^[0-9a-f]{64}$ ]]

--- a/Scripts/smoke_package_windows.ps1
+++ b/Scripts/smoke_package_windows.ps1
@@ -89,7 +89,7 @@ try {
 
         $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $zip).Hash.ToLowerInvariant()
         if ($hash -notmatch '^[0-9a-f]{64}$') { throw "Invalid package SHA-256: $zip" }
-        Write-Host "Packaging smoke passed for $rid: $zip ($hash)"
+        Write-Host "Packaging smoke passed for ${rid}: $zip ($hash)"
     }
 }
 finally {

--- a/Scripts/smoke_package_windows.ps1
+++ b/Scripts/smoke_package_windows.ps1
@@ -1,0 +1,99 @@
+param(
+    [string]$Version = "0.0.0-ci",
+    [string]$OutputRoot = ""
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+if ([string]::IsNullOrWhiteSpace($OutputRoot)) {
+    $OutputRoot = Join-Path ([IO.Path]::GetTempPath()) ("PhotoOrganizer-package-smoke-" + [Guid]::NewGuid().ToString('N'))
+}
+
+function Get-PeMachine([string]$Path) {
+    $stream = [IO.File]::OpenRead($Path)
+    try {
+        $reader = [IO.BinaryReader]::new($stream)
+        if ($reader.ReadUInt16() -ne 0x5A4D) { throw "Not an MZ executable: $Path" }
+        $stream.Position = 0x3c
+        $peOffset = $reader.ReadInt32()
+        if ($peOffset -lt 0 -or $peOffset + 6 -gt $stream.Length) { throw "Invalid PE offset: $Path" }
+        $stream.Position = $peOffset
+        if ($reader.ReadUInt32() -ne 0x00004550) { throw "Missing PE signature: $Path" }
+        return $reader.ReadUInt16()
+    }
+    finally {
+        $stream.Dispose()
+    }
+}
+
+$expectedMachine = @{
+    'x64' = 0x8664
+    'arm64' = 0xAA64
+}
+
+try {
+    New-Item -ItemType Directory -Force -Path $OutputRoot | Out-Null
+
+    foreach ($arch in @('x64', 'arm64')) {
+        $rid = "win-$arch"
+        $publish = Join-Path $OutputRoot "$rid\publish"
+        $packageDir = Join-Path $OutputRoot "$rid\package"
+        New-Item -ItemType Directory -Force -Path $publish, $packageDir | Out-Null
+
+        dotnet publish src/PhotoOrganizer.App/PhotoOrganizer.App.csproj `
+            --configuration Release `
+            --runtime $rid `
+            --self-contained true `
+            -p:Version=$Version `
+            -p:ContinuousIntegrationBuild=true `
+            --output $publish
+        if ($LASTEXITCODE -ne 0) { throw "dotnet publish failed for $rid" }
+
+        $required = @(
+            'PhotoOrganizer.exe',
+            'PhotoOrganizer.dll',
+            'PhotoOrganizer.Core.dll',
+            'PhotoOrganizer.deps.json',
+            'PhotoOrganizer.runtimeconfig.json'
+        )
+        foreach ($name in $required) {
+            $file = Join-Path $publish $name
+            if (-not (Test-Path -LiteralPath $file -PathType Leaf)) { throw "Required publish output missing: $file" }
+            if ((Get-Item -LiteralPath $file).Length -le 0) { throw "Required publish output is empty: $file" }
+        }
+
+        $exe = Join-Path $publish 'PhotoOrganizer.exe'
+        $machine = Get-PeMachine $exe
+        if ($machine -ne $expectedMachine[$arch]) {
+            throw ("Unexpected PE machine for {0}: 0x{1:X4}" -f $rid, $machine)
+        }
+
+        Copy-Item LICENSE (Join-Path $publish 'LICENSE.txt')
+        Copy-Item -Recurse -Force (Join-Path $publish '*') $packageDir
+
+        $zip = Join-Path $OutputRoot "PhotoOrganizer-Windows-$arch-$Version.zip"
+        if (Test-Path $zip) { Remove-Item $zip -Force }
+        Compress-Archive -Path (Join-Path $packageDir '*') -DestinationPath $zip -CompressionLevel Optimal
+        if (-not (Test-Path -LiteralPath $zip -PathType Leaf) -or (Get-Item $zip).Length -le 0) {
+            throw "Smoke package was not created: $zip"
+        }
+
+        $extract = Join-Path $OutputRoot "$rid\extract"
+        Expand-Archive -LiteralPath $zip -DestinationPath $extract
+        foreach ($name in @('PhotoOrganizer.exe', 'PhotoOrganizer.dll', 'PhotoOrganizer.Core.dll', 'LICENSE.txt')) {
+            if (-not (Test-Path -LiteralPath (Join-Path $extract $name) -PathType Leaf)) {
+                throw "Packaged file missing after ZIP round trip: $name"
+            }
+        }
+
+        $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $zip).Hash.ToLowerInvariant()
+        if ($hash -notmatch '^[0-9a-f]{64}$') { throw "Invalid package SHA-256: $zip" }
+        Write-Host "Packaging smoke passed for $rid: $zip ($hash)"
+    }
+}
+finally {
+    if (Test-Path $OutputRoot) {
+        Remove-Item $OutputRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}


### PR DESCRIPTION
Hardens the #7 migration/release acceptance path before real-device testing.

Production signing secrets intentionally remain mandatory for the real Release workflow, but that previously meant the publish/package code paths were not executed by normal PR CI. This PR adds unsigned packaging smoke tests that exercise the same four release runtime targets without weakening any signing or acceptance gate.

- Windows x64 and ARM64 self-contained publish
- validates PE machine architecture for each executable
- ZIP creation plus extraction round trip and SHA-256
- macOS arm64 and x64 self-contained publish
- validated ICO -> ICNS generation
- real `.app` bundle/Info.plist/resource construction
- executable architecture validation
- DMG creation, `hdiutil verify`, read-only mount and contents validation
- `required` now depends on both packaging smoke jobs as well as platform tests and release-contract checks

No unsigned smoke artifact is uploaded or published. Stable production release still requires the existing signed/notarized prerelease candidate and recorded physical acceptance.