### PR TITLE
Harden macOS storage identity collection

### DIFF
--- a/docs/STORAGE_IDENTITY.md
+++ b/docs/STORAGE_IDENTITY.md
@@ -1,24 +1,28 @@
 # Storage identity
 
-Photo Organizer must never treat a path string, drive letter, mount point, persistent UUID, or volume GUID as sufficient proof that the currently mounted storage is the same mount session that was scanned earlier.
+Photo Organizer must never treat a path string, drive letter, mount point, persistent UUID, volume GUID, or physical-disk number as sufficient proof that the currently mounted storage is the same mount session that was scanned earlier.
 
-The unified app therefore separates two concepts:
+The unified app therefore separates three concepts:
 
-1. **OS volume fingerprint** — Windows volume GUID or macOS mounted-device fingerprint. This distinguishes different backing volumes when available.
-2. **Process-local mount session ID** — a random identifier created when a mounted volume is first observed. It is discarded on removal or fingerprint change and is never persisted.
+1. **OS volume fingerprint** — a Windows volume GUID or, on macOS, a persistent filesystem/partition UUID reported by `diskutil info -plist` when available. macOS falls back to the current BSD `DeviceIdentifier` only when no persistent UUID is exposed.
+2. **Physical storage fingerprint** — the Windows physical-disk mapping or macOS `ParentWholeDisk`/whole-disk identifier. Source and destination must resolve to different physical storage devices.
+3. **Process-local mount session ID** — a random identifier created when a mounted volume is first observed. It is discarded on removal or fingerprint/physical-device change and is never persisted.
 
-A safety approval can only remain valid while both the fingerprint and the current mount-session ID match. Removal followed by reinsertion creates a new session ID even for the same physical card.
+A safety approval can only remain valid while the volume fingerprint, physical storage fingerprint, and current mount-session ID match. Removal followed by reinsertion creates a new session ID even for the same physical card when the removal is observed.
 
 ## Event sources
 
 Windows uses `Win32_VolumeChangeEvent` with a one-second enumeration fallback. macOS watches `/Volumes` with `FileSystemWatcher` and also uses the same periodic fallback. Removal events explicitly invalidate the old session before refreshing current mounts.
 
+On macOS each enumeration uses one bounded `diskutil info -plist` operation per mounted volume to obtain both the volume and whole-disk identities. Redirected output is drained asynchronously and a timed-out child process is killed; storage identity collection must not block indefinitely on a failing filesystem. The persistent UUID is a fingerprint only: it never substitutes for the process-local mount-session ID.
+
 ## Fail-closed rules
 
-- If the platform fingerprint cannot be obtained, no storage identity snapshot is issued.
+- If the platform volume fingerprint or required physical-device fingerprint cannot be obtained, no reusable-card approval can be issued.
 - Persistent identifiers are never accepted without the process-local session ID.
+- Different partitions/volumes on the same physical device are not independent backup locations.
 - Camera-card manual selection must resolve to a non-system mounted volume root that itself contains `DCIM` or `PRIVATE`.
 - Selecting `DCIM/100NIKON` or another child expands to the complete mounted camera-card root.
 - An ordinary folder is never accepted merely because its path resembles camera media.
 
-Real-device acceptance must still exercise removal/reinsertion, same drive-letter or mount-path replacement, source removal during import, and destination removal during verification on both supported operating systems.
+Real-device acceptance must still exercise removal/reinsertion, same drive-letter or mount-path replacement, source removal during import, destination removal during verification, and physically distinct source/destination detection on both supported operating systems.

--- a/src/PhotoOrganizer.App/PlatformStorageVolumeProvider.cs
+++ b/src/PhotoOrganizer.App/PlatformStorageVolumeProvider.cs
@@ -11,6 +11,10 @@ namespace PhotoOrganizer.App;
 
 public sealed class PlatformStorageVolumeProvider : IStorageVolumeProvider
 {
+    private sealed record MacStorageIdentity(
+        string VolumeFingerprint,
+        string? PhysicalDeviceFingerprint);
+
     public StringComparison PathComparison => OperatingSystem.IsWindows()
         ? StringComparison.OrdinalIgnoreCase
         : StringComparison.Ordinal;
@@ -21,8 +25,20 @@ public sealed class PlatformStorageVolumeProvider : IStorageVolumeProvider
             ? Path.GetPathRoot(Environment.SystemDirectory)
             : "/";
 
+        DriveInfo[] drives;
+        try
+        {
+            drives = DriveInfo.GetDrives();
+        }
+        catch
+        {
+            // Enumeration failure cannot be allowed to manufacture or preserve an
+            // unverified identity. Callers treat an empty set as fail-closed.
+            return [];
+        }
+
         var volumes = new List<MountedVolumeInfo>();
-        foreach (var drive in DriveInfo.GetDrives())
+        foreach (var drive in drives)
         {
             try
             {
@@ -35,10 +51,30 @@ public sealed class PlatformStorageVolumeProvider : IStorageVolumeProvider
                     continue;
                 }
 
-                var fingerprint = TryGetFingerprint(root);
+                string? fingerprint;
+                string? physicalDeviceFingerprint;
+
+                if (OperatingSystem.IsWindows())
+                {
+                    fingerprint = TryGetWindowsVolumeGuid(root);
+                    physicalDeviceFingerprint = TryGetWindowsPhysicalDiskFingerprint(root);
+                }
+                else if (OperatingSystem.IsMacOS())
+                {
+                    // diskutil already exposes both persistent volume identity and the
+                    // containing whole-disk identity. Resolve them together so a safety
+                    // refresh never launches a second subprocess for the same volume.
+                    var identity = TryGetMacStorageIdentity(root);
+                    fingerprint = identity?.VolumeFingerprint;
+                    physicalDeviceFingerprint = identity?.PhysicalDeviceFingerprint;
+                }
+                else
+                {
+                    continue;
+                }
+
                 if (string.IsNullOrWhiteSpace(fingerprint)) continue;
 
-                var physicalDeviceFingerprint = TryGetPhysicalDeviceFingerprint(root);
                 var isSystem = !string.IsNullOrWhiteSpace(systemRoot)
                     && string.Equals(PathSafety.Normalize(systemRoot), root, PathComparison);
                 var isRemovable = drive.DriveType == DriveType.Removable
@@ -87,20 +123,6 @@ public sealed class PlatformStorageVolumeProvider : IStorageVolumeProvider
             .Where(v => PathSafety.IsSameOrDescendant(current, v.RootPath, PathComparison))
             .OrderByDescending(v => PathSafety.Normalize(v.RootPath).Length)
             .FirstOrDefault();
-    }
-
-    private static string? TryGetFingerprint(string root)
-    {
-        if (OperatingSystem.IsWindows()) return TryGetWindowsVolumeGuid(root);
-        if (OperatingSystem.IsMacOS()) return TryGetMacDeviceFingerprint(root);
-        return null;
-    }
-
-    private static string? TryGetPhysicalDeviceFingerprint(string root)
-    {
-        if (OperatingSystem.IsWindows()) return TryGetWindowsPhysicalDiskFingerprint(root);
-        if (OperatingSystem.IsMacOS()) return TryGetMacWholeDiskFingerprint(root);
-        return null;
     }
 
     private static string? TryGetWindowsVolumeGuid(string root)
@@ -152,38 +174,8 @@ public sealed class PlatformStorageVolumeProvider : IStorageVolumeProvider
         return null;
     }
 
-    private static string? TryGetMacDeviceFingerprint(string root)
-    {
-        try
-        {
-            using var process = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "/usr/bin/stat",
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
-            };
-            process.StartInfo.ArgumentList.Add("-f");
-            process.StartInfo.ArgumentList.Add("%d");
-            process.StartInfo.ArgumentList.Add(root);
-
-            if (!process.Start()) return null;
-            var output = process.StandardOutput.ReadToEnd().Trim();
-            process.WaitForExit(3000);
-            if (process.ExitCode != 0 || string.IsNullOrWhiteSpace(output)) return null;
-            return "mac-device:" + output;
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    private static string? TryGetMacWholeDiskFingerprint(string root)
+    [SupportedOSPlatform("macos")]
+    private static MacStorageIdentity? TryGetMacStorageIdentity(string root)
     {
         try
         {
@@ -203,11 +195,16 @@ public sealed class PlatformStorageVolumeProvider : IStorageVolumeProvider
             process.StartInfo.ArgumentList.Add(root);
 
             if (!process.Start()) return null;
+
+            // Begin draining both redirected pipes before waiting. Reading either
+            // pipe synchronously first can deadlock if the child blocks or fills the
+            // other pipe, which would make the nominal timeout ineffective.
             var stdout = process.StandardOutput.ReadToEndAsync();
             var stderr = process.StandardError.ReadToEndAsync();
             if (!process.WaitForExit(5000))
             {
                 try { process.Kill(entireProcessTree: true); } catch { }
+                try { process.WaitForExit(1000); } catch { }
                 return null;
             }
 
@@ -219,28 +216,38 @@ public sealed class PlatformStorageVolumeProvider : IStorageVolumeProvider
             var dictionary = document.Root?.Elements().FirstOrDefault(element => element.Name.LocalName == "dict");
             if (dictionary is null) return null;
 
-            var parentWholeDisk = GetPlistString(dictionary, "ParentWholeDisk");
-            if (!string.IsNullOrWhiteSpace(parentWholeDisk))
-            {
-                return "mac-whole-disk:" + parentWholeDisk;
-            }
+            // Prefer a persistent filesystem/partition identity. DeviceIdentifier is
+            // only a last-resort fallback because BSD disk numbers are ephemeral.
+            var persistentVolumeId = FirstNonEmpty(
+                GetPlistString(dictionary, "VolumeUUID"),
+                GetPlistString(dictionary, "APFSVolumeUUID"),
+                GetPlistString(dictionary, "DiskUUID"),
+                GetPlistString(dictionary, "MediaUUID"));
+            var deviceIdentifier = GetPlistString(dictionary, "DeviceIdentifier");
+            var volumeIdentity = FirstNonEmpty(persistentVolumeId, deviceIdentifier);
+            if (string.IsNullOrWhiteSpace(volumeIdentity)) return null;
 
-            if (GetPlistBoolean(dictionary, "WholeDisk") == true)
-            {
-                var deviceIdentifier = GetPlistString(dictionary, "DeviceIdentifier");
-                if (!string.IsNullOrWhiteSpace(deviceIdentifier))
-                {
-                    return "mac-whole-disk:" + deviceIdentifier;
-                }
-            }
+            var parentWholeDisk = GetPlistString(dictionary, "ParentWholeDisk");
+            var wholeDisk = GetPlistBoolean(dictionary, "WholeDisk") == true
+                ? deviceIdentifier
+                : null;
+            var physicalIdentity = FirstNonEmpty(parentWholeDisk, wholeDisk);
+
+            return new MacStorageIdentity(
+                "mac-volume:" + volumeIdentity,
+                string.IsNullOrWhiteSpace(physicalIdentity)
+                    ? null
+                    : "mac-whole-disk:" + physicalIdentity);
         }
         catch
         {
-            // Physical identity is a safety signal. Callers fail closed when unavailable.
+            // Storage identity is a safety signal. Callers fail closed when unavailable.
+            return null;
         }
-
-        return null;
     }
+
+    private static string? FirstNonEmpty(params string?[] values) =>
+        values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
 
     private static string? GetPlistString(XElement dictionary, string key)
     {

--- a/tests/PhotoOrganizer.App.Tests/PlatformStorageIdentityTests.cs
+++ b/tests/PhotoOrganizer.App.Tests/PlatformStorageIdentityTests.cs
@@ -21,4 +21,21 @@ public sealed class PlatformStorageIdentityTests
             string.IsNullOrWhiteSpace(volume.PhysicalDeviceFingerprint),
             $"Physical-device identity is missing for {path} on {Environment.OSVersion}.");
     }
+
+    [TestMethod]
+    public void SystemVolume_RepeatedResolutionKeepsSameIdentity()
+    {
+        var provider = new PlatformStorageVolumeProvider();
+        var path = OperatingSystem.IsWindows()
+            ? Path.GetPathRoot(Environment.SystemDirectory)!
+            : "/";
+
+        var first = provider.ResolveVolumeForPath(path);
+        var second = provider.ResolveVolumeForPath(path);
+
+        Assert.IsNotNull(first);
+        Assert.IsNotNull(second);
+        Assert.AreEqual(first.Fingerprint, second.Fingerprint);
+        Assert.AreEqual(first.PhysicalDeviceFingerprint, second.PhysicalDeviceFingerprint);
+    }
 }


### PR DESCRIPTION
Closes #39.

## What changed
- removes the separate synchronous `stat` subprocess used for macOS mounted-volume fingerprinting;
- obtains volume and whole-disk identity from one bounded `diskutil info -plist` invocation per volume;
- prefers persistent volume/partition UUID fields and uses BSD `DeviceIdentifier` only as a fail-closed fallback;
- drains stdout/stderr before waiting, kills a timed-out child, and prevents storage enumeration from escaping as an unsafe identity;
- retains `ParentWholeDisk`/whole-disk physical separation;
- adds a real-platform repeated-resolution identity test;
- documents the volume, physical-device and process-local mount-session identity layers.

## Safety
Persistent UUIDs remain fingerprints only. They do not authorize SD reuse without the process-local mount-session identity, and missing physical identity remains fail-closed.

## Validation
Run shared Core tests, platform identity tests, Windows/macOS app builds, package smoke, I/O benchmark and CodeQL.