### PR TITLE
Reject destination path aliases from SD reuse safety

### DIFF
--- a/docs/DATA_SAFETY.md
+++ b/docs/DATA_SAFETY.md
@@ -28,6 +28,14 @@ Any scan error is fail-closed. Supported zero-byte media is an error. An incompl
 
 Manual selection of a nested camera directory must be expanded to the safe camera-card root. An arbitrary folder must not be accepted as equivalent to a complete card scan.
 
+## Destination path independence
+
+A destination used for copy, duplicate lookup, or final reuse verification must be reached through a direct filesystem path. If the destination itself or any existing parent component is a symbolic link, junction, or other reparse point, the operation must fail closed.
+
+A lexical path alias must never count as an independent backup. In particular, a destination path that resolves back onto the camera card must not be allowed to write data or prove that the source bytes have been backed up.
+
+Source and destination must also resolve to different mounted-storage identities. Path strings alone are insufficient proof of independence.
+
 ## Copy transaction
 
 For every new source file:
@@ -54,11 +62,12 @@ Reuse approval requires all of the following after copy processing:
 - the same selected source storage is still mounted;
 - the same selected destination storage is still mounted;
 - source and destination storage identities still match the identities captured for this operation;
+- the destination path remains a direct filesystem path with no symlink/junction/reparse component;
 - a fresh complete scan of the whole safe camera-card scope succeeds;
 - all supported source media expected from the initial scan is still present;
 - every currently supported source file is non-zero and readable;
 - an independent destination file with equal size and SHA-256 exists for every supported source file;
-- a source path itself is never accepted as proof of an independent destination copy;
+- a source path itself, including the same bytes reached through a path alias, is never accepted as proof of an independent destination copy;
 - storage identity is checked again after hashing before approval is displayed.
 
 If any condition cannot be proved, the UI must remain blocked/not-verified.

--- a/docs/DATA_SAFETY.md
+++ b/docs/DATA_SAFETY.md
@@ -30,7 +30,7 @@ Manual selection of a nested camera directory must be expanded to the safe camer
 
 ## Destination path independence
 
-A destination used for copy, duplicate lookup, or final reuse verification must be reached through a direct filesystem path. If the destination itself or any existing parent component is a symbolic link, junction, or other reparse point, the operation must fail closed.
+A destination used for copy, duplicate lookup, or final reuse verification must not pass through a user-controlled symbolic link, junction, or other reparse point. A platform may recognize a fixed OS-owned compatibility alias only when its resolved target is explicitly verified against the expected system path; all other aliases fail closed.
 
 A lexical path alias must never count as an independent backup. In particular, a destination path that resolves back onto the camera card must not be allowed to write data or prove that the source bytes have been backed up.
 
@@ -62,7 +62,7 @@ Reuse approval requires all of the following after copy processing:
 - the same selected source storage is still mounted;
 - the same selected destination storage is still mounted;
 - source and destination storage identities still match the identities captured for this operation;
-- the destination path remains a direct filesystem path with no symlink/junction/reparse component;
+- the destination path remains free of user-controlled symlink/junction/reparse aliases;
 - a fresh complete scan of the whole safe camera-card scope succeeds;
 - all supported source media expected from the initial scan is still present;
 - every currently supported source file is non-zero and readable;

--- a/src/PhotoOrganizer.Core/DestinationLibrary.cs
+++ b/src/PhotoOrganizer.Core/DestinationLibrary.cs
@@ -91,6 +91,12 @@ public sealed class DestinationLibrary
             return new DestinationIndex(filesBySize, errors);
         }
 
+        if (!PathSafety.TryValidateDirectFilesystemPath(destinationRoot, out var pathError))
+        {
+            errors.Add($"Destination root is not a direct filesystem path: {pathError}");
+            return new DestinationIndex(filesBySize, errors);
+        }
+
         if (!Directory.Exists(destinationRoot))
         {
             return new DestinationIndex(filesBySize, errors);

--- a/src/PhotoOrganizer.Core/FormatSafetyVerifier.cs
+++ b/src/PhotoOrganizer.Core/FormatSafetyVerifier.cs
@@ -138,7 +138,19 @@ public sealed class FormatSafetyVerifier
         var index = new Dictionary<long, List<string>>();
         var errors = new List<string>();
 
-        if (string.IsNullOrWhiteSpace(destinationRoot) || !Directory.Exists(destinationRoot))
+        if (string.IsNullOrWhiteSpace(destinationRoot))
+        {
+            errors.Add("Destination root does not exist or is not a directory.");
+            return new DestinationIndex(index, errors);
+        }
+
+        if (!PathSafety.TryValidateDirectFilesystemPath(destinationRoot, out var pathError))
+        {
+            errors.Add($"Destination root is not a direct filesystem path: {pathError}");
+            return new DestinationIndex(index, errors);
+        }
+
+        if (!Directory.Exists(destinationRoot))
         {
             errors.Add("Destination root does not exist or is not a directory.");
             return new DestinationIndex(index, errors);

--- a/src/PhotoOrganizer.Core/SafeCopyService.cs
+++ b/src/PhotoOrganizer.Core/SafeCopyService.cs
@@ -33,7 +33,19 @@ public sealed class SafeCopyService
                 return new CopyResult(CopyStatus.Failed, null, "Zero-byte supported media cannot be imported safely.");
             }
 
+            if (!PathSafety.TryValidateDirectFilesystemPath(destinationDirectory, out var pathError))
+            {
+                return new CopyResult(CopyStatus.Failed, null, $"Destination path is not a direct filesystem path: {pathError}");
+            }
+
             Directory.CreateDirectory(destinationDirectory);
+
+            // Re-check after creation so a path alias can never be accepted merely
+            // because a leaf component did not exist during the first inspection.
+            if (!PathSafety.TryValidateDirectFilesystemPath(destinationDirectory, out pathError))
+            {
+                return new CopyResult(CopyStatus.Failed, null, $"Destination path became unsafe: {pathError}");
+            }
 
             var sourceSize = sourceInfo.Length;
             var sourceLastWriteUtc = sourceInfo.LastWriteTimeUtc;
@@ -96,6 +108,11 @@ public sealed class SafeCopyService
             if (!string.Equals(sourceHashBefore, sourceHashAfter, StringComparison.Ordinal))
             {
                 return new CopyResult(CopyStatus.Failed, null, "Source media changed while copying.");
+            }
+
+            if (!PathSafety.TryValidateDirectFilesystemPath(destinationDirectory, out pathError))
+            {
+                return new CopyResult(CopyStatus.Failed, null, $"Destination path changed before finalization: {pathError}");
             }
 
             var finalPath = resolution.Path;

--- a/src/PhotoOrganizer.Core/StorageIdentity.cs
+++ b/src/PhotoOrganizer.Core/StorageIdentity.cs
@@ -53,8 +53,8 @@ public static class PathSafety
     /// <summary>
     /// Verifies that an absolute path is reached only through direct filesystem
     /// components. A symlink/junction/reparse point can make a lexically separate
-    /// destination resolve back onto the camera card, so such aliases are never
-    /// permitted to participate in backup or reuse-safety decisions.
+    /// destination resolve back onto the camera card, so user-controlled aliases are
+    /// never permitted to participate in backup or reuse-safety decisions.
     ///
     /// Missing leaf components are allowed because the application may create them;
     /// every component that already exists is inspected, including its ancestors.
@@ -86,7 +86,8 @@ public static class PathSafety
             try
             {
                 var attributes = File.GetAttributes(current);
-                if ((attributes & FileAttributes.ReparsePoint) != 0)
+                if ((attributes & FileAttributes.ReparsePoint) != 0
+                    && !IsVerifiedMacSystemAlias(current))
                 {
                     error = $"Path contains a symbolic link, junction, or reparse point: {current}";
                     return false;
@@ -129,6 +130,29 @@ public static class PathSafety
         }
 
         return true;
+    }
+
+    private static bool IsVerifiedMacSystemAlias(string path)
+    {
+        // macOS exposes /var as a root-owned compatibility symlink to /private/var.
+        // .NET temporary directories therefore commonly live under /var/folders.
+        // Trust only this exact OS alias and only after resolving it to the expected
+        // fixed target; every user-controlled alias remains fail-closed.
+        if (!OperatingSystem.IsMacOS() || !string.Equals(path, "/var", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        try
+        {
+            var target = new DirectoryInfo(path).ResolveLinkTarget(returnFinalTarget: true);
+            return target is not null
+                && string.Equals(Normalize(target.FullName), "/private/var", StringComparison.Ordinal);
+        }
+        catch
+        {
+            return false;
+        }
     }
 }
 

--- a/src/PhotoOrganizer.Core/StorageIdentity.cs
+++ b/src/PhotoOrganizer.Core/StorageIdentity.cs
@@ -213,6 +213,7 @@ public sealed class StorageSessionTracker
     public StorageSessionIdentity? Capture(string path)
     {
         if (string.IsNullOrWhiteSpace(path)) return null;
+        if (!PathSafety.TryValidateDirectFilesystemPath(path, out _)) return null;
         Refresh();
 
         var volume = _provider.ResolveVolumeForPath(path);

--- a/src/PhotoOrganizer.Core/StorageIdentity.cs
+++ b/src/PhotoOrganizer.Core/StorageIdentity.cs
@@ -49,6 +49,87 @@ public static class PathSafety
 
         return normalizedPath.StartsWith(prefix, comparison);
     }
+
+    /// <summary>
+    /// Verifies that an absolute path is reached only through direct filesystem
+    /// components. A symlink/junction/reparse point can make a lexically separate
+    /// destination resolve back onto the camera card, so such aliases are never
+    /// permitted to participate in backup or reuse-safety decisions.
+    ///
+    /// Missing leaf components are allowed because the application may create them;
+    /// every component that already exists is inspected, including its ancestors.
+    /// Any metadata error other than a genuinely missing component fails closed.
+    /// </summary>
+    public static bool TryValidateDirectFilesystemPath(string path, out string? error)
+    {
+        error = null;
+
+        string current;
+        try
+        {
+            current = Normalize(path);
+        }
+        catch (Exception ex)
+        {
+            error = $"Path could not be normalized: {ex.Message}";
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(current))
+        {
+            error = "Path is empty.";
+            return false;
+        }
+
+        while (true)
+        {
+            try
+            {
+                var attributes = File.GetAttributes(current);
+                if ((attributes & FileAttributes.ReparsePoint) != 0)
+                {
+                    error = $"Path contains a symbolic link, junction, or reparse point: {current}";
+                    return false;
+                }
+            }
+            catch (FileNotFoundException)
+            {
+                // A not-yet-created leaf is allowed; existing ancestors are still checked below.
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // A not-yet-created leaf is allowed; existing ancestors are still checked below.
+            }
+            catch (Exception ex)
+            {
+                error = $"Unable to inspect path component {current}: {ex.Message}";
+                return false;
+            }
+
+            string? parent;
+            try
+            {
+                parent = Directory.GetParent(current)?.FullName;
+            }
+            catch (Exception ex)
+            {
+                error = $"Unable to inspect path parent for {current}: {ex.Message}";
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(parent)
+                || string.Equals(parent, current, OperatingSystem.IsWindows()
+                    ? StringComparison.OrdinalIgnoreCase
+                    : StringComparison.Ordinal))
+            {
+                break;
+            }
+
+            current = parent;
+        }
+
+        return true;
+    }
 }
 
 /// <summary>

--- a/tests/PhotoOrganizer.Core.Tests/PathAliasSafetyTests.cs
+++ b/tests/PhotoOrganizer.Core.Tests/PathAliasSafetyTests.cs
@@ -1,0 +1,114 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PhotoOrganizer.Core.Tests;
+
+[TestClass]
+public sealed class PathAliasSafetyTests
+{
+    [TestMethod]
+    public void DirectFilesystemPath_IsAccepted()
+    {
+        using var temp = new TempDirectory();
+        var direct = Directory.CreateDirectory(Path.Combine(temp.Path, "direct", "library")).FullName;
+
+        Assert.IsTrue(
+            PathSafety.TryValidateDirectFilesystemPath(direct, out var error),
+            error);
+    }
+
+    [TestMethod]
+    public void DirectorySymlink_IsRejectedAsDestinationPath()
+    {
+        using var temp = new TempDirectory();
+        var target = Directory.CreateDirectory(Path.Combine(temp.Path, "target")).FullName;
+        var alias = Path.Combine(temp.Path, "alias");
+        CreateDirectorySymlinkOrSkip(alias, target);
+
+        Assert.IsFalse(PathSafety.TryValidateDirectFilesystemPath(alias, out var error));
+        StringAssert.Contains(error ?? string.Empty, "reparse");
+    }
+
+    [TestMethod]
+    public void NestedPathThroughDirectorySymlink_IsRejected()
+    {
+        using var temp = new TempDirectory();
+        var target = Directory.CreateDirectory(Path.Combine(temp.Path, "target")).FullName;
+        var alias = Path.Combine(temp.Path, "alias");
+        CreateDirectorySymlinkOrSkip(alias, target);
+
+        var nested = Path.Combine(alias, "new-event", "JPG");
+        Assert.IsFalse(PathSafety.TryValidateDirectFilesystemPath(nested, out var error));
+        Assert.IsFalse(string.IsNullOrWhiteSpace(error));
+    }
+
+    [TestMethod]
+    public async Task FormatVerifier_NeverAcceptsSourceThroughDestinationSymlink()
+    {
+        using var temp = new TempDirectory();
+        var sourceDirectory = Directory.CreateDirectory(Path.Combine(temp.Path, "camera")).FullName;
+        var source = Path.Combine(sourceDirectory, "photo.jpg");
+        File.WriteAllText(source, "irreplaceable-camera-bytes");
+
+        var alias = Path.Combine(temp.Path, "destination-alias");
+        CreateDirectorySymlinkOrSkip(alias, sourceDirectory);
+
+        var result = await new FormatSafetyVerifier(new MediaClassifier())
+            .VerifyAsync([source], alias);
+
+        Assert.IsFalse(result.IsSafe);
+        Assert.AreEqual(0, result.Verified);
+        Assert.IsTrue(result.Errors.Count > 0);
+    }
+
+    [TestMethod]
+    public async Task SafeCopyService_RefusesAliasedDestinationWithoutWritingSource()
+    {
+        using var temp = new TempDirectory();
+        var sourceDirectory = Directory.CreateDirectory(Path.Combine(temp.Path, "camera")).FullName;
+        var source = Path.Combine(sourceDirectory, "photo.jpg");
+        File.WriteAllText(source, "irreplaceable-camera-bytes");
+
+        var alias = Path.Combine(temp.Path, "destination-alias");
+        CreateDirectorySymlinkOrSkip(alias, sourceDirectory);
+
+        var result = await new SafeCopyService().CopyAsync(source, alias);
+
+        Assert.AreEqual(CopyStatus.Failed, result.Status);
+        Assert.AreEqual("irreplaceable-camera-bytes", File.ReadAllText(source));
+        Assert.IsFalse(File.Exists(Path.Combine(sourceDirectory, "photo_2.jpg")));
+        Assert.IsFalse(Directory.EnumerateFiles(sourceDirectory).Any(path =>
+            Path.GetFileName(path).StartsWith(".partial-", StringComparison.Ordinal)));
+    }
+
+    private static void CreateDirectorySymlinkOrSkip(string alias, string target)
+    {
+        try
+        {
+            Directory.CreateSymbolicLink(alias, target);
+        }
+        catch (Exception ex) when (ex is PlatformNotSupportedException
+                                   or UnauthorizedAccessException
+                                   or IOException)
+        {
+            Assert.Inconclusive($"Directory symbolic links are unavailable in this test environment: {ex.Message}");
+        }
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"PhotoOrganizerPathAlias-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Path, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
Closes #27

Fixes a P0 path-alias safety gap where a destination symlink/junction/reparse path could lexically look separate while resolving back onto the camera card. In the worst case, the same source bytes reached through a different path could otherwise be mistaken for an independent backup.

This change fails closed at multiple layers:
- `PathSafety` rejects any destination path whose existing component is a symlink/junction/reparse point;
- storage identity capture refuses aliased paths;
- `SafeCopyService` validates the destination before creation, after creation, and before finalization;
- `DestinationLibrary` refuses aliased roots for duplicate lookup;
- `FormatSafetyVerifier` independently refuses aliased roots, preventing a false reuse approval even when invoked directly;
- regression tests reproduce the alias-to-source scenario and verify no collision/partial file is written through the alias;
- the normative data-safety contract now requires direct filesystem destination paths.

Source media remains immutable; a path alias can never count as an independent backup.