### PR TITLE
Align reuse UI and release acceptance with durable commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ tests/
 
 Photo Organizer must never delete, move, rename, modify, or overwrite source media on the camera card.
 
-Copy completion is **not** equivalent to SD-card reuse approval. Reuse approval requires a fresh complete card scan, mount-session storage-identity checks, and byte-for-byte destination verification with file size and SHA-256.
+Copy completion is **not** equivalent to SD-card reuse approval. Reuse approval requires a fresh complete card scan, mount-session and physical-storage identity checks, an independent destination match by file size and SHA-256, and a platform-specific durable destination commit so the green state does not rely only on volatile operating-system or device caches.
 
 Supported import/reuse-verification scope:
 
@@ -60,7 +60,7 @@ The Avalonia application provides one Windows/macOS workflow for:
 
 Closing the workflow window while idle hides it instead of stopping camera-card monitoring. Use the tray/menu-bar menu to show the window again or explicitly quit. Graceful quit is rejected during an active import. Starting with `--background`, or enabling the background-start preference, keeps the main window hidden until a camera card is detected or the user opens it from the tray/menu bar.
 
-A green `保存先コピー検証済み — SDカード再利用可能` state is produced only by the shared Core after final post-import verification. It is never persisted across application restarts.
+A green `保存先コピー検証済み — SDカード再利用可能` state is produced only by the shared Core after the post-import full-card rescan, fresh destination byte verification, durable destination synchronization, and final storage-identity checks. It is never persisted across application restarts. Green means one specified destination copy was proven; it does not mean a second independent backup exists.
 
 ## Development
 

--- a/docs/RELEASE_ACCEPTANCE.md
+++ b/docs/RELEASE_ACCEPTANCE.md
@@ -55,8 +55,25 @@ Use disposable/test media with independent ground-truth copies. Do not begin acc
 - [ ] Same-name identical bytes are treated as an already-backed-up duplicate and no unnecessary collision copy is created.
 - [ ] Reusing a camera filename with the same size but different bytes is never mistaken for an old import.
 - [ ] If a supported file copy fails, the run remains blocked rather than silently declaring success; rerunning safely skips files already proven byte-identical and retries the remaining work under a fresh transaction.
-- [ ] Copy completion does not show the green reuse state before the post-import rescan and SHA-256 verification finish.
-- [ ] Green `保存先コピー検証済み — SDカード再利用可能` appears only after every currently supported file on the card has an independent destination size+SHA-256 match.
+- [ ] Copy completion does not show the green reuse state before the post-import rescan, fresh SHA-256 verification, durable destination synchronization, and final storage-identity checks finish.
+- [ ] Green `保存先コピー検証済み — SDカード再利用可能` appears only after every currently supported file on the card has an independent destination size+SHA-256 match whose destination can be durably synchronized.
+- [ ] The green detail/log explicitly reports durable destination synchronization; it must not describe a cache-readable SHA-256 match alone as sufficient proof.
+
+## Durable destination interruption acceptance
+
+This section is intentionally destructive. Use a **disposable destination device/filesystem** and keep independent ground-truth copies elsewhere. Never perform this test with irreplaceable photos, a production photo library, or a storage device whose filesystem damage would matter.
+
+Run this on both Windows and macOS using a removable destination device where an abrupt disconnect is practical:
+
+- [ ] Import a representative JPG/RAW/video set and wait for the verified green state.
+- [ ] Record the exact destination file list, sizes, and independent ground-truth SHA-256 values before the interruption.
+- [ ] Without performing a normal clean eject, abruptly disconnect the disposable destination shortly after green is displayed. Do not disconnect the camera card as part of this case.
+- [ ] Reconnect/remount the destination, run the operating system's appropriate filesystem check if the abrupt disconnect caused a filesystem warning, and independently hash every copied destination file.
+- [ ] Every verified file remains present and byte-identical to ground truth; no final library entry exists only as a lost volatile-cache write.
+- [ ] Repeat the case at least once with a larger file/video so the storage write path is meaningfully exercised.
+- [ ] Record destination device/filesystem/controller details and any OS warnings. A filesystem or device that cannot safely support the durability contract blocks release acceptance for that tested configuration rather than weakening the green-state definition.
+
+This acceptance case validates the practical storage path but is not a mathematical guarantee against defective hardware or firmware that lies about flush completion. The application must still fail closed whenever the operating system reports a durability operation failure.
 
 ## Repeated shooting workflow
 
@@ -72,7 +89,7 @@ For every cycle:
 - [ ] Only genuinely new bytes consume new destination space.
 - [ ] Duplicate-only import does not create an empty event folder.
 - [ ] Event date is based on pending/new media when present.
-- [ ] Final verification covers all supported media currently visible on the card.
+- [ ] Final verification covers all supported media currently visible on the card and includes durable synchronization of the matched destination copies.
 
 ## Failure and race scenarios
 
@@ -87,7 +104,7 @@ For every cycle:
 - [ ] Change the physical-device mapping associated with an otherwise unchanged mounted-volume identity: the previous session is invalidated.
 - [ ] Insert a second camera card while the first is being scanned/imported: active target does not switch and the second card is queued.
 - [ ] Remove a queued second card before it becomes active: it is removed from the queue and is not scanned from stale state.
-- [ ] Add a new supported file to the card between initial scan and final verification: final rescan includes it, and reuse cannot become safe unless that file also exists byte-identically in the destination.
+- [ ] Add a new supported file to the card between initial scan and final verification: final rescan includes it, and reuse cannot become safe unless that file also exists byte-identically and durably in the destination.
 - [ ] Make an initially scanned supported file disappear before final verification: reuse is blocked.
 - [ ] Force-kill the process during import, relaunch it, and confirm no previous reuse-safe state is restored.
 

--- a/src/PhotoOrganizer.App/MainWindow.axaml
+++ b/src/PhotoOrganizer.App/MainWindow.axaml
@@ -85,7 +85,7 @@
     <Grid Grid.Row="3" ColumnDefinitions="Auto,Auto,*,Auto" ColumnSpacing="10">
       <Button Grid.Column="0" Content="取り込み開始" Click="Import_Click"
               IsEnabled="{Binding CanImport}" MinWidth="120" />
-      <Button Grid.Column="1" Content="キャンセル" Click="Cancel_Click"
+      <Button Grid.Row="0" Grid.Column="1" Content="キャンセル" Click="Cancel_Click"
               IsEnabled="{Binding CanCancel}" />
       <TextBlock Grid.Column="2" Text="{Binding ProgressLabel}" VerticalAlignment="Center" Opacity="0.75" />
       <TextBlock Grid.Column="3" Text="対象: JPG/JPEG・設定済みRAW・MOV/MP4"
@@ -99,14 +99,14 @@
         <TextBlock Text="{Binding SafetyHeadline}" FontSize="17" FontWeight="SemiBold"
                    Foreground="{Binding SafetyBrush}" TextWrapping="Wrap" />
         <TextBlock Text="{Binding SafetyDetail}" TextWrapping="Wrap" />
-        <TextBlock Text="緑表示は指定保存先1か所への実ファイル検証を意味します。別媒体への二重バックアップ済みという意味ではありません。"
+        <TextBlock Text="緑表示は指定保存先1か所への実ファイル照合と永続媒体への同期を確認したことを意味します。別媒体への二重バックアップ済みという意味ではありません。"
                    Opacity="0.65" TextWrapping="Wrap" />
       </StackPanel>
     </Border>
 
     <Border Grid.Row="5" Padding="10" CornerRadius="6" BorderThickness="1">
       <TextBlock TextWrapping="Wrap"
-                 Text="重要: コピー処理が完了しただけではSDカードを再利用しないでください。取り込み後のカード全体再スキャンと保存先のサイズ・SHA-256照合が完了した場合だけ再利用可能になります。" />
+                 Text="重要: コピー処理が完了しただけではSDカードを再利用しないでください。取り込み後のカード全体再スキャン、保存先のサイズ・SHA-256照合、永続媒体への同期（durable commit）が完了した場合だけ再利用可能になります。" />
     </Border>
 
     <TextBlock Grid.Row="6" Text="ログ" FontWeight="SemiBold" />

--- a/src/PhotoOrganizer.App/MainWindowViewModel.cs
+++ b/src/PhotoOrganizer.App/MainWindowViewModel.cs
@@ -224,7 +224,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged, IDisposable
             SelectedSdPath = result.Session!.CardRoot;
             RemoveQueuedCard(result.Session.CardRoot);
             UpdateCounts(result.Session.Files);
-            SetNotVerified("完全スキャン済み。取り込みと保存先実ファイル検証が完了するまでSDカードを再利用しないでください。");
+            SetNotVerified("完全スキャン済み。取り込み後の再スキャン、保存先実ファイルのサイズ・SHA-256照合、永続媒体への同期が完了するまでSDカードを再利用しないでください。");
             ProgressLabel = "取り込み準備完了";
             AppendLog($"スキャン完了: {result.Session.Files.Count} 件 / {CountLabel}");
             RequestShowWindow?.Invoke();
@@ -262,7 +262,7 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged, IDisposable
                 }
                 if (update.Phase == ImportProgressPhase.Rescanning)
                 {
-                    AppendLog("コピー処理完了。SDカード全体の再スキャンと実bytes検証を開始します。");
+                    AppendLog("コピー処理完了。SDカード全体の再スキャン、実bytes検証、保存先の永続化確認を開始します。");
                 }
             });
 
@@ -282,10 +282,10 @@ public sealed class MainWindowViewModel : INotifyPropertyChanged, IDisposable
             {
                 var verified = result.Verification?.Verified ?? 0;
                 SafetyHeadline = "保存先コピー検証済み — SDカード再利用可能";
-                SafetyDetail = $"対象メディア {verified} 件について、取り込み後のSD再スキャンと保存先実ファイルのサイズ・SHA-256一致を確認済みです。これは指定保存先1か所へのコピー検証であり、二重バックアップ済みという意味ではありません。";
+                SafetyDetail = $"対象メディア {verified} 件について、取り込み後のSD再スキャン、保存先実ファイルのサイズ・SHA-256一致、永続媒体への同期（durable commit）を確認済みです。これは指定保存先1か所へのコピー検証であり、二重バックアップ済みという意味ではありません。";
                 SafetyBrush = Brushes.ForestGreen;
-                ProgressLabel = "保存先コピー検証済み";
-                AppendLog($"最終確認完了: {verified} 件を実ファイルとSHA-256照合しました。SDカードを再利用できます。");
+                ProgressLabel = "保存先コピー・永続化検証済み";
+                AppendLog($"最終確認完了: {verified} 件を実ファイルとSHA-256照合し、保存先への永続化を確認しました。SDカードを再利用できます。");
             }
             else
             {


### PR DESCRIPTION
Closes #41.

## What changed
- green reuse UI now explicitly reports post-import rescan, SHA-256 equality, and durable destination commit;
- main safety notice explains that copy completion alone is insufficient and that green is one verified destination copy, not double backup;
- README matches the normative durable-commit safety contract;
- release acceptance now requires durable synchronization before green approval;
- adds a disposable-destination abrupt-disconnect/remount/independent-rehash acceptance case on Windows and macOS, with explicit warnings never to use production or irreplaceable data.

## Why
After #38, the implementation was stronger than several user-facing and release-testing descriptions. This PR makes the product contract, UI, and physical acceptance criteria agree.

## Validation
Normal Windows/macOS CI, package smoke and CodeQL must remain green.