### PR TITLE
Fail closed on hidden supported media instead of skipping it

### DIFF
--- a/docs/DATA_SAFETY.md
+++ b/docs/DATA_SAFETY.md
@@ -22,6 +22,8 @@ The application must not offer an operation that formats or erases the camera ca
 
 A scan is complete only if every directory and relevant file in the selected camera-card scope was enumerated without an I/O or metadata error.
 
+Hidden or dot-prefixed directories are not an exception: supported JPG/JPEG, configured RAW, MOV, or MP4 media inside them remains in scope and must be discovered. Unsupported hidden sidecars/system metadata remain outside import scope. Reparse points/symlinks and nested mounted volumes are excluded so scanning cannot escape the selected physical card.
+
 Any scan error is fail-closed. Supported zero-byte media is an error. An incomplete scan must never start an import or produce a reusable-card approval.
 
 Manual selection of a nested camera directory must be expanded to the safe camera-card root. An arbitrary folder must not be accepted as equivalent to a complete card scan.

--- a/src/PhotoOrganizer.Core/MediaScanner.cs
+++ b/src/PhotoOrganizer.Core/MediaScanner.cs
@@ -67,11 +67,11 @@ public sealed class MediaScanner
 
                     if ((attributes & FileAttributes.Directory) != 0)
                     {
-                        if ((attributes & FileAttributes.Hidden) != 0 || entry.Name.StartsWith('.'))
-                        {
-                            continue;
-                        }
-
+                        // Hidden/dot-prefixed directories are still part of the
+                        // camera-card scope. A supported JPG/RAW/video inside one
+                        // would otherwise be silently omitted and could be lost when
+                        // the user reformats the card after a false reuse approval.
+                        // Only reparse points and nested mounted volumes are excluded.
                         if (guard.IsNestedMountedVolume(entry.FullName))
                         {
                             continue;

--- a/tests/PhotoOrganizer.Core.Tests/HiddenMediaSafetyTests.cs
+++ b/tests/PhotoOrganizer.Core.Tests/HiddenMediaSafetyTests.cs
@@ -1,0 +1,68 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PhotoOrganizer.Core.Tests;
+
+[TestClass]
+public sealed class HiddenMediaSafetyTests
+{
+    [TestMethod]
+    public void HiddenDirectorySupportedMedia_IsIncludedInCompleteScan()
+    {
+        using var temp = new TempDirectory();
+        var hidden = Directory.CreateDirectory(Path.Combine(temp.Path, ".camera-hidden"));
+        var photo = Path.Combine(hidden.FullName, "recoverable.jpg");
+        File.WriteAllText(photo, "camera-bytes");
+
+        var result = new MediaScanner(new MediaClassifier()).Scan(temp.Path);
+
+        Assert.IsTrue(result.IsComplete, string.Join(Environment.NewLine, result.Errors));
+        CollectionAssert.Contains(result.Files.ToList(), photo);
+    }
+
+    [TestMethod]
+    public void HiddenDirectoryZeroByteSupportedMedia_BlocksCompleteScan()
+    {
+        using var temp = new TempDirectory();
+        var hidden = Directory.CreateDirectory(Path.Combine(temp.Path, ".camera-hidden"));
+        var photo = Path.Combine(hidden.FullName, "broken.nef");
+        File.WriteAllBytes(photo, []);
+
+        var result = new MediaScanner(new MediaClassifier()).Scan(temp.Path);
+
+        Assert.IsFalse(result.IsComplete);
+        CollectionAssert.Contains(result.Files.ToList(), photo);
+        Assert.IsTrue(result.Errors.Any(error => error.Contains("zero bytes", StringComparison.OrdinalIgnoreCase)));
+    }
+
+    [TestMethod]
+    public void HiddenUnsupportedSidecar_DoesNotBecomeImportScope()
+    {
+        using var temp = new TempDirectory();
+        var hidden = Directory.CreateDirectory(Path.Combine(temp.Path, ".camera-hidden"));
+        File.WriteAllText(Path.Combine(hidden.FullName, "metadata.xmp"), "sidecar");
+        var photo = Path.Combine(temp.Path, "visible.jpg");
+        File.WriteAllText(photo, "camera-bytes");
+
+        var result = new MediaScanner(new MediaClassifier()).Scan(temp.Path);
+
+        Assert.IsTrue(result.IsComplete, string.Join(Environment.NewLine, result.Errors));
+        Assert.AreEqual(1, result.Files.Count);
+        Assert.AreEqual(photo, result.Files.Single());
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"PhotoOrganizerHiddenMedia-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Path, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Fixes a release-safety gap found during the final unified-main review.

The normative data-safety contract requires a complete scan of all relevant media in the camera-card scope. The scanner still skipped hidden/dot-prefixed directories, which meant a JPG/RAW/MOV/MP4 stored there could be omitted from import and final reuse verification.

This change:
- traverses hidden/dot-prefixed directories on the source card;
- keeps reparse points/symlinks and nested mounted volumes excluded;
- imports/verifies supported hidden media exactly like visible supported media;
- makes hidden zero-byte supported media fail the scan closed;
- leaves unsupported hidden sidecars/system metadata outside import scope;
- updates the normative safety contract and adds cross-platform regression tests.

This is intentionally conservative: if a hidden directory cannot be enumerated, the normal scan error path blocks import/reuse approval rather than silently assuming no relevant media exists.