### PR TITLE
Require physical-device separation for SD reuse safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,14 @@ jobs:
       - name: Restore app
         run: dotnet restore src/PhotoOrganizer.App/PhotoOrganizer.App.csproj
 
+      - name: Restore platform identity tests
+        run: dotnet restore tests/PhotoOrganizer.App.Tests/PhotoOrganizer.App.Tests.csproj
+
       - name: Run shared safety tests
         run: dotnet test tests/PhotoOrganizer.Core.Tests/PhotoOrganizer.Core.Tests.csproj --configuration Release --no-restore
+
+      - name: Run platform storage identity tests
+        run: dotnet test tests/PhotoOrganizer.App.Tests/PhotoOrganizer.App.Tests.csproj --configuration Release --no-restore
 
       - name: Build unified desktop app
         run: dotnet build src/PhotoOrganizer.App/PhotoOrganizer.App.csproj --configuration Release --no-restore

--- a/PhotoOrganizer.slnx
+++ b/PhotoOrganizer.slnx
@@ -2,4 +2,5 @@
   <Project Path="src/PhotoOrganizer.Core/PhotoOrganizer.Core.csproj" />
   <Project Path="src/PhotoOrganizer.App/PhotoOrganizer.App.csproj" />
   <Project Path="tests/PhotoOrganizer.Core.Tests/PhotoOrganizer.Core.Tests.csproj" />
+  <Project Path="tests/PhotoOrganizer.App.Tests/PhotoOrganizer.App.Tests.csproj" />
 </Solution>

--- a/docs/DATA_SAFETY.md
+++ b/docs/DATA_SAFETY.md
@@ -28,13 +28,13 @@ Any scan error is fail-closed. Supported zero-byte media is an error. An incompl
 
 Manual selection of a nested camera directory must be expanded to the safe camera-card root. An arbitrary folder must not be accepted as equivalent to a complete card scan.
 
-## Destination path independence
+## Destination path and device independence
 
 A destination used for copy, duplicate lookup, or final reuse verification must not pass through a user-controlled symbolic link, junction, or other reparse point. A platform may recognize a fixed OS-owned compatibility alias only when its resolved target is explicitly verified against the expected system path; all other aliases fail closed.
 
 A lexical path alias must never count as an independent backup. In particular, a destination path that resolves back onto the camera card must not be allowed to write data or prove that the source bytes have been backed up.
 
-Source and destination must also resolve to different mounted-storage identities. Path strings alone are insufficient proof of independence.
+Source and destination must resolve to different mounted-volume identities **and different physical storage-device identities**. Two partitions/volumes on one physical SD, USB drive, or disk are not independent backup locations. If the physical-device identity of either side cannot be established, import/reuse approval fails closed.
 
 ## Copy transaction
 
@@ -61,7 +61,8 @@ Reuse approval requires all of the following after copy processing:
 
 - the same selected source storage is still mounted;
 - the same selected destination storage is still mounted;
-- source and destination storage identities still match the identities captured for this operation;
+- source and destination volume identities, physical-device identities, and mount-session identities still match the identities captured for this operation;
+- source and destination remain on different physical storage devices;
 - the destination path remains free of user-controlled symlink/junction/reparse aliases;
 - a fresh complete scan of the whole safe camera-card scope succeeds;
 - all supported source media expected from the initial scan is still present;
@@ -74,9 +75,9 @@ If any condition cannot be proved, the UI must remain blocked/not-verified.
 
 ## Storage replacement
 
-Path strings alone are not storage identity. Unmount/remount, same-letter replacement on Windows, or same-mount-path replacement on macOS must invalidate a previous scan and approval.
+Path strings alone are not storage identity. Unmount/remount, same-letter replacement on Windows, same-mount-path replacement on macOS, or a physical-device mapping change must invalidate a previous scan and approval.
 
-Platform adapters are responsible for a mount-session storage identity that fails closed when unavailable.
+Platform adapters are responsible for mounted-volume, physical-device, and process-local mount-session identities that fail closed when required identity cannot be established.
 
 ## Multi-card behavior
 

--- a/docs/RELEASE_ACCEPTANCE.md
+++ b/docs/RELEASE_ACCEPTANCE.md
@@ -48,6 +48,8 @@ Use disposable/test media with independent ground-truth copies. Do not begin acc
 - [ ] A zero-byte supported JPG/RAW/video makes the scan incomplete/blocked.
 - [ ] Destination on the camera card, or a parent/child path overlapping the card, is rejected before copying.
 - [ ] Destination on another folder of the same physical volume is rejected.
+- [ ] On a disposable multi-partition test device, selecting a different partition/volume on the **same physical device** as the camera card is rejected before copying on both Windows and macOS.
+- [ ] A camera card whose physical-device identity cannot be established remains blocked rather than becoming import-ready; a destination whose physical-device identity cannot be established is likewise rejected before copying.
 - [ ] After import, every source file remains byte-identical and at the same source path; the app has not deleted, moved, renamed, modified, or overwritten any source media.
 - [ ] Existing destination file with the same name but different bytes is preserved; imported data receives `_2`, `_3`, etc.
 - [ ] Same-name identical bytes are treated as an already-backed-up duplicate and no unnecessary collision copy is created.
@@ -82,6 +84,7 @@ For every cycle:
 - [ ] Attempt tray/menu-bar Quit during an active import: shutdown is rejected and the workflow window is shown.
 - [ ] Mount a different card/device at the same path after a successful scan: the old scan session is rejected.
 - [ ] Unmount and remount the same card in the same app session: the previous mount-session approval is invalidated and a fresh scan is required.
+- [ ] Change the physical-device mapping associated with an otherwise unchanged mounted-volume identity: the previous session is invalidated.
 - [ ] Insert a second camera card while the first is being scanned/imported: active target does not switch and the second card is queued.
 - [ ] Remove a queued second card before it becomes active: it is removed from the queue and is not scanned from stale state.
 - [ ] Add a new supported file to the card between initial scan and final verification: final rescan includes it, and reuse cannot become safe unless that file also exists byte-identically in the destination.

--- a/src/PhotoOrganizer.App/PlatformStorageVolumeProvider.cs
+++ b/src/PhotoOrganizer.App/PlatformStorageVolumeProvider.cs
@@ -1,6 +1,9 @@
 using System.Diagnostics;
+using System.Globalization;
+using System.Management;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Xml.Linq;
 using PhotoOrganizer.Core;
 
 namespace PhotoOrganizer.App;
@@ -34,12 +37,18 @@ public sealed class PlatformStorageVolumeProvider : IStorageVolumeProvider
                 var fingerprint = TryGetFingerprint(root);
                 if (string.IsNullOrWhiteSpace(fingerprint)) continue;
 
+                var physicalDeviceFingerprint = TryGetPhysicalDeviceFingerprint(root);
                 var isSystem = !string.IsNullOrWhiteSpace(systemRoot)
                     && string.Equals(PathSafety.Normalize(systemRoot), root, PathComparison);
                 var isRemovable = drive.DriveType == DriveType.Removable
                     || (OperatingSystem.IsMacOS() && root.StartsWith("/Volumes/", StringComparison.Ordinal));
 
-                volumes.Add(new MountedVolumeInfo(root, fingerprint, isRemovable, isSystem));
+                volumes.Add(new MountedVolumeInfo(
+                    root,
+                    fingerprint,
+                    isRemovable,
+                    isSystem,
+                    physicalDeviceFingerprint));
             }
             catch
             {
@@ -86,6 +95,13 @@ public sealed class PlatformStorageVolumeProvider : IStorageVolumeProvider
         return null;
     }
 
+    private static string? TryGetPhysicalDeviceFingerprint(string root)
+    {
+        if (OperatingSystem.IsWindows()) return TryGetWindowsPhysicalDiskFingerprint(root);
+        if (OperatingSystem.IsMacOS()) return TryGetMacWholeDiskFingerprint(root);
+        return null;
+    }
+
     private static string? TryGetWindowsVolumeGuid(string root)
     {
         var mountPoint = root.EndsWith('\\') ? root : root + "\\";
@@ -93,6 +109,39 @@ public sealed class PlatformStorageVolumeProvider : IStorageVolumeProvider
         return GetVolumeNameForVolumeMountPoint(mountPoint, buffer, (uint)buffer.Capacity)
             ? "windows-volume:" + buffer.ToString()
             : null;
+    }
+
+    private static string? TryGetWindowsPhysicalDiskFingerprint(string root)
+    {
+        try
+        {
+            var logicalDeviceId = Path.GetPathRoot(root)?.TrimEnd('\\');
+            if (string.IsNullOrWhiteSpace(logicalDeviceId) || logicalDeviceId.Length != 2 || logicalDeviceId[1] != ':')
+            {
+                return null;
+            }
+
+            var query = $"ASSOCIATORS OF {{Win32_LogicalDisk.DeviceID='{logicalDeviceId}'}} WHERE AssocClass=Win32_LogicalDiskToPartition";
+            using var searcher = new ManagementObjectSearcher("root\\CIMV2", query);
+            using var results = searcher.Get();
+
+            foreach (ManagementObject partition in results)
+            {
+                using (partition)
+                {
+                    var diskIndex = partition["DiskIndex"];
+                    if (diskIndex is null) continue;
+                    var value = Convert.ToUInt32(diskIndex, CultureInfo.InvariantCulture);
+                    return $"windows-physical-disk:{value}";
+                }
+            }
+        }
+        catch
+        {
+            // Physical identity is a safety signal. Callers fail closed when unavailable.
+        }
+
+        return null;
     }
 
     private static string? TryGetMacDeviceFingerprint(string root)
@@ -124,6 +173,96 @@ public sealed class PlatformStorageVolumeProvider : IStorageVolumeProvider
         {
             return null;
         }
+    }
+
+    private static string? TryGetMacWholeDiskFingerprint(string root)
+    {
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "/usr/sbin/diskutil",
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+            process.StartInfo.ArgumentList.Add("info");
+            process.StartInfo.ArgumentList.Add("-plist");
+            process.StartInfo.ArgumentList.Add(root);
+
+            if (!process.Start()) return null;
+            var stdout = process.StandardOutput.ReadToEndAsync();
+            var stderr = process.StandardError.ReadToEndAsync();
+            if (!process.WaitForExit(5000))
+            {
+                try { process.Kill(entireProcessTree: true); } catch { }
+                return null;
+            }
+
+            var output = stdout.GetAwaiter().GetResult();
+            _ = stderr.GetAwaiter().GetResult();
+            if (process.ExitCode != 0 || string.IsNullOrWhiteSpace(output)) return null;
+
+            var document = XDocument.Parse(output, LoadOptions.None);
+            var dictionary = document.Root?.Elements().FirstOrDefault(element => element.Name.LocalName == "dict");
+            if (dictionary is null) return null;
+
+            var parentWholeDisk = GetPlistString(dictionary, "ParentWholeDisk");
+            if (!string.IsNullOrWhiteSpace(parentWholeDisk))
+            {
+                return "mac-whole-disk:" + parentWholeDisk;
+            }
+
+            if (GetPlistBoolean(dictionary, "WholeDisk") == true)
+            {
+                var deviceIdentifier = GetPlistString(dictionary, "DeviceIdentifier");
+                if (!string.IsNullOrWhiteSpace(deviceIdentifier))
+                {
+                    return "mac-whole-disk:" + deviceIdentifier;
+                }
+            }
+        }
+        catch
+        {
+            // Physical identity is a safety signal. Callers fail closed when unavailable.
+        }
+
+        return null;
+    }
+
+    private static string? GetPlistString(XElement dictionary, string key)
+    {
+        var elements = dictionary.Elements().ToArray();
+        for (var index = 0; index + 1 < elements.Length; index++)
+        {
+            if (elements[index].Name.LocalName != "key" || elements[index].Value != key) continue;
+            return elements[index + 1].Name.LocalName == "string"
+                ? elements[index + 1].Value
+                : null;
+        }
+
+        return null;
+    }
+
+    private static bool? GetPlistBoolean(XElement dictionary, string key)
+    {
+        var elements = dictionary.Elements().ToArray();
+        for (var index = 0; index + 1 < elements.Length; index++)
+        {
+            if (elements[index].Name.LocalName != "key" || elements[index].Value != key) continue;
+            return elements[index + 1].Name.LocalName switch
+            {
+                "true" => true,
+                "false" => false,
+                _ => null
+            };
+        }
+
+        return null;
     }
 
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]

--- a/src/PhotoOrganizer.App/PlatformStorageVolumeProvider.cs
+++ b/src/PhotoOrganizer.App/PlatformStorageVolumeProvider.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Management;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Text;
 using System.Xml.Linq;
 using PhotoOrganizer.Core;
@@ -111,6 +112,7 @@ public sealed class PlatformStorageVolumeProvider : IStorageVolumeProvider
             : null;
     }
 
+    [SupportedOSPlatform("windows")]
     private static string? TryGetWindowsPhysicalDiskFingerprint(string root)
     {
         try
@@ -124,6 +126,7 @@ public sealed class PlatformStorageVolumeProvider : IStorageVolumeProvider
             var query = $"ASSOCIATORS OF {{Win32_LogicalDisk.DeviceID='{logicalDeviceId}'}} WHERE AssocClass=Win32_LogicalDiskToPartition";
             using var searcher = new ManagementObjectSearcher("root\\CIMV2", query);
             using var results = searcher.Get();
+            var diskIndices = new SortedSet<uint>();
 
             foreach (ManagementObject partition in results)
             {
@@ -131,10 +134,14 @@ public sealed class PlatformStorageVolumeProvider : IStorageVolumeProvider
                 {
                     var diskIndex = partition["DiskIndex"];
                     if (diskIndex is null) continue;
-                    var value = Convert.ToUInt32(diskIndex, CultureInfo.InvariantCulture);
-                    return $"windows-physical-disk:{value}";
+                    diskIndices.Add(Convert.ToUInt32(diskIndex, CultureInfo.InvariantCulture));
                 }
             }
+
+            if (diskIndices.Count == 0) return null;
+            return string.Join(
+                '|',
+                diskIndices.Select(index => $"windows-physical-disk:{index}"));
         }
         catch
         {

--- a/src/PhotoOrganizer.App/PlatformStorageVolumeProvider.cs
+++ b/src/PhotoOrganizer.App/PlatformStorageVolumeProvider.cs
@@ -138,10 +138,11 @@ public sealed class PlatformStorageVolumeProvider : IStorageVolumeProvider
                 }
             }
 
-            if (diskIndices.Count == 0) return null;
-            return string.Join(
-                '|',
-                diskIndices.Select(index => $"windows-physical-disk:{index}"));
+            // A volume backed by multiple physical disks cannot be represented by
+            // one unambiguous physical-device identity. Fail closed rather than risk
+            // accepting a destination that overlaps the camera-card disk.
+            if (diskIndices.Count != 1) return null;
+            return $"windows-physical-disk:{diskIndices.Min}";
         }
         catch
         {

--- a/src/PhotoOrganizer.Core/ImportCoordinator.cs
+++ b/src/PhotoOrganizer.Core/ImportCoordinator.cs
@@ -92,6 +92,11 @@ public sealed class ImportCoordinator
             return BlockedScan("The camera-card mount-session identity is unavailable.");
         }
 
+        if (string.IsNullOrWhiteSpace(identity.PhysicalDeviceFingerprint))
+        {
+            return BlockedScan("The camera-card physical-device identity is unavailable.");
+        }
+
         var scan = _scanner.Scan(root);
         if (!_storageSessions.Matches(identity, root))
         {
@@ -134,6 +139,11 @@ public sealed class ImportCoordinator
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            if (string.IsNullOrWhiteSpace(session.SourceIdentity.PhysicalDeviceFingerprint))
+            {
+                return Blocked("The camera-card physical-device identity is unavailable. Scan it again before importing.", summary);
+            }
+
             if (!_storageSessions.Matches(session.SourceIdentity, session.CardRoot))
             {
                 return Blocked("The camera card changed after the successful scan. Scan it again.", summary);
@@ -162,10 +172,23 @@ public sealed class ImportCoordinator
                 return Blocked("Destination mount-session identity is unavailable.", summary);
             }
 
+            if (string.IsNullOrWhiteSpace(destinationIdentity.PhysicalDeviceFingerprint))
+            {
+                return Blocked("Destination physical-device identity is unavailable. Choose a destination whose physical storage can be verified.", summary);
+            }
+
             if (destinationIdentity.SessionId == session.SourceIdentity.SessionId
                 || string.Equals(destinationIdentity.Fingerprint, session.SourceIdentity.Fingerprint, StringComparison.Ordinal))
             {
                 return Blocked("Destination must be on a different volume from the camera card.", summary);
+            }
+
+            if (string.Equals(
+                    destinationIdentity.PhysicalDeviceFingerprint,
+                    session.SourceIdentity.PhysicalDeviceFingerprint,
+                    StringComparison.Ordinal))
+            {
+                return Blocked("Destination must be on a different physical storage device from the camera card.", summary);
             }
 
             var initialFiles = session.Files

--- a/src/PhotoOrganizer.Core/StorageIdentity.cs
+++ b/src/PhotoOrganizer.Core/StorageIdentity.cs
@@ -22,6 +22,24 @@ public interface IStorageVolumeProvider
     MountedVolumeInfo? ResolveVolumeForPath(string path);
 }
 
+public static class PhysicalDeviceIdentity
+{
+    private const char Separator = '|';
+
+    public static bool Overlaps(string? left, string? right)
+    {
+        if (string.IsNullOrWhiteSpace(left) || string.IsNullOrWhiteSpace(right)) return false;
+
+        var leftDevices = left
+            .Split(Separator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .ToHashSet(StringComparer.Ordinal);
+
+        return right
+            .Split(Separator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Any(leftDevices.Contains);
+    }
+}
+
 public static class PathSafety
 {
     public static string Normalize(string path)

--- a/src/PhotoOrganizer.Core/StorageIdentity.cs
+++ b/src/PhotoOrganizer.Core/StorageIdentity.cs
@@ -4,12 +4,14 @@ public sealed record MountedVolumeInfo(
     string RootPath,
     string Fingerprint,
     bool IsRemovable,
-    bool IsSystem);
+    bool IsSystem,
+    string? PhysicalDeviceFingerprint = null);
 
 public sealed record StorageSessionIdentity(
     string RootPath,
     string Fingerprint,
-    Guid SessionId);
+    Guid SessionId,
+    string? PhysicalDeviceFingerprint = null);
 
 public interface IStorageVolumeProvider
 {
@@ -158,12 +160,16 @@ public static class PathSafety
 
 /// <summary>
 /// Tracks a process-local identity for each currently mounted filesystem volume.
-/// A persistent OS volume identifier is only a fingerprint; it never authorizes reuse by itself.
-/// Once a mount disappears or its fingerprint changes, its session id is discarded permanently.
+/// A persistent OS volume identifier and physical-device identifier are fingerprints;
+/// neither authorizes reuse by itself. Once a mount disappears or either identity
+/// changes, its session id is discarded permanently.
 /// </summary>
 public sealed class StorageSessionTracker
 {
-    private sealed record SessionEntry(string Fingerprint, Guid SessionId);
+    private sealed record SessionEntry(
+        string Fingerprint,
+        string? PhysicalDeviceFingerprint,
+        Guid SessionId);
 
     private readonly IStorageVolumeProvider _provider;
     private readonly object _gate = new();
@@ -203,7 +209,11 @@ public sealed class StorageSessionTracker
             foreach (var existing in _sessions.Keys.ToList())
             {
                 if (!mounted.TryGetValue(existing, out var current)
-                    || !string.Equals(_sessions[existing].Fingerprint, current.Fingerprint, StringComparison.Ordinal))
+                    || !string.Equals(_sessions[existing].Fingerprint, current.Fingerprint, StringComparison.Ordinal)
+                    || !string.Equals(
+                        _sessions[existing].PhysicalDeviceFingerprint,
+                        current.PhysicalDeviceFingerprint,
+                        StringComparison.Ordinal))
                 {
                     _sessions.Remove(existing);
                     removed.Add(existing);
@@ -213,7 +223,10 @@ public sealed class StorageSessionTracker
             foreach (var volume in mounted.Values)
             {
                 if (_sessions.ContainsKey(volume.RootPath)) continue;
-                _sessions[volume.RootPath] = new SessionEntry(volume.Fingerprint, Guid.NewGuid());
+                _sessions[volume.RootPath] = new SessionEntry(
+                    volume.Fingerprint,
+                    volume.PhysicalDeviceFingerprint,
+                    Guid.NewGuid());
                 added.Add(volume.RootPath);
             }
         }
@@ -248,7 +261,16 @@ public sealed class StorageSessionTracker
         {
             if (!_sessions.TryGetValue(root, out var entry)) return null;
             if (!string.Equals(entry.Fingerprint, volume.Fingerprint, StringComparison.Ordinal)) return null;
-            return new StorageSessionIdentity(root, entry.Fingerprint, entry.SessionId);
+            if (!string.Equals(
+                    entry.PhysicalDeviceFingerprint,
+                    volume.PhysicalDeviceFingerprint,
+                    StringComparison.Ordinal)) return null;
+
+            return new StorageSessionIdentity(
+                root,
+                entry.Fingerprint,
+                entry.SessionId,
+                entry.PhysicalDeviceFingerprint);
         }
     }
 
@@ -258,6 +280,10 @@ public sealed class StorageSessionTracker
         return current is not null
             && current.SessionId == identity.SessionId
             && string.Equals(current.Fingerprint, identity.Fingerprint, StringComparison.Ordinal)
+            && string.Equals(
+                current.PhysicalDeviceFingerprint,
+                identity.PhysicalDeviceFingerprint,
+                StringComparison.Ordinal)
             && string.Equals(current.RootPath, identity.RootPath, _provider.PathComparison);
     }
 }

--- a/src/PhotoOrganizer.Core/StorageIdentity.cs
+++ b/src/PhotoOrganizer.Core/StorageIdentity.cs
@@ -22,24 +22,6 @@ public interface IStorageVolumeProvider
     MountedVolumeInfo? ResolveVolumeForPath(string path);
 }
 
-public static class PhysicalDeviceIdentity
-{
-    private const char Separator = '|';
-
-    public static bool Overlaps(string? left, string? right)
-    {
-        if (string.IsNullOrWhiteSpace(left) || string.IsNullOrWhiteSpace(right)) return false;
-
-        var leftDevices = left
-            .Split(Separator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .ToHashSet(StringComparer.Ordinal);
-
-        return right
-            .Split(Separator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Any(leftDevices.Contains);
-    }
-}
-
 public static class PathSafety
 {
     public static string Normalize(string path)

--- a/tests/PhotoOrganizer.App.Tests/PhotoOrganizer.App.Tests.csproj
+++ b/tests/PhotoOrganizer.App.Tests/PhotoOrganizer.App.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <IsTestProject>true</IsTestProject>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.3.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/PhotoOrganizer.App/PhotoOrganizer.App.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/PhotoOrganizer.App.Tests/PlatformStorageIdentityTests.cs
+++ b/tests/PhotoOrganizer.App.Tests/PlatformStorageIdentityTests.cs
@@ -1,0 +1,24 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PhotoOrganizer.App.Tests;
+
+[TestClass]
+public sealed class PlatformStorageIdentityTests
+{
+    [TestMethod]
+    public void SystemVolume_ResolvesVolumeAndPhysicalDeviceIdentity()
+    {
+        var provider = new PlatformStorageVolumeProvider();
+        var path = OperatingSystem.IsWindows()
+            ? Path.GetPathRoot(Environment.SystemDirectory)!
+            : "/";
+
+        var volume = provider.ResolveVolumeForPath(path);
+
+        Assert.IsNotNull(volume, $"Unable to resolve mounted volume for {path}.");
+        Assert.IsFalse(string.IsNullOrWhiteSpace(volume.Fingerprint), "Mounted-volume identity is missing.");
+        Assert.IsFalse(
+            string.IsNullOrWhiteSpace(volume.PhysicalDeviceFingerprint),
+            $"Physical-device identity is missing for {path} on {Environment.OSVersion}.");
+    }
+}

--- a/tests/PhotoOrganizer.Core.Tests/ImportCoordinatorTests.cs
+++ b/tests/PhotoOrganizer.Core.Tests/ImportCoordinatorTests.cs
@@ -81,6 +81,56 @@ public sealed class ImportCoordinatorTests
     }
 
     [TestMethod]
+    public async Task DifferentVolumeOnSamePhysicalDevice_IsRejectedBeforeCopy()
+    {
+        using var env = TestEnvironment.Create();
+        env.AddCameraFile("DCIM/photo.jpg", "camera-data", new DateTime(2026, 4, 6));
+        env.Provider.SetPhysicalDeviceFingerprint(env.DestinationRoot, "physical-camera-card");
+        env.Tracker.Refresh();
+        var coordinator = env.CreateCoordinator();
+        var scan = coordinator.ScanCard(env.CardRoot);
+
+        Assert.IsTrue(scan.IsReady);
+        var result = await coordinator.ImportAsync(scan.Session!, env.DestinationRoot, "Event");
+
+        Assert.AreEqual(ImportSafetyStatus.Blocked, result.Status);
+        StringAssert.Contains(result.Message, "physical storage device");
+        Assert.IsFalse(Directory.Exists(Path.Combine(env.DestinationRoot, "2026")));
+    }
+
+    [TestMethod]
+    public void MissingCameraPhysicalDeviceIdentity_BlocksScan()
+    {
+        using var env = TestEnvironment.Create();
+        env.AddCameraFile("DCIM/photo.jpg", "camera-data", new DateTime(2026, 4, 7));
+        env.Provider.SetPhysicalDeviceFingerprint(env.CardRoot, null);
+        env.Tracker.Refresh();
+
+        var scan = env.CreateCoordinator().ScanCard(env.CardRoot);
+
+        Assert.AreEqual(ImportSafetyStatus.Blocked, scan.Status);
+        Assert.IsFalse(scan.IsReady);
+        StringAssert.Contains(scan.Message, "physical-device identity");
+    }
+
+    [TestMethod]
+    public async Task MissingDestinationPhysicalDeviceIdentity_BlocksBeforeCopy()
+    {
+        using var env = TestEnvironment.Create();
+        env.AddCameraFile("DCIM/photo.jpg", "camera-data", new DateTime(2026, 4, 8));
+        var coordinator = env.CreateCoordinator();
+        var scan = coordinator.ScanCard(env.CardRoot);
+        env.Provider.SetPhysicalDeviceFingerprint(env.DestinationRoot, null);
+        env.Tracker.Refresh();
+
+        var result = await coordinator.ImportAsync(scan.Session!, env.DestinationRoot, "Event");
+
+        Assert.AreEqual(ImportSafetyStatus.Blocked, result.Status);
+        StringAssert.Contains(result.Message, "Destination physical-device identity is unavailable");
+        Assert.IsFalse(Directory.Exists(Path.Combine(env.DestinationRoot, "2026")));
+    }
+
+    [TestMethod]
     public async Task RemovalAndReinsertAfterScan_InvalidatesSession()
     {
         using var env = TestEnvironment.Create();
@@ -238,8 +288,8 @@ public sealed class ImportCoordinatorTests
             Directory.CreateDirectory(Path.Combine(card, "DCIM"));
             Directory.CreateDirectory(destination);
             var provider = new FakeVolumeProvider([
-                new MutableVolume(card, "camera-card", true, false, true),
-                new MutableVolume(destination, "destination-volume", false, false, true)
+                new MutableVolume(card, "camera-card", true, false, true, "physical-camera-card"),
+                new MutableVolume(destination, "destination-volume", false, false, true, "physical-destination")
             ]);
             return new TestEnvironment(root, card, destination, provider);
         }
@@ -274,7 +324,8 @@ public sealed class ImportCoordinatorTests
         string Fingerprint,
         bool IsRemovable,
         bool IsSystem,
-        bool Mounted);
+        bool Mounted,
+        string? PhysicalDeviceFingerprint);
 
     private sealed class FakeVolumeProvider : IStorageVolumeProvider
     {
@@ -293,7 +344,12 @@ public sealed class ImportCoordinatorTests
 
         public IReadOnlyList<MountedVolumeInfo> GetMountedVolumes() => _volumes
             .Where(v => v.Mounted)
-            .Select(v => new MountedVolumeInfo(v.RootPath, v.Fingerprint, v.IsRemovable, v.IsSystem))
+            .Select(v => new MountedVolumeInfo(
+                v.RootPath,
+                v.Fingerprint,
+                v.IsRemovable,
+                v.IsSystem,
+                v.PhysicalDeviceFingerprint))
             .ToArray();
 
         public MountedVolumeInfo? ResolveVolumeForPath(string path)
@@ -314,7 +370,12 @@ public sealed class ImportCoordinatorTests
 
             return volume is null
                 ? null
-                : new MountedVolumeInfo(volume.RootPath, volume.Fingerprint, volume.IsRemovable, volume.IsSystem);
+                : new MountedVolumeInfo(
+                    volume.RootPath,
+                    volume.Fingerprint,
+                    volume.IsRemovable,
+                    volume.IsSystem,
+                    volume.PhysicalDeviceFingerprint);
         }
 
         public void SetMounted(string root, bool mounted)
@@ -329,6 +390,13 @@ public sealed class ImportCoordinatorTests
             var normalized = PathSafety.Normalize(root);
             var index = _volumes.FindIndex(v => string.Equals(v.RootPath, normalized, PathComparison));
             if (index >= 0) _volumes[index] = _volumes[index] with { Fingerprint = fingerprint };
+        }
+
+        public void SetPhysicalDeviceFingerprint(string root, string? fingerprint)
+        {
+            var normalized = PathSafety.Normalize(root);
+            var index = _volumes.FindIndex(v => string.Equals(v.RootPath, normalized, PathComparison));
+            if (index >= 0) _volumes[index] = _volumes[index] with { PhysicalDeviceFingerprint = fingerprint };
         }
     }
 }

--- a/tests/PhotoOrganizer.Core.Tests/StorageIdentityTests.cs
+++ b/tests/PhotoOrganizer.Core.Tests/StorageIdentityTests.cs
@@ -17,6 +17,7 @@ public sealed class StorageIdentityTests
 
         Assert.IsNotNull(snapshot);
         Assert.IsTrue(tracker.Matches(snapshot, temp.Path));
+        Assert.AreEqual("physical-a", snapshot.PhysicalDeviceFingerprint);
     }
 
     [TestMethod]
@@ -50,6 +51,24 @@ public sealed class StorageIdentityTests
         tracker.Refresh();
 
         Assert.IsFalse(tracker.Matches(snapshot, temp.Path));
+    }
+
+    [TestMethod]
+    public void SameVolumeFingerprintDifferentPhysicalDevice_InvalidatesOldSession()
+    {
+        using var temp = new TempDirectory();
+        var provider = new FakeProvider(temp.Path, "volume-a", physicalDeviceFingerprint: "physical-a");
+        var tracker = new StorageSessionTracker(provider);
+        var snapshot = tracker.Capture(temp.Path)!;
+
+        provider.PhysicalDeviceFingerprint = "physical-b";
+        tracker.Refresh();
+
+        Assert.IsFalse(tracker.Matches(snapshot, temp.Path));
+        var replacement = tracker.Capture(temp.Path);
+        Assert.IsNotNull(replacement);
+        Assert.AreNotEqual(snapshot.SessionId, replacement.SessionId);
+        Assert.AreEqual("physical-b", replacement.PhysicalDeviceFingerprint);
     }
 
     [TestMethod]
@@ -115,16 +134,23 @@ public sealed class StorageIdentityTests
         private readonly bool _isRemovable;
         private readonly bool _isSystem;
 
-        public FakeProvider(string root, string fingerprint, bool isRemovable = false, bool isSystem = false)
+        public FakeProvider(
+            string root,
+            string fingerprint,
+            bool isRemovable = false,
+            bool isSystem = false,
+            string? physicalDeviceFingerprint = "physical-a")
         {
             _root = PathSafety.Normalize(root);
             Fingerprint = fingerprint;
+            PhysicalDeviceFingerprint = physicalDeviceFingerprint;
             _isRemovable = isRemovable;
             _isSystem = isSystem;
         }
 
         public bool Mounted { get; set; } = true;
         public string Fingerprint { get; set; }
+        public string? PhysicalDeviceFingerprint { get; set; }
         public StringComparison PathComparison => OperatingSystem.IsWindows()
             ? StringComparison.OrdinalIgnoreCase
             : StringComparison.Ordinal;
@@ -132,14 +158,24 @@ public sealed class StorageIdentityTests
         public IReadOnlyList<MountedVolumeInfo> GetMountedVolumes()
         {
             if (!Mounted) return [];
-            return [new MountedVolumeInfo(_root, Fingerprint, _isRemovable, _isSystem)];
+            return [new MountedVolumeInfo(
+                _root,
+                Fingerprint,
+                _isRemovable,
+                _isSystem,
+                PhysicalDeviceFingerprint)];
         }
 
         public MountedVolumeInfo? ResolveVolumeForPath(string path)
         {
             if (!Mounted || string.IsNullOrWhiteSpace(Fingerprint)) return null;
             if (!PathSafety.IsSameOrDescendant(path, _root, PathComparison)) return null;
-            return new MountedVolumeInfo(_root, Fingerprint, _isRemovable, _isSystem);
+            return new MountedVolumeInfo(
+                _root,
+                Fingerprint,
+                _isRemovable,
+                _isSystem,
+                PhysicalDeviceFingerprint);
         }
     }
 


### PR DESCRIPTION
Closes #33

Fixes a P0 independence gap: two different partitions/volumes on the same physical SD/storage device must never be treated as source + independent backup.

Changes:
- mounted-volume and mount-session identities now carry a physical-device fingerprint;
- session identity is invalidated if either volume identity or physical-device identity changes;
- camera-card scan fails closed when the source physical device cannot be identified;
- destination selection fails closed when its physical device cannot be identified;
- import is rejected before any copy when source and destination are different volumes on the same physical device;
- Windows derives containing physical disk from `Win32_LogicalDiskToPartition` / `Win32_DiskPartition.DiskIndex`;
- macOS derives the whole-disk identity from `diskutil info -plist`;
- shared regression tests cover same-physical/different-volume rejection, unavailable identities, and physical-device replacement;
- normative safety and real-device acceptance docs now require physical device independence.

Existing source immutability, path-alias rejection, mount-session checks, complete rescans, collision safety and fresh SHA-256 final verification remain intact.