### PR TITLE
Protect production signing behind a main-only environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,8 @@ jobs:
       - name: Validate release helper syntax
         shell: bash
         run: |
+          set -euo pipefail
+          bash -n Scripts/configure_repository.sh
           bash -n Scripts/configure_release_secrets.sh
           bash -n Scripts/build_macos_icon.sh
           bash -n Scripts/smoke_package_macos.sh
@@ -127,13 +129,39 @@ jobs:
           promotion=.github/workflows/promote-release.yml
           project=src/PhotoOrganizer.App/PhotoOrganizer.App.csproj
           window=src/PhotoOrganizer.App/MainWindow.axaml
+          repo_helper=Scripts/configure_repository.sh
+          secret_helper=Scripts/configure_release_secrets.sh
+
           for secret in \
             WINDOWS_CERTIFICATE WINDOWS_CERTIFICATE_PASSWORD \
             MACOS_CERTIFICATE MACOS_CERTIFICATE_PASSWORD DEVELOPER_ID_APPLICATION \
             APPLE_ID APPLE_TEAM_ID APPLE_APP_SPECIFIC_PASSWORD; do
             grep -q "$secret" "$workflow"
           done
-          grep -q 'needs: \[preflight, windows, macos\]' "$workflow"
+
+          # Signing is a protected, manually dispatched main-only capability.
+          grep -q '^  workflow_dispatch:' "$workflow"
+          if grep -q '^  push:' "$workflow"; then
+            echo 'release.yml must not auto-trigger from tags or release branches.'
+            exit 1
+          fi
+          grep -q 'refs/heads/main' "$workflow"
+          [[ "$(grep -c 'name: production-signing' "$workflow")" -ge 4 ]]
+          grep -q 'deployment: false' "$workflow"
+          grep -q 'needs: \[preflight, signing-preflight, windows, macos\]' "$workflow"
+          grep -q 'Tag already exists' "$workflow"
+          grep -q 'contents: read' "$workflow"
+          grep -q 'contents: write' "$workflow"
+
+          # Helpers must build the server-side environment boundary and place secrets
+          # there rather than leaving repository-wide signing credentials behind.
+          grep -q 'environments/${SIGNING_ENVIRONMENT}' "$repo_helper"
+          grep -q 'deployment-branch-policies' "$repo_helper"
+          grep -q "name='main'" "$repo_helper"
+          grep -q 'actions/permissions/workflow' "$repo_helper"
+          grep -q -- '--env "$environment"' "$secret_helper"
+          grep -q 'Removed legacy repository secret' "$secret_helper"
+
           grep -q 'signtool' "$workflow"
           grep -q 'notarytool submit' "$workflow"
           grep -q 'stapler validate' "$workflow"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,9 +153,11 @@ jobs:
           grep -q 'contents: read' "$workflow"
           grep -q 'contents: write' "$workflow"
 
-          # Helpers must build the server-side environment boundary and place secrets
-          # there rather than leaving repository-wide signing credentials behind.
-          grep -q 'environments/${SIGNING_ENVIRONMENT}' "$repo_helper"
+          # Helpers must build server-side main-only environment boundaries and place
+          # signing secrets there instead of leaving repository-wide credentials.
+          grep -q 'SIGNING_ENVIRONMENT="production-signing"' "$repo_helper"
+          grep -q 'RELEASE_ENVIRONMENT="production-release"' "$repo_helper"
+          grep -q 'configure_main_only_environment' "$repo_helper"
           grep -q 'deployment-branch-policies' "$repo_helper"
           grep -q "name='main'" "$repo_helper"
           grep -q 'actions/permissions/workflow' "$repo_helper"
@@ -192,7 +194,19 @@ jobs:
             exit 1
           fi
 
-          # Stable promotion requires an explicit real-device acceptance record.
+          # Stable promotion is also main-only and server-gated. A modified promotion
+          # workflow on another ref must not have authority to mutate a release.
+          grep -q '^  workflow_dispatch:' "$promotion"
+          if grep -q '^  push:' "$promotion"; then
+            echo 'promote-release.yml must remain manually dispatched only.'
+            exit 1
+          fi
+          grep -q 'refs/heads/main' "$promotion"
+          grep -q 'name: production-release' "$promotion"
+          grep -q 'deployment: false' "$promotion"
+          grep -q 'needs: ref-preflight' "$promotion"
+          grep -q 'contents: read' "$promotion"
+          grep -q 'contents: write' "$promotion"
           grep -q 'acceptance_confirmed' "$promotion"
           grep -q 'candidate_commit' "$promotion"
           grep -q 'ACCEPTANCE_EVIDENCE' "$promotion"

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -22,16 +22,35 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: promote-release-${{ inputs.version }}
   cancel-in-progress: false
 
 jobs:
+  ref-preflight:
+    name: Stable promotion ref preflight
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require manual promotion from main
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "::error::Stable promotion must be dispatched from main. Current ref: $GITHUB_REF"
+            exit 1
+          fi
+
   promote:
     name: Promote verified acceptance candidate
+    needs: ref-preflight
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    environment:
+      name: production-release
+      deployment: false
     env:
       RELEASE_TAG: ${{ inputs.version }}
       EXPECTED_COMMIT: ${{ inputs.candidate_commit }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,6 @@
 name: Release
 
 on:
-  push:
-    tags:
-      - 'v*'
-    branches:
-      - 'release/v*'
   workflow_dispatch:
     inputs:
       version:
@@ -15,10 +10,10 @@ on:
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ github.repository }}-${{ inputs.version }}
   cancel-in-progress: false
 
 env:
@@ -26,11 +21,46 @@ env:
 
 jobs:
   preflight:
-    name: Signing preflight
+    name: Release ref preflight
     runs-on: ubuntu-latest
     outputs:
       release_tag: ${{ steps.version.outputs.release_tag }}
       version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Require manual release from main
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "::error::Production release must be dispatched from main. Current ref: $GITHUB_REF"
+            exit 1
+          fi
+
+      - name: Resolve release version
+        id: version
+        shell: bash
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          RELEASE_TAG="${DISPATCH_VERSION:-}"
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag must match vMAJOR.MINOR.PATCH: $RELEASE_TAG"
+            exit 1
+          fi
+
+          VERSION="${RELEASE_TAG#v}"
+          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Release $RELEASE_TAG from exact main commit $GITHUB_SHA"
+
+  signing-preflight:
+    name: Protected signing credential preflight
+    needs: preflight
+    runs-on: ubuntu-latest
+    environment:
+      name: production-signing
+      deployment: false
     env:
       WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
       WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
@@ -41,32 +71,7 @@ jobs:
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
       APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
     steps:
-      - name: Resolve release version
-        id: version
-        shell: bash
-        env:
-          DISPATCH_VERSION: ${{ inputs.version }}
-        run: |
-          set -euo pipefail
-          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
-            RELEASE_TAG="$GITHUB_REF_NAME"
-          elif [[ "$GITHUB_REF_NAME" == release/v* ]]; then
-            RELEASE_TAG="${GITHUB_REF_NAME#release/}"
-          else
-            RELEASE_TAG="${DISPATCH_VERSION:-}"
-          fi
-
-          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::error::Release tag must match vMAJOR.MINOR.PATCH: $RELEASE_TAG"
-            exit 1
-          fi
-
-          VERSION="${RELEASE_TAG#v}"
-          echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "Release $RELEASE_TAG from exact commit $GITHUB_SHA"
-
-      - name: Require every production signing secret
+      - name: Require every production environment secret
         shell: bash
         run: |
           set -euo pipefail
@@ -76,20 +81,23 @@ jobs:
             MACOS_CERTIFICATE MACOS_CERTIFICATE_PASSWORD DEVELOPER_ID_APPLICATION \
             APPLE_ID APPLE_TEAM_ID APPLE_APP_SPECIFIC_PASSWORD; do
             if [[ -z "${!name:-}" ]]; then
-              echo "::error::Missing required repository secret: $name"
+              echo "::error::Missing required production-signing environment secret: $name"
               missing=1
             fi
           done
           if [[ "$missing" -ne 0 ]]; then
-            echo "::error::Production release aborted before any release artifact was built or published."
+            echo "::error::Production release aborted before any signed artifact was built or published."
             exit 1
           fi
 
   windows:
     name: Signed Windows packages
-    needs: preflight
+    needs: [preflight, signing-preflight]
     runs-on: windows-latest
     timeout-minutes: 45
+    environment:
+      name: production-signing
+      deployment: false
     env:
       VERSION: ${{ needs.preflight.outputs.version }}
       WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
@@ -109,6 +117,13 @@ jobs:
           $ErrorActionPreference = 'Stop'
           dotnet restore tests/PhotoOrganizer.Core.Tests/PhotoOrganizer.Core.Tests.csproj
           dotnet test tests/PhotoOrganizer.Core.Tests/PhotoOrganizer.Core.Tests.csproj --configuration Release --no-restore
+
+      - name: Require Windows environment secrets
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if ([string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE)) { throw 'Missing WINDOWS_CERTIFICATE environment secret.' }
+          if ([string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_PASSWORD)) { throw 'Missing WINDOWS_CERTIFICATE_PASSWORD environment secret.' }
 
       - name: Decode Windows signing certificate
         shell: pwsh
@@ -189,9 +204,12 @@ jobs:
 
   macos:
     name: Signed and notarized macOS packages
-    needs: preflight
+    needs: [preflight, signing-preflight]
     runs-on: macos-15
     timeout-minutes: 120
+    environment:
+      name: production-signing
+      deployment: false
     env:
       VERSION: ${{ needs.preflight.outputs.version }}
       MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
@@ -216,6 +234,14 @@ jobs:
           dotnet restore tests/PhotoOrganizer.Core.Tests/PhotoOrganizer.Core.Tests.csproj
           dotnet test tests/PhotoOrganizer.Core.Tests/PhotoOrganizer.Core.Tests.csproj --configuration Release --no-restore
           plutil -lint packaging/macos/PhotoOrganizer.entitlements
+
+      - name: Require macOS environment secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          for name in MACOS_CERTIFICATE MACOS_CERTIFICATE_PASSWORD DEVELOPER_ID_APPLICATION APPLE_ID APPLE_TEAM_ID APPLE_APP_SPECIFIC_PASSWORD; do
+            [[ -n "${!name:-}" ]] || { echo "::error::Missing $name environment secret."; exit 1; }
+          done
 
       - name: Import Developer ID Application certificate
         shell: bash
@@ -410,8 +436,13 @@ jobs:
 
   publish:
     name: Publish complete cross-platform acceptance candidate
-    needs: [preflight, windows, macos]
+    needs: [preflight, signing-preflight, windows, macos]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    environment:
+      name: production-signing
+      deployment: false
     env:
       RELEASE_TAG: ${{ needs.preflight.outputs.release_tag }}
       VERSION: ${{ needs.preflight.outputs.version }}
@@ -445,8 +476,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+          if gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             echo "::error::Release already exists: $RELEASE_TAG"
+            exit 1
+          fi
+          if gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "::error::Tag already exists. Refusing to reuse a pre-existing release tag: $RELEASE_TAG"
             exit 1
           fi
           gh release create "$RELEASE_TAG" release-assets/* \

--- a/Scripts/configure_release_secrets.sh
+++ b/Scripts/configure_release_secrets.sh
@@ -2,9 +2,24 @@
 set -euo pipefail
 
 repo="${1:-PeachGumi/PhotoOrganizer}"
+environment="${2:-production-signing}"
 
 command -v gh >/dev/null 2>&1 || { echo "GitHub CLI (gh) is required." >&2; exit 1; }
 gh auth status >/dev/null
+
+# Refuse to place production credentials into an environment until its server-side
+# deployment policy has been verified. Run configure_repository.sh first.
+gh api "repos/${repo}/environments/${environment}" >/dev/null 2>&1 || {
+  echo "Protected environment '${environment}' does not exist. Run Scripts/configure_repository.sh first." >&2
+  exit 1
+}
+[[ "$(gh api "repos/${repo}/environments/${environment}" --jq '.deployment_branch_policy.protected_branches')" == "false" ]]
+[[ "$(gh api "repos/${repo}/environments/${environment}" --jq '.deployment_branch_policy.custom_branch_policies')" == "true" ]]
+[[ "$(gh api "repos/${repo}/environments/${environment}/deployment-branch-policies?per_page=100" --jq '.total_count')" == "1" ]]
+[[ "$(gh api "repos/${repo}/environments/${environment}/deployment-branch-policies?per_page=100" --jq '[.branch_policies[] | select(.name == "main" and ((.type // "branch") == "branch"))] | length')" == "1" ]] || {
+  echo "Environment '${environment}' is not restricted to the main branch. Refusing to configure signing credentials." >&2
+  exit 1
+}
 
 read -r -p "Windows code-signing PFX path: " windows_pfx
 read -r -s -p "Windows PFX password: " windows_password
@@ -27,8 +42,8 @@ echo
 
 set_secret() {
   local name="$1"
-  gh secret set "$name" --repo "$repo"
-  echo "Configured $name"
+  gh secret set "$name" --repo "$repo" --env "$environment"
+  echo "Configured environment secret $name"
 }
 
 base64 < "$windows_pfx" | tr -d '\n' | set_secret WINDOWS_CERTIFICATE
@@ -42,4 +57,26 @@ printf '%s' "$apple_app_password" | set_secret APPLE_APP_SPECIFIC_PASSWORD
 
 unset windows_password mac_password apple_app_password
 
-echo "Release secrets configured for $repo. Values were sent to GitHub through stdin and were not printed by this script."
+required=(
+  WINDOWS_CERTIFICATE WINDOWS_CERTIFICATE_PASSWORD
+  MACOS_CERTIFICATE MACOS_CERTIFICATE_PASSWORD DEVELOPER_ID_APPLICATION
+  APPLE_ID APPLE_TEAM_ID APPLE_APP_SPECIFIC_PASSWORD
+)
+for name in "${required[@]}"; do
+  gh secret list --repo "$repo" --env "$environment" | awk '{print $1}' | grep -Fxq "$name" || {
+    echo "Environment secret verification failed: $name" >&2
+    exit 1
+  }
+done
+
+# Remove legacy repository-level copies only after all protected environment secrets
+# have been confirmed. This closes the old repository-wide credential path.
+repo_secret_names="$(gh secret list --repo "$repo" | awk '{print $1}')"
+for name in "${required[@]}"; do
+  if grep -Fxq "$name" <<< "$repo_secret_names"; then
+    gh secret delete "$name" --repo "$repo"
+    echo "Removed legacy repository secret $name"
+  fi
+done
+
+echo "Release secrets configured and verified in ${environment} for ${repo}. Values were sent through stdin and were not printed by this script."

--- a/Scripts/configure_repository.sh
+++ b/Scripts/configure_repository.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-REPO="PeachGumi/PhotoOrganizer"
+REPO="${1:-PeachGumi/PhotoOrganizer}"
+SIGNING_ENVIRONMENT="production-signing"
 
+command -v gh >/dev/null 2>&1 || { echo "GitHub CLI (gh) is required." >&2; exit 1; }
 gh auth status >/dev/null
 
 echo "Configuring repository settings for ${REPO}..."
@@ -25,12 +27,21 @@ gh api --method PUT "repos/${REPO}/topics" --input - >/dev/null <<'JSON'
 }
 JSON
 
+# Keep the default GITHUB_TOKEN read-only. Workflows that genuinely publish must
+# request their narrow write permission explicitly.
+gh api --method PUT "repos/${REPO}/actions/permissions/workflow" --input - >/dev/null <<'JSON'
+{
+  "default_workflow_permissions": "read",
+  "can_approve_pull_request_reviews": false
+}
+JSON
+
 # Public repositories can use Dependabot/vulnerability alerts. These calls may be
 # policy-dependent, so a failure is reported but does not hide the successful core settings.
 gh api --method PUT "repos/${REPO}/vulnerability-alerts" >/dev/null || echo "warning: could not enable vulnerability alerts"
 gh api --method PUT "repos/${REPO}/automated-security-fixes" >/dev/null || echo "warning: could not enable automated security fixes"
 
-cat <<'JSON' | gh api --method PUT "repos/PeachGumi/PhotoOrganizer/branches/main/protection" --input - >/dev/null
+cat <<'JSON' | gh api --method PUT "repos/${REPO}/branches/main/protection" --input - >/dev/null
 {
   "required_status_checks": {
     "strict": true,
@@ -51,4 +62,44 @@ cat <<'JSON' | gh api --method PUT "repos/PeachGumi/PhotoOrganizer/branches/main
 }
 JSON
 
-echo "Repository settings and main branch protection configured."
+# Production signing credentials live in an Environment whose server-side branch
+# policy permits only main. Reset the custom policies to exactly one main-branch rule.
+cat <<'JSON' | gh api --method PUT "repos/${REPO}/environments/${SIGNING_ENVIRONMENT}" --input - >/dev/null
+{
+  "deployment_branch_policy": {
+    "protected_branches": false,
+    "custom_branch_policies": true
+  }
+}
+JSON
+
+while IFS= read -r policy_id; do
+  [[ -n "$policy_id" ]] || continue
+  gh api --method DELETE \
+    "repos/${REPO}/environments/${SIGNING_ENVIRONMENT}/deployment-branch-policies/${policy_id}" >/dev/null
+done < <(gh api "repos/${REPO}/environments/${SIGNING_ENVIRONMENT}/deployment-branch-policies?per_page=100" \
+  --jq '.branch_policies[].id')
+
+gh api --method POST \
+  "repos/${REPO}/environments/${SIGNING_ENVIRONMENT}/deployment-branch-policies" \
+  -f name='main' -f type='branch' >/dev/null
+
+# Post-configuration verification is intentionally fatal. Do not print a success
+# message when GitHub rejected or partially applied a hardening setting.
+[[ "$(gh api "repos/${REPO}" --jq '.allow_squash_merge')" == "true" ]]
+[[ "$(gh api "repos/${REPO}" --jq '.allow_merge_commit')" == "false" ]]
+[[ "$(gh api "repos/${REPO}" --jq '.allow_rebase_merge')" == "false" ]]
+[[ "$(gh api "repos/${REPO}" --jq '.allow_auto_merge')" == "true" ]]
+[[ "$(gh api "repos/${REPO}" --jq '.allow_update_branch')" == "true" ]]
+
+[[ "$(gh api "repos/${REPO}/actions/permissions/workflow" --jq '.default_workflow_permissions')" == "read" ]]
+[[ "$(gh api "repos/${REPO}/branches/main/protection" --jq '.enforce_admins.enabled')" == "true" ]]
+[[ "$(gh api "repos/${REPO}/branches/main/protection" --jq '.required_status_checks.strict')" == "true" ]]
+[[ "$(gh api "repos/${REPO}/branches/main/protection" --jq '[.required_status_checks.contexts[] | select(. == "required")] | length')" == "1" ]]
+
+[[ "$(gh api "repos/${REPO}/environments/${SIGNING_ENVIRONMENT}" --jq '.deployment_branch_policy.protected_branches')" == "false" ]]
+[[ "$(gh api "repos/${REPO}/environments/${SIGNING_ENVIRONMENT}" --jq '.deployment_branch_policy.custom_branch_policies')" == "true" ]]
+[[ "$(gh api "repos/${REPO}/environments/${SIGNING_ENVIRONMENT}/deployment-branch-policies?per_page=100" --jq '.total_count')" == "1" ]]
+[[ "$(gh api "repos/${REPO}/environments/${SIGNING_ENVIRONMENT}/deployment-branch-policies?per_page=100" --jq '[.branch_policies[] | select(.name == "main" and ((.type // "branch") == "branch"))] | length')" == "1" ]]
+
+echo "Repository settings, main protection, and ${SIGNING_ENVIRONMENT} main-only policy verified."

--- a/Scripts/configure_repository.sh
+++ b/Scripts/configure_repository.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 REPO="${1:-PeachGumi/PhotoOrganizer}"
 SIGNING_ENVIRONMENT="production-signing"
+RELEASE_ENVIRONMENT="production-release"
 
 command -v gh >/dev/null 2>&1 || { echo "GitHub CLI (gh) is required." >&2; exit 1; }
 gh auth status >/dev/null
@@ -62,9 +63,10 @@ cat <<'JSON' | gh api --method PUT "repos/${REPO}/branches/main/protection" --in
 }
 JSON
 
-# Production signing credentials live in an Environment whose server-side branch
-# policy permits only main. Reset the custom policies to exactly one main-branch rule.
-cat <<'JSON' | gh api --method PUT "repos/${REPO}/environments/${SIGNING_ENVIRONMENT}" --input - >/dev/null
+configure_main_only_environment() {
+  local environment="$1"
+
+  cat <<'JSON' | gh api --method PUT "repos/${REPO}/environments/${environment}" --input - >/dev/null
 {
   "deployment_branch_policy": {
     "protected_branches": false,
@@ -73,16 +75,30 @@ cat <<'JSON' | gh api --method PUT "repos/${REPO}/environments/${SIGNING_ENVIRON
 }
 JSON
 
-while IFS= read -r policy_id; do
-  [[ -n "$policy_id" ]] || continue
-  gh api --method DELETE \
-    "repos/${REPO}/environments/${SIGNING_ENVIRONMENT}/deployment-branch-policies/${policy_id}" >/dev/null
-done < <(gh api "repos/${REPO}/environments/${SIGNING_ENVIRONMENT}/deployment-branch-policies?per_page=100" \
-  --jq '.branch_policies[].id')
+  while IFS= read -r policy_id; do
+    [[ -n "$policy_id" ]] || continue
+    gh api --method DELETE \
+      "repos/${REPO}/environments/${environment}/deployment-branch-policies/${policy_id}" >/dev/null
+  done < <(gh api "repos/${REPO}/environments/${environment}/deployment-branch-policies?per_page=100" \
+    --jq '.branch_policies[].id')
 
-gh api --method POST \
-  "repos/${REPO}/environments/${SIGNING_ENVIRONMENT}/deployment-branch-policies" \
-  -f name='main' -f type='branch' >/dev/null
+  gh api --method POST \
+    "repos/${REPO}/environments/${environment}/deployment-branch-policies" \
+    -f name='main' -f type='branch' >/dev/null
+}
+
+verify_main_only_environment() {
+  local environment="$1"
+  [[ "$(gh api "repos/${REPO}/environments/${environment}" --jq '.deployment_branch_policy.protected_branches')" == "false" ]]
+  [[ "$(gh api "repos/${REPO}/environments/${environment}" --jq '.deployment_branch_policy.custom_branch_policies')" == "true" ]]
+  [[ "$(gh api "repos/${REPO}/environments/${environment}/deployment-branch-policies?per_page=100" --jq '.total_count')" == "1" ]]
+  [[ "$(gh api "repos/${REPO}/environments/${environment}/deployment-branch-policies?per_page=100" --jq '[.branch_policies[] | select(.name == "main" and ((.type // "branch") == "branch"))] | length')" == "1" ]]
+}
+
+# Both credential access and stable-release mutation are protected server-side.
+# Reset custom policies to exactly one main-branch rule, making the helper idempotent.
+configure_main_only_environment "$SIGNING_ENVIRONMENT"
+configure_main_only_environment "$RELEASE_ENVIRONMENT"
 
 # Post-configuration verification is intentionally fatal. Do not print a success
 # message when GitHub rejected or partially applied a hardening setting.
@@ -97,9 +113,7 @@ gh api --method POST \
 [[ "$(gh api "repos/${REPO}/branches/main/protection" --jq '.required_status_checks.strict')" == "true" ]]
 [[ "$(gh api "repos/${REPO}/branches/main/protection" --jq '[.required_status_checks.contexts[] | select(. == "required")] | length')" == "1" ]]
 
-[[ "$(gh api "repos/${REPO}/environments/${SIGNING_ENVIRONMENT}" --jq '.deployment_branch_policy.protected_branches')" == "false" ]]
-[[ "$(gh api "repos/${REPO}/environments/${SIGNING_ENVIRONMENT}" --jq '.deployment_branch_policy.custom_branch_policies')" == "true" ]]
-[[ "$(gh api "repos/${REPO}/environments/${SIGNING_ENVIRONMENT}/deployment-branch-policies?per_page=100" --jq '.total_count')" == "1" ]]
-[[ "$(gh api "repos/${REPO}/environments/${SIGNING_ENVIRONMENT}/deployment-branch-policies?per_page=100" --jq '[.branch_policies[] | select(.name == "main" and ((.type // "branch") == "branch"))] | length')" == "1" ]]
+verify_main_only_environment "$SIGNING_ENVIRONMENT"
+verify_main_only_environment "$RELEASE_ENVIRONMENT"
 
-echo "Repository settings, main protection, and ${SIGNING_ENVIRONMENT} main-only policy verified."
+echo "Repository settings, main protection, ${SIGNING_ENVIRONMENT}, and ${RELEASE_ENVIRONMENT} main-only policies verified."

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,6 +1,6 @@
 # Production release
 
-Photo Organizer publishes one version for Windows and macOS from one exact commit. Release is intentionally fail-closed: if any required signing credential or platform build fails, no candidate is published. A signed CI candidate is still **not** a production-ready stable release until the real-device acceptance checklist passes and a separate promotion workflow records that approval.
+Photo Organizer publishes one version for Windows and macOS from one exact `main` commit. Release is intentionally fail-closed: if the protected signing environment, any required signing credential, or either platform build fails, no candidate is published. A signed CI candidate is still **not** a production-ready stable release until the real-device acceptance checklist passes and a separate promotion workflow records that approval.
 
 ## Canonical artifacts
 
@@ -16,7 +16,21 @@ Windows packages are self-contained .NET applications. The Photo Organizer execu
 
 macOS packages contain a self-contained Avalonia `.app`. Mach-O components and the app are signed with Developer ID Application and Hardened Runtime. The app and DMG are notarized with `notarytool`, stapled, and verified with `codesign`, `stapler`, and Gatekeeper (`spctl`). Apple Silicon and Intel are released separately because a self-contained .NET application contains architecture-specific runtime files; merely using `lipo` on the app host would not make the entire runtime universal.
 
-## Required GitHub Actions secrets
+## Protected production-signing environment
+
+Production signing credentials are **environment secrets**, not repository-wide Actions secrets. The repository hardening helper creates a GitHub Environment named `production-signing` and resets its deployment policy to exactly one allowed branch: `main`.
+
+Run this first from an authenticated administrator checkout:
+
+```bash
+bash Scripts/configure_repository.sh
+```
+
+The helper also configures and verifies `main` protection and a read-only default `GITHUB_TOKEN`. If any required hardening check does not match after the API calls, the helper exits non-zero instead of printing a false success message.
+
+GitHub only makes environment secrets available to jobs that reference that environment and satisfy its protection rules. Consequently, a release workflow copied or modified on a release branch/tag cannot obtain the production signing secrets from `production-signing`.
+
+## Required `production-signing` environment secrets
 
 Windows:
 
@@ -32,19 +46,34 @@ macOS:
 - `APPLE_TEAM_ID`
 - `APPLE_APP_SPECIFIC_PASSWORD`
 
-Do not commit any certificate, private key, password, or app-specific password. On a trusted local machine, `bash Scripts/configure_release_secrets.sh` sends values to `gh secret set` through stdin without deliberately printing the values.
+Do not commit any certificate, private key, password, or app-specific password. On a trusted local machine, run:
+
+```bash
+bash Scripts/configure_release_secrets.sh
+```
+
+The script refuses to accept credentials unless `production-signing` already has the verified main-only deployment policy. It sends the values through stdin to `gh secret set --env production-signing`, verifies that every environment-secret name exists, and only then removes legacy repository-level copies of the same signing-secret names. Secret values are not deliberately printed.
+
+If an older setup used repository-level signing secrets, rerunning this helper performs that migration after the protected environment has been configured.
 
 ## Stage 1 — signed acceptance candidate
 
-1. Ensure `main` CI and CodeQL are green and no unresolved code blocker remains.
-2. Configure all signing secrets.
-3. Create or fast-forward `release/vX.Y.Z` to the exact approved `main` commit, or push tag `vX.Y.Z`.
-4. The `Signing preflight` job validates the semantic version and requires every Windows and Apple signing secret before platform release jobs run.
-5. Windows and macOS independently run the shared safety tests from the same commit, produce signed packages, verify signatures, and upload short-lived workflow artifacts.
-6. Only after both platform jobs succeed does the publish job download the complete set, verify every SHA-256 checksum, and create a **GitHub Prerelease acceptance candidate**.
-7. The candidate is intentionally not marked Latest or stable. Use these exact candidate bytes for clean-machine and real-camera-card acceptance.
+1. Ensure the exact `main` commit has green `required` CI and CodeQL and no unresolved code blocker remains.
+2. Run `Scripts/configure_repository.sh` and verify that `main` protection plus the `production-signing` main-only environment policy succeed.
+3. Configure all signing credentials with `Scripts/configure_release_secrets.sh`.
+4. Manually dispatch `.github/workflows/release.yml` **from `main`** with the desired `vMAJOR.MINOR.PATCH` input. For example:
 
-The release workflow must never promote its own output to stable. This separation prevents a successful signing/build run from being mistaken for evidence that the real workflow is safe on physical machines and cards.
+   ```bash
+   gh workflow run release.yml --repo PeachGumi/PhotoOrganizer --ref main -f version=v1.0.0
+   ```
+
+5. The unprivileged preflight rejects any ref other than `refs/heads/main` and validates the semantic version.
+6. A `production-signing` environment job requires every Windows and Apple credential before signed platform work begins. Windows and macOS signing jobs also reference the protected environment.
+7. Windows and macOS independently run the shared safety tests from the same exact main commit, produce signed packages, verify signatures, and upload short-lived workflow artifacts.
+8. Only after both platform jobs succeed does the protected publish job download the complete set, verify every SHA-256 checksum, reject an already-existing release **or tag**, and create a new **GitHub Prerelease acceptance candidate** whose tag targets that exact main commit.
+9. The candidate is intentionally not marked Latest or stable. Use these exact candidate bytes for clean-machine and real-camera-card acceptance.
+
+The release workflow has no push/tag/release-branch trigger. The candidate tag is created by the final publish job only after the complete signed artifact set has passed verification. The release workflow must never promote its own output to stable.
 
 ## Stage 2 — explicit stable promotion
 
@@ -77,7 +106,9 @@ None of the following is sufficient on its own:
 - an unsigned local build;
 - only one platform succeeding;
 - a prerelease candidate that has not completed the real-device checklist;
-- a release whose accepted commit or evidence record cannot be identified.
+- a release whose accepted commit or evidence record cannot be identified;
+- a release run from any ref other than `main`;
+- credentials left only as repository-level secrets rather than in the protected `production-signing` environment.
 
 ## SmartScreen and Gatekeeper
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,6 +1,6 @@
 # Production release
 
-Photo Organizer publishes one version for Windows and macOS from one exact `main` commit. Release is intentionally fail-closed: if the protected signing environment, any required signing credential, or either platform build fails, no candidate is published. A signed CI candidate is still **not** a production-ready stable release until the real-device acceptance checklist passes and a separate promotion workflow records that approval.
+Photo Organizer publishes one version for Windows and macOS from one exact `main` commit. Release is intentionally fail-closed: if a protected release environment, any required signing credential, or either platform build fails, no candidate is published or promoted. A signed CI candidate is still **not** a production-ready stable release until the real-device acceptance checklist passes and a separate protected promotion workflow records that approval.
 
 ## Canonical artifacts
 
@@ -16,9 +16,12 @@ Windows packages are self-contained .NET applications. The Photo Organizer execu
 
 macOS packages contain a self-contained Avalonia `.app`. Mach-O components and the app are signed with Developer ID Application and Hardened Runtime. The app and DMG are notarized with `notarytool`, stapled, and verified with `codesign`, `stapler`, and Gatekeeper (`spctl`). Apple Silicon and Intel are released separately because a self-contained .NET application contains architecture-specific runtime files; merely using `lipo` on the app host would not make the entire runtime universal.
 
-## Protected production-signing environment
+## Protected production environments
 
-Production signing credentials are **environment secrets**, not repository-wide Actions secrets. The repository hardening helper creates a GitHub Environment named `production-signing` and resets its deployment policy to exactly one allowed branch: `main`.
+Release authority is split across two GitHub Environments, both restricted server-side to the `main` branch:
+
+- `production-signing` — contains Windows/macOS signing and notarization secrets and gates signed candidate creation.
+- `production-release` — contains no signing credentials and gates the privileged mutation that promotes an accepted prerelease to stable/Latest.
 
 Run this first from an authenticated administrator checkout:
 
@@ -26,9 +29,9 @@ Run this first from an authenticated administrator checkout:
 bash Scripts/configure_repository.sh
 ```
 
-The helper also configures and verifies `main` protection and a read-only default `GITHUB_TOKEN`. If any required hardening check does not match after the API calls, the helper exits non-zero instead of printing a false success message.
+The helper creates both environments and resets each custom deployment policy to exactly one allowed branch: `main`. It also configures and verifies `main` protection and a read-only default `GITHUB_TOKEN`. If any required hardening check does not match after the API calls, the helper exits non-zero instead of printing a false success message.
 
-GitHub only makes environment secrets available to jobs that reference that environment and satisfy its protection rules. Consequently, a release workflow copied or modified on a release branch/tag cannot obtain the production signing secrets from `production-signing`.
+GitHub only allows jobs referencing these environments to pass their protection rules from approved refs. Consequently, a release or promotion workflow copied or modified on another branch/tag cannot obtain production signing secrets or stable-release mutation authority.
 
 ## Required `production-signing` environment secrets
 
@@ -52,14 +55,14 @@ Do not commit any certificate, private key, password, or app-specific password. 
 bash Scripts/configure_release_secrets.sh
 ```
 
-The script refuses to accept credentials unless `production-signing` already has the verified main-only deployment policy. It sends the values through stdin to `gh secret set --env production-signing`, verifies that every environment-secret name exists, and only then removes legacy repository-level copies of the same signing-secret names. Secret values are not deliberately printed.
+The script refuses to accept credentials unless `production-signing` already has the verified main-only deployment policy. It sends values through stdin to `gh secret set --env production-signing`, verifies that every environment-secret name exists, and only then removes legacy repository-level copies of the same signing-secret names. Secret values are not deliberately printed.
 
 If an older setup used repository-level signing secrets, rerunning this helper performs that migration after the protected environment has been configured.
 
 ## Stage 1 — signed acceptance candidate
 
 1. Ensure the exact `main` commit has green `required` CI and CodeQL and no unresolved code blocker remains.
-2. Run `Scripts/configure_repository.sh` and verify that `main` protection plus the `production-signing` main-only environment policy succeed.
+2. Run `Scripts/configure_repository.sh` and verify that `main` protection plus both main-only production environments succeed.
 3. Configure all signing credentials with `Scripts/configure_release_secrets.sh`.
 4. Manually dispatch `.github/workflows/release.yml` **from `main`** with the desired `vMAJOR.MINOR.PATCH` input. For example:
 
@@ -77,7 +80,7 @@ The release workflow has no push/tag/release-branch trigger. The candidate tag i
 
 ## Stage 2 — explicit stable promotion
 
-After every applicable item in `docs/RELEASE_ACCEPTANCE.md` has passed for the exact prerelease candidate, run `.github/workflows/promote-release.yml` manually.
+After every applicable item in `docs/RELEASE_ACCEPTANCE.md` has passed for the exact prerelease candidate, manually dispatch `.github/workflows/promote-release.yml` **from `main`**. Its write-capable job is protected by the separate main-only `production-release` Environment.
 
 The promotion workflow requires:
 
@@ -88,6 +91,8 @@ The promotion workflow requires:
 
 Before promotion it verifies that:
 
+- the workflow was dispatched from `main`;
+- the `production-release` environment policy allows the privileged job;
 - the release exists and is a published prerelease, not a draft;
 - its target commit exactly equals `candidate_commit`;
 - all four expected Windows/macOS artifacts are present;
@@ -107,8 +112,9 @@ None of the following is sufficient on its own:
 - only one platform succeeding;
 - a prerelease candidate that has not completed the real-device checklist;
 - a release whose accepted commit or evidence record cannot be identified;
-- a release run from any ref other than `main`;
-- credentials left only as repository-level secrets rather than in the protected `production-signing` environment.
+- a release or promotion run from any ref other than `main`;
+- credentials left only as repository-level secrets rather than in the protected `production-signing` environment;
+- a stable mutation that did not pass the protected `production-release` environment.
 
 ## SmartScreen and Gatekeeper
 


### PR DESCRIPTION
Closes #35

Moves production signing from repository-wide workflow secrets to a server-protected `production-signing` Environment.

Security changes:
- release workflow is `workflow_dispatch` only and explicitly rejects any ref other than `main`;
- signing preflight, Windows signing, macOS signing/notarization, and candidate publication all reference `production-signing`;
- repository default `GITHUB_TOKEN` is configured read-only; only candidate publication requests `contents: write`;
- the hardening helper creates the Environment with a custom deployment policy reset to exactly the `main` branch and verifies the applied state;
- the secrets helper refuses credentials until that policy is verified, writes with `gh secret set --env production-signing`, verifies all names, then removes legacy repository-level copies;
- pre-existing release tags and releases are rejected before candidate publication;
- release-contract CI now enforces these supply-chain invariants;
- release documentation is updated for the protected two-stage process.

The environment restriction is server-side, so a modified workflow on a release branch/tag cannot obtain production signing environment secrets.