### PR TITLE
Require durable destination commit before SD reuse

### DIFF
--- a/docs/DATA_SAFETY.md
+++ b/docs/DATA_SAFETY.md
@@ -42,16 +42,23 @@ For every new source file:
 
 1. Read source size and SHA-256.
 2. Never delete or overwrite an existing destination file.
-3. If an existing candidate has identical size and SHA-256, treat it as an already-imported duplicate.
+3. If an existing candidate has identical size and SHA-256, treat it as an already-imported duplicate only after that candidate can be durably synchronized.
 4. If a name collides with different bytes, select `_2`, `_3`, and so on.
 5. Copy to an app-created hidden `.partial-*` path.
 6. Flush the temporary destination.
 7. Verify temporary size and SHA-256.
 8. Re-read the source SHA-256 and size to ensure the source did not change during copy.
 9. Move the verified temporary file to an unused final path without overwrite.
-10. Verify final size and SHA-256 again.
+10. Set final metadata, then durably commit the finalized file and its directory entry before reporting copy success.
+11. Verify final size and SHA-256 again.
 
-Only app-created never-finalized `.partial-*` files may be automatically deleted by copy cleanup. Existing library files and finalized copies must never be deleted as part of collision handling or error recovery.
+Durable commit is platform-specific and fail-closed:
+
+- on macOS, the finalized file must receive `F_FULLFSYNC`, and the parent directory entry created by the no-clobber move must be synchronized;
+- on Windows, the final no-replace move must use `MOVEFILE_WRITE_THROUGH`, and the finalized file handle must be flushed after final metadata changes;
+- if durable commit cannot be established, the copy result is failed and SD reuse remains blocked even when the destination bytes currently hash correctly.
+
+Only app-created never-finalized `.partial-*` files may be automatically deleted by copy cleanup. Existing library files and finalized copies must never be deleted as part of collision handling or error recovery. In particular, if durability fails after the temporary file has become a finalized destination file, that finalized file is retained for a later safe retry or verification attempt.
 
 ## SD-card reuse approval
 
@@ -68,8 +75,11 @@ Reuse approval requires all of the following after copy processing:
 - all supported source media expected from the initial scan is still present;
 - every currently supported source file is non-zero and readable;
 - an independent destination file with equal size and SHA-256 exists for every supported source file;
+- every destination file used as proof of backup can be durably synchronized at final verification time;
 - a source path itself, including the same bytes reached through a path alias, is never accepted as proof of an independent destination copy;
-- storage identity is checked again after hashing before approval is displayed.
+- storage identity is checked again after hashing and durability synchronization before approval is displayed.
+
+A SHA-256 match served from operating-system or device caches is not by itself sufficient proof that the camera card can be reformatted. Green approval requires durable destination commit in addition to byte verification.
 
 If any condition cannot be proved, the UI must remain blocked/not-verified.
 

--- a/src/PhotoOrganizer.Core/FileDurability.cs
+++ b/src/PhotoOrganizer.Core/FileDurability.cs
@@ -1,0 +1,233 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace PhotoOrganizer.Core;
+
+public sealed record DurabilityResult(bool Success, string? Error = null);
+
+public enum FinalizeFileStatus
+{
+    Committed,
+    DestinationExists,
+    Failed
+}
+
+public sealed record FinalizeFileResult(
+    FinalizeFileStatus Status,
+    bool FinalPathCreated,
+    string? Error = null);
+
+public interface IFileDurabilityService
+{
+    FinalizeFileResult FinalizeNewFile(string temporaryPath, string finalPath, DateTime lastWriteUtc);
+
+    DurabilityResult EnsureDurable(string filePath);
+}
+
+public sealed partial class PlatformFileDurabilityService : IFileDurabilityService
+{
+    private const uint MoveFileWriteThrough = 0x00000008;
+    private const int FFullFsync = 51;
+    private const int OpenReadOnly = 0;
+    private const int InterruptedSystemCall = 4;
+
+    public FinalizeFileResult FinalizeNewFile(string temporaryPath, string finalPath, DateTime lastWriteUtc)
+    {
+        var moved = false;
+
+        try
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                if (!MoveFileEx(temporaryPath, finalPath, MoveFileWriteThrough))
+                {
+                    var error = Marshal.GetLastPInvokeError();
+                    if (File.Exists(finalPath) || Directory.Exists(finalPath))
+                    {
+                        return new FinalizeFileResult(FinalizeFileStatus.DestinationExists, false);
+                    }
+
+                    return new FinalizeFileResult(
+                        FinalizeFileStatus.Failed,
+                        false,
+                        $"MOVEFILE_WRITE_THROUGH final move failed ({error}): {new Win32Exception(error).Message}");
+                }
+            }
+            else
+            {
+                try
+                {
+                    File.Move(temporaryPath, finalPath, overwrite: false);
+                }
+                catch (IOException) when (File.Exists(finalPath) || Directory.Exists(finalPath))
+                {
+                    return new FinalizeFileResult(FinalizeFileStatus.DestinationExists, false);
+                }
+            }
+
+            moved = true;
+            File.SetLastWriteTimeUtc(finalPath, lastWriteUtc);
+
+            var durability = EnsureDurable(finalPath);
+            if (!durability.Success)
+            {
+                return new FinalizeFileResult(
+                    FinalizeFileStatus.Failed,
+                    true,
+                    durability.Error ?? "Finalized file could not be committed durably.");
+            }
+
+            return new FinalizeFileResult(FinalizeFileStatus.Committed, true);
+        }
+        catch (Exception ex)
+        {
+            return new FinalizeFileResult(
+                FinalizeFileStatus.Failed,
+                moved,
+                $"Durable finalization failed: {ex.Message}");
+        }
+    }
+
+    public DurabilityResult EnsureDurable(string filePath)
+    {
+        try
+        {
+            var fullPath = Path.GetFullPath(filePath);
+            if (!File.Exists(fullPath))
+            {
+                return new DurabilityResult(false, "Destination file no longer exists while establishing durability.");
+            }
+
+            if (OperatingSystem.IsWindows())
+            {
+                using var stream = new FileStream(
+                    fullPath,
+                    FileMode.Open,
+                    FileAccess.ReadWrite,
+                    FileShare.Read,
+                    bufferSize: 1,
+                    FileOptions.WriteThrough);
+                stream.Flush(flushToDisk: true);
+                return new DurabilityResult(true);
+            }
+
+            if (OperatingSystem.IsMacOS())
+            {
+                var parent = Path.GetDirectoryName(fullPath);
+                if (string.IsNullOrWhiteSpace(parent))
+                {
+                    return new DurabilityResult(false, "Destination parent directory could not be resolved for durable commit.");
+                }
+
+                // Push the rename/directory-entry metadata to the device first. F_FULLFSYNC
+                // on the finalized file then drains the device queue, covering that prior fsync
+                // as well as the finalized file's data and timestamp metadata.
+                var directorySync = SynchronizeMacDirectory(parent);
+                if (!directorySync.Success)
+                {
+                    return directorySync;
+                }
+
+                return FullFsyncMacFile(fullPath);
+            }
+
+            // The shipping targets are Windows and macOS. Keep non-shipping Unix CI
+            // functional with the strongest portable .NET flush available.
+            using (var stream = new FileStream(
+                       fullPath,
+                       FileMode.Open,
+                       FileAccess.ReadWrite,
+                       FileShare.Read,
+                       bufferSize: 1,
+                       FileOptions.WriteThrough))
+            {
+                stream.Flush(flushToDisk: true);
+            }
+
+            return new DurabilityResult(true);
+        }
+        catch (Exception ex)
+        {
+            return new DurabilityResult(false, $"Destination durability flush failed: {ex.Message}");
+        }
+    }
+
+    private static DurabilityResult SynchronizeMacDirectory(string directoryPath)
+    {
+        var descriptor = OpenMac(directoryPath, OpenReadOnly);
+        if (descriptor < 0)
+        {
+            var error = Marshal.GetLastPInvokeError();
+            return MacFailure("open parent directory", error);
+        }
+
+        try
+        {
+            while (FsyncMac(descriptor) != 0)
+            {
+                var error = Marshal.GetLastPInvokeError();
+                if (error == InterruptedSystemCall)
+                {
+                    continue;
+                }
+
+                return MacFailure("fsync parent directory", error);
+            }
+
+            return new DurabilityResult(true);
+        }
+        finally
+        {
+            _ = CloseMac(descriptor);
+        }
+    }
+
+    private static DurabilityResult FullFsyncMacFile(string filePath)
+    {
+        var descriptor = OpenMac(filePath, OpenReadOnly);
+        if (descriptor < 0)
+        {
+            var error = Marshal.GetLastPInvokeError();
+            return MacFailure("open finalized file", error);
+        }
+
+        try
+        {
+            while (FcntlMac(descriptor, FFullFsync) != 0)
+            {
+                var error = Marshal.GetLastPInvokeError();
+                if (error == InterruptedSystemCall)
+                {
+                    continue;
+                }
+
+                return MacFailure("F_FULLFSYNC finalized file", error);
+            }
+
+            return new DurabilityResult(true);
+        }
+        finally
+        {
+            _ = CloseMac(descriptor);
+        }
+    }
+
+    private static DurabilityResult MacFailure(string operation, int error) =>
+        new(false, $"macOS {operation} failed (errno {error}): {new Win32Exception(error).Message}");
+
+    [LibraryImport("kernel32.dll", EntryPoint = "MoveFileExW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool MoveFileEx(string existingFileName, string newFileName, uint flags);
+
+    [LibraryImport("/usr/lib/libSystem.B.dylib", EntryPoint = "open", SetLastError = true, StringMarshalling = StringMarshalling.Utf8)]
+    private static partial int OpenMac(string path, int flags);
+
+    [LibraryImport("/usr/lib/libSystem.B.dylib", EntryPoint = "fsync", SetLastError = true)]
+    private static partial int FsyncMac(int fileDescriptor);
+
+    [LibraryImport("/usr/lib/libSystem.B.dylib", EntryPoint = "fcntl", SetLastError = true)]
+    private static partial int FcntlMac(int fileDescriptor, int command);
+
+    [LibraryImport("/usr/lib/libSystem.B.dylib", EntryPoint = "close", SetLastError = true)]
+    private static partial int CloseMac(int fileDescriptor);
+}

--- a/src/PhotoOrganizer.Core/FileDurability.cs
+++ b/src/PhotoOrganizer.Core/FileDurability.cs
@@ -29,6 +29,7 @@ public sealed partial class PlatformFileDurabilityService : IFileDurabilityServi
     private const uint MoveFileWriteThrough = 0x00000008;
     private const int FFullFsync = 51;
     private const int OpenReadOnly = 0;
+    private const int OpenReadWrite = 2;
     private const int InterruptedSystemCall = 4;
 
     public FinalizeFileResult FinalizeNewFile(string temporaryPath, string finalPath, DateTime lastWriteUtc)
@@ -184,11 +185,13 @@ public sealed partial class PlatformFileDurabilityService : IFileDurabilityServi
 
     private static DurabilityResult FullFsyncMacFile(string filePath)
     {
-        var descriptor = OpenMac(filePath, OpenReadOnly);
+        // Use a writable descriptor for a write durability operation. If the
+        // destination has become read-only, fail closed rather than approving SD reuse.
+        var descriptor = OpenMac(filePath, OpenReadWrite);
         if (descriptor < 0)
         {
             var error = Marshal.GetLastPInvokeError();
-            return MacFailure("open finalized file", error);
+            return MacFailure("open finalized file for durable synchronization", error);
         }
 
         try
@@ -213,7 +216,7 @@ public sealed partial class PlatformFileDurabilityService : IFileDurabilityServi
     }
 
     private static DurabilityResult MacFailure(string operation, int error) =>
-        new(false, $"macOS {operation} failed (errno {error}): {new Win32Exception(error).Message}");
+        new(false, $"macOS {operation} failed (errno {error}).");
 
     [LibraryImport("kernel32.dll", EntryPoint = "MoveFileExW", SetLastError = true, StringMarshalling = StringMarshalling.Utf16)]
     [return: MarshalAs(UnmanagedType.Bool)]

--- a/src/PhotoOrganizer.Core/FormatSafetyVerifier.cs
+++ b/src/PhotoOrganizer.Core/FormatSafetyVerifier.cs
@@ -14,15 +14,18 @@ public sealed class FormatSafetyVerifier
     private readonly MediaClassifier _classifier;
     private readonly IStorageVolumeProvider? _volumeProvider;
     private readonly IFileHasher _hasher;
+    private readonly IFileDurabilityService _durability;
 
     public FormatSafetyVerifier(
         MediaClassifier classifier,
         IStorageVolumeProvider? volumeProvider = null,
-        IFileHasher? hasher = null)
+        IFileHasher? hasher = null,
+        IFileDurabilityService? durability = null)
     {
         _classifier = classifier;
         _volumeProvider = volumeProvider;
         _hasher = hasher ?? new Sha256FileHasher();
+        _durability = durability ?? new PlatformFileDurabilityService();
     }
 
     public async Task<FormatVerificationResult> VerifyAsync(
@@ -102,11 +105,23 @@ public sealed class FormatSafetyVerifier
                             destinationHashCache[candidate] = destinationHash;
                         }
 
-                        if (string.Equals(sourceHash, destinationHash, StringComparison.Ordinal))
+                        if (!string.Equals(sourceHash, destinationHash, StringComparison.Ordinal))
                         {
-                            matched = true;
-                            break;
+                            continue;
                         }
+
+                        // A cache-readable SHA match is not sufficient for SD reuse.
+                        // Force the matched independent destination copy to durable
+                        // storage before allowing it to count as verified.
+                        var durability = _durability.EnsureDurable(candidate);
+                        if (!durability.Success)
+                        {
+                            errors.Add($"{candidate}: {durability.Error ?? "durable destination commit failed"}");
+                            continue;
+                        }
+
+                        matched = true;
+                        break;
                     }
                     catch (Exception ex) when (ex is not OperationCanceledException)
                     {

--- a/src/PhotoOrganizer.Core/ImportCoordinator.cs
+++ b/src/PhotoOrganizer.Core/ImportCoordinator.cs
@@ -368,7 +368,7 @@ public sealed class ImportCoordinator
                 ImportProgressPhase.Verifying,
                 0,
                 rescan.Files.Count,
-                "Verifying destination bytes with SHA-256."));
+                "Verifying destination SHA-256 and durable storage commit."));
 
             var verification = await _verifier
                 .VerifyAsync(rescan.Files, destination, cancellationToken)
@@ -377,14 +377,14 @@ public sealed class ImportCoordinator
             if (!_storageSessions.Matches(session.SourceIdentity, session.CardRoot)
                 || !_storageSessions.Matches(destinationIdentity, destination))
             {
-                return Blocked("Source or destination storage changed during final byte verification.", summary, verification);
+                return Blocked("Source or destination storage changed during final byte and durability verification.", summary, verification);
             }
 
             if (!verification.IsSafe)
             {
                 errors.AddRange(verification.Errors);
                 return Blocked(
-                    $"Only {verification.Verified} of {verification.Total} supported file(s) were verified in the destination. Do not reuse the card.",
+                    $"Only {verification.Verified} of {verification.Total} supported file(s) were verified and durably synchronized in the destination. Do not reuse the card.",
                     summary,
                     verification);
             }
@@ -393,11 +393,11 @@ public sealed class ImportCoordinator
                 ImportProgressPhase.Verifying,
                 verification.Verified,
                 verification.Total,
-                "Destination copies verified; camera card may be reused."));
+                "Destination copies verified and durably synchronized; camera card may be reused."));
 
             return new ImportRunResult(
                 ImportSafetyStatus.SafeToReuse,
-                $"Verified {verification.Verified} supported file(s) by size and SHA-256. Camera card may be reused.",
+                $"Verified {verification.Verified} supported file(s) by size and SHA-256 and durably synchronized destination storage. Camera card may be reused.",
                 summary,
                 verification);
         }

--- a/src/PhotoOrganizer.Core/PhotoOrganizer.Core.csproj
+++ b/src/PhotoOrganizer.Core/PhotoOrganizer.Core.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <AssemblyName>PhotoOrganizer.Core</AssemblyName>
     <RootNamespace>PhotoOrganizer.Core</RootNamespace>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/PhotoOrganizer.Core/SafeCopyService.cs
+++ b/src/PhotoOrganizer.Core/SafeCopyService.cs
@@ -215,6 +215,14 @@ public sealed class SafeCopyService
         {
             var candidateName = suffix == 1 ? $"{fileName}{extension}" : $"{fileName}_{suffix}{extension}";
             var candidate = Path.Combine(destinationDirectory, candidateName);
+
+            // A directory occupies the same namespace entry as a file. Treat it as
+            // an immutable collision and move on instead of retrying the same path.
+            if (Directory.Exists(candidate))
+            {
+                continue;
+            }
+
             if (!File.Exists(candidate))
             {
                 return (candidate, false);

--- a/src/PhotoOrganizer.Core/SafeCopyService.cs
+++ b/src/PhotoOrganizer.Core/SafeCopyService.cs
@@ -12,6 +12,12 @@ public sealed record CopyResult(CopyStatus Status, string? DestinationPath, stri
 public sealed class SafeCopyService
 {
     private const int BufferSize = 4 * 1024 * 1024;
+    private readonly IFileDurabilityService _durability;
+
+    public SafeCopyService(IFileDurabilityService? durability = null)
+    {
+        _durability = durability ?? new PlatformFileDurabilityService();
+    }
 
     public async Task<CopyResult> CopyAsync(
         string sourcePath,
@@ -60,7 +66,10 @@ public sealed class SafeCopyService
 
             if (resolution.IsDuplicate)
             {
-                return new CopyResult(CopyStatus.SkippedDuplicate, resolution.Path);
+                var durability = _durability.EnsureDurable(resolution.Path);
+                return durability.Success
+                    ? new CopyResult(CopyStatus.SkippedDuplicate, resolution.Path)
+                    : new CopyResult(CopyStatus.Failed, resolution.Path, durability.Error ?? "Existing duplicate could not be committed durably.");
             }
 
             var transactionTemporaryPath = Path.Combine(destinationDirectory, $".partial-{Guid.NewGuid():N}");
@@ -118,31 +127,44 @@ public sealed class SafeCopyService
             var finalPath = resolution.Path;
             while (true)
             {
-                try
+                var finalization = _durability.FinalizeNewFile(transactionTemporaryPath, finalPath, sourceLastWriteUtc);
+                if (finalization.FinalPathCreated)
                 {
-                    File.Move(transactionTemporaryPath, finalPath, overwrite: false);
+                    // Once the temporary file has become a finalized user-library file,
+                    // cleanup must never delete it even when durability later fails.
                     temporaryPathForCleanup = null;
+                }
+
+                if (finalization.Status == FinalizeFileStatus.Committed)
+                {
                     break;
                 }
-                catch (IOException) when (File.Exists(finalPath))
+
+                if (finalization.Status == FinalizeFileStatus.Failed)
                 {
-                    resolution = await ResolveDestinationAsync(
-                        sourcePath,
-                        destinationDirectory,
-                        sourceSize,
-                        sourceHashBefore,
-                        cancellationToken).ConfigureAwait(false);
-
-                    if (resolution.IsDuplicate)
-                    {
-                        return new CopyResult(CopyStatus.SkippedDuplicate, resolution.Path);
-                    }
-
-                    finalPath = resolution.Path;
+                    return new CopyResult(
+                        CopyStatus.Failed,
+                        finalization.FinalPathCreated ? finalPath : null,
+                        finalization.Error ?? "Durable destination finalization failed.");
                 }
-            }
 
-            File.SetLastWriteTimeUtc(finalPath, sourceLastWriteUtc);
+                resolution = await ResolveDestinationAsync(
+                    sourcePath,
+                    destinationDirectory,
+                    sourceSize,
+                    sourceHashBefore,
+                    cancellationToken).ConfigureAwait(false);
+
+                if (resolution.IsDuplicate)
+                {
+                    var durability = _durability.EnsureDurable(resolution.Path);
+                    return durability.Success
+                        ? new CopyResult(CopyStatus.SkippedDuplicate, resolution.Path)
+                        : new CopyResult(CopyStatus.Failed, resolution.Path, durability.Error ?? "Existing duplicate could not be committed durably.");
+                }
+
+                finalPath = resolution.Path;
+            }
 
             var finalInfo = new FileInfo(finalPath);
             if (finalInfo.Length != sourceSize)

--- a/tests/PhotoOrganizer.Core.Tests/DurableCopySafetyTests.cs
+++ b/tests/PhotoOrganizer.Core.Tests/DurableCopySafetyTests.cs
@@ -25,6 +25,25 @@ public sealed class DurableCopySafetyTests
     }
 
     [TestMethod]
+    public async Task ExistingDirectoryWithRequestedFileName_IsPreservedAndUsesCollisionSuffix()
+    {
+        using var temp = new TempDirectory();
+        var sourceDirectory = Directory.CreateDirectory(Path.Combine(temp.Path, "source")).FullName;
+        var destinationDirectory = Directory.CreateDirectory(Path.Combine(temp.Path, "destination")).FullName;
+        var source = Path.Combine(sourceDirectory, "DSC_0001.jpg");
+        var conflictingDirectory = Directory.CreateDirectory(Path.Combine(destinationDirectory, "DSC_0001.jpg")).FullName;
+        File.WriteAllText(source, "camera-data");
+
+        var result = await new SafeCopyService().CopyAsync(source, destinationDirectory);
+
+        Assert.AreEqual(CopyStatus.Copied, result.Status, result.Error);
+        Assert.IsTrue(Directory.Exists(conflictingDirectory));
+        Assert.AreEqual(
+            "camera-data",
+            File.ReadAllText(Path.Combine(destinationDirectory, "DSC_0001_2.jpg")));
+    }
+
+    [TestMethod]
     public async Task FinalReuseVerification_DurabilityFailureLeavesMatchingBytesUnverified()
     {
         using var temp = new TempDirectory();

--- a/tests/PhotoOrganizer.Core.Tests/DurableCopySafetyTests.cs
+++ b/tests/PhotoOrganizer.Core.Tests/DurableCopySafetyTests.cs
@@ -1,0 +1,96 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PhotoOrganizer.Core.Tests;
+
+[TestClass]
+public sealed class DurableCopySafetyTests
+{
+    [TestMethod]
+    public async Task DurabilityFailureAfterFinalMove_ReturnsFailedWithoutDeletingFinalizedFile()
+    {
+        using var temp = new TempDirectory();
+        var sourceDirectory = Directory.CreateDirectory(Path.Combine(temp.Path, "source")).FullName;
+        var destinationDirectory = Directory.CreateDirectory(Path.Combine(temp.Path, "destination")).FullName;
+        var source = Path.Combine(sourceDirectory, "DSC_0001.jpg");
+        File.WriteAllText(source, "camera-data-that-must-survive");
+
+        var result = await new SafeCopyService(new FailAfterMoveDurabilityService())
+            .CopyAsync(source, destinationDirectory);
+
+        Assert.AreEqual(CopyStatus.Failed, result.Status);
+        Assert.IsNotNull(result.DestinationPath);
+        Assert.IsTrue(File.Exists(result.DestinationPath));
+        Assert.AreEqual("camera-data-that-must-survive", File.ReadAllText(result.DestinationPath));
+        Assert.IsFalse(Directory.EnumerateFiles(destinationDirectory, ".partial-*", SearchOption.TopDirectoryOnly).Any());
+    }
+
+    [TestMethod]
+    public async Task FinalReuseVerification_DurabilityFailureLeavesMatchingBytesUnverified()
+    {
+        using var temp = new TempDirectory();
+        var sourceDirectory = Directory.CreateDirectory(Path.Combine(temp.Path, "source")).FullName;
+        var destinationDirectory = Directory.CreateDirectory(Path.Combine(temp.Path, "destination")).FullName;
+        var source = Path.Combine(sourceDirectory, "photo.jpg");
+        var destination = Path.Combine(destinationDirectory, "photo.jpg");
+        File.WriteAllText(source, "identical-bytes");
+        File.WriteAllText(destination, "identical-bytes");
+
+        var result = await new FormatSafetyVerifier(
+                new MediaClassifier(),
+                durability: new AlwaysFailDurabilityService())
+            .VerifyAsync([source], destinationDirectory);
+
+        Assert.IsFalse(result.IsSafe);
+        Assert.AreEqual(0, result.Verified);
+        CollectionAssert.Contains(result.UnverifiedFiles.ToList(), source);
+        Assert.IsTrue(result.Errors.Any(error => error.Contains("simulated durability failure", StringComparison.Ordinal)));
+    }
+
+    private sealed class FailAfterMoveDurabilityService : IFileDurabilityService
+    {
+        public FinalizeFileResult FinalizeNewFile(string temporaryPath, string finalPath, DateTime lastWriteUtc)
+        {
+            File.Move(temporaryPath, finalPath, overwrite: false);
+            File.SetLastWriteTimeUtc(finalPath, lastWriteUtc);
+            return new FinalizeFileResult(
+                FinalizeFileStatus.Failed,
+                FinalPathCreated: true,
+                "simulated durability failure after final move");
+        }
+
+        public DurabilityResult EnsureDurable(string filePath) =>
+            new(false, "simulated durability failure");
+    }
+
+    private sealed class AlwaysFailDurabilityService : IFileDurabilityService
+    {
+        public FinalizeFileResult FinalizeNewFile(string temporaryPath, string finalPath, DateTime lastWriteUtc) =>
+            throw new NotSupportedException();
+
+        public DurabilityResult EnsureDurable(string filePath) =>
+            new(false, "simulated durability failure");
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"PhotoOrganizerDurabilityTests-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+            catch
+            {
+                // Test cleanup only. Never used for application/user data.
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #37.

## What changed
- adds a platform durability service for finalized destination files;
- Windows finalization uses a no-replace `MoveFileExW(..., MOVEFILE_WRITE_THROUGH)` and flushes the finalized file after metadata changes;
- macOS synchronizes the parent directory entry and uses `F_FULLFSYNC` on the finalized file;
- `SafeCopyService` reports failure when durable finalization cannot be established and never deletes a file once it has reached its final library path;
- duplicate copies must also pass a durability synchronization step;
- final SD-reuse verification now requires both SHA-256 equality and a fresh durable synchronization of the matched independent destination copy;
- adds regression tests for durability failure after final move and durability failure during final reuse verification;
- updates the normative data-safety contract.

## Safety properties preserved
- source media is never modified or deleted;
- existing destination files are never overwritten;
- `.partial-*` cleanup only applies before finalization;
- a durability failure after finalization leaves the completed destination file intact but blocks SD reuse;
- collision suffix behavior remains no-clobber/fail-safe.

## Validation
CI should exercise Core tests on Windows and macOS plus the existing package/release policy checks.