### PR TITLE
Retry transient macOS DMG verification in CI

### DIFF
--- a/Scripts/smoke_package_macos.sh
+++ b/Scripts/smoke_package_macos.sh
@@ -48,6 +48,24 @@ create_dmg() {
   return 1
 }
 
+verify_dmg() {
+  local image="$1"
+  local attempt
+
+  # GitHub-hosted macOS runners occasionally report EAGAIN immediately after
+  # image creation while diskimages-helper is still releasing resources. Retry
+  # only a small bounded number of times; a persistently invalid DMG must fail.
+  for attempt in 1 2 3; do
+    if hdiutil verify "$image" >/dev/null; then
+      return 0
+    fi
+    sleep "$attempt"
+  done
+
+  echo "Unable to verify DMG after 3 attempts: $image" >&2
+  return 1
+}
+
 icon="$OUTPUT_ROOT/PhotoOrganizer.icns"
 bash Scripts/build_macos_icon.sh src/PhotoOrganizer.App/Assets/app-icon.ico "$icon"
 test -s "$icon"
@@ -122,7 +140,7 @@ PLIST
 
   create_dmg "$dmg_stage" "$dmg" "Photo Organizer Smoke $arch"
   test -s "$dmg"
-  hdiutil verify "$dmg" >/dev/null
+  verify_dmg "$dmg"
 
   mount_point="$OUTPUT_ROOT/$rid/mount"
   mkdir -p "$mount_point"


### PR DESCRIPTION
Closes #29

Main CI exposed a GitHub-hosted macOS runner flake where the arm64 DMG verified successfully but the immediately following x64 `hdiutil verify` returned `Resource temporarily unavailable`. The same commit's PR smoke had passed.

This keeps verification fail-closed while adding the same bounded retry pattern already used for `hdiutil create`:
- up to 3 verification attempts;
- short increasing sleeps between attempts;
- persistent invalid/unverifiable images still fail non-zero;
- DMG mount/content checks and SHA-256 validation are unchanged.

This is CI reliability only; it does not weaken package validation.