### PR TITLE
Re-hash destination after durable sync before reuse approval

### DIFF
--- a/src/PhotoOrganizer.Core/FormatSafetyVerifier.cs
+++ b/src/PhotoOrganizer.Core/FormatSafetyVerifier.cs
@@ -59,10 +59,9 @@ public sealed class FormatSafetyVerifier
         var errors = new List<string>();
         var verified = 0;
 
-        // This cache exists only for this one *fresh* verification invocation. It
-        // prevents rereading a destination candidate for multiple source files but
-        // is discarded immediately afterward. A later reuse decision always hashes
-        // destination bytes again from disk.
+        // This cache exists only for this one fresh verification invocation. It is
+        // a prefilter/hint only: a candidate that appears to match must still be
+        // durably synchronized and then hashed again before it can authorize reuse.
         var destinationHashCache = new Dictionary<string, string>(PathComparer.Instance);
 
         foreach (var source in supported)
@@ -111,12 +110,26 @@ public sealed class FormatSafetyVerifier
                         }
 
                         // A cache-readable SHA match is not sufficient for SD reuse.
-                        // Force the matched independent destination copy to durable
-                        // storage before allowing it to count as verified.
+                        // Synchronize the matched independent destination first.
                         var durability = _durability.EnsureDurable(candidate);
                         if (!durability.Success)
                         {
                             errors.Add($"{candidate}: {durability.Error ?? "durable destination commit failed"}");
+                            continue;
+                        }
+
+                        // Hash again *after* durable synchronization. Another process
+                        // may have replaced or modified the candidate between the first
+                        // hash handle closing and the durability handle opening. The
+                        // earlier hash is therefore only a prefilter, never final proof.
+                        var postDurabilityHash = await _hasher
+                            .Sha256Async(candidate, cancellationToken)
+                            .ConfigureAwait(false);
+                        destinationHashCache[candidate] = postDurabilityHash;
+
+                        if (!string.Equals(sourceHash, postDurabilityHash, StringComparison.Ordinal))
+                        {
+                            errors.Add($"{candidate}: destination bytes changed during durable verification.");
                             continue;
                         }
 

--- a/src/PhotoOrganizer.Core/FormatSafetyVerifier.cs
+++ b/src/PhotoOrganizer.Core/FormatSafetyVerifier.cs
@@ -59,10 +59,12 @@ public sealed class FormatSafetyVerifier
         var errors = new List<string>();
         var verified = 0;
 
-        // This cache exists only for this one fresh verification invocation. It is
-        // a prefilter/hint only: a candidate that appears to match must still be
-        // durably synchronized and then hashed again before it can authorize reuse.
+        // The first cache is only a cheap within-invocation prefilter. The second
+        // contains only hashes observed *after* successful durable synchronization
+        // and is the only cache that may directly satisfy another identical source
+        // during this same fresh verification invocation.
         var destinationHashCache = new Dictionary<string, string>(PathComparer.Instance);
+        var durableHashCache = new Dictionary<string, string>(PathComparer.Instance);
 
         foreach (var source in supported)
         {
@@ -98,6 +100,17 @@ public sealed class FormatSafetyVerifier
 
                     try
                     {
+                        if (durableHashCache.TryGetValue(candidate, out var durableHash))
+                        {
+                            if (string.Equals(sourceHash, durableHash, StringComparison.Ordinal))
+                            {
+                                matched = true;
+                                break;
+                            }
+
+                            continue;
+                        }
+
                         if (!destinationHashCache.TryGetValue(candidate, out var destinationHash))
                         {
                             destinationHash = await _hasher.Sha256Async(candidate, cancellationToken).ConfigureAwait(false);
@@ -133,6 +146,7 @@ public sealed class FormatSafetyVerifier
                             continue;
                         }
 
+                        durableHashCache[candidate] = postDurabilityHash;
                         matched = true;
                         break;
                     }

--- a/tests/PhotoOrganizer.Core.Tests/DurableCopySafetyTests.cs
+++ b/tests/PhotoOrganizer.Core.Tests/DurableCopySafetyTests.cs
@@ -65,6 +65,30 @@ public sealed class DurableCopySafetyTests
         Assert.IsTrue(result.Errors.Any(error => error.Contains("simulated durability failure", StringComparison.Ordinal)));
     }
 
+    [TestMethod]
+    public async Task FinalReuseVerification_DestinationMutationDuringDurabilityIsRehashedAndBlocked()
+    {
+        using var temp = new TempDirectory();
+        var sourceDirectory = Directory.CreateDirectory(Path.Combine(temp.Path, "source")).FullName;
+        var destinationDirectory = Directory.CreateDirectory(Path.Combine(temp.Path, "destination")).FullName;
+        var source = Path.Combine(sourceDirectory, "photo.jpg");
+        var destination = Path.Combine(destinationDirectory, "photo.jpg");
+        File.WriteAllText(source, "identical-before-durability");
+        File.WriteAllText(destination, "identical-before-durability");
+
+        var result = await new FormatSafetyVerifier(
+                new MediaClassifier(),
+                durability: new MutateDuringDurabilityService())
+            .VerifyAsync([source], destinationDirectory);
+
+        Assert.IsFalse(result.IsSafe);
+        Assert.AreEqual(0, result.Verified);
+        CollectionAssert.Contains(result.UnverifiedFiles.ToList(), source);
+        Assert.AreEqual("mutated-during-durability", File.ReadAllText(destination));
+        Assert.IsTrue(result.Errors.Any(error =>
+            error.Contains("changed during durable verification", StringComparison.Ordinal)));
+    }
+
     private sealed class FailAfterMoveDurabilityService : IFileDurabilityService
     {
         public FinalizeFileResult FinalizeNewFile(string temporaryPath, string finalPath, DateTime lastWriteUtc)
@@ -88,6 +112,20 @@ public sealed class DurableCopySafetyTests
 
         public DurabilityResult EnsureDurable(string filePath) =>
             new(false, "simulated durability failure");
+    }
+
+    private sealed class MutateDuringDurabilityService : IFileDurabilityService
+    {
+        public FinalizeFileResult FinalizeNewFile(string temporaryPath, string finalPath, DateTime lastWriteUtc) =>
+            throw new NotSupportedException();
+
+        public DurabilityResult EnsureDurable(string filePath)
+        {
+            File.WriteAllText(filePath, "mutated-during-durability");
+            using var stream = new FileStream(filePath, FileMode.Open, FileAccess.ReadWrite, FileShare.Read);
+            stream.Flush(flushToDisk: true);
+            return new DurabilityResult(true);
+        }
     }
 
     private sealed class TempDirectory : IDisposable

--- a/tests/PhotoOrganizer.Core.Tests/IoOptimizationTests.cs
+++ b/tests/PhotoOrganizer.Core.Tests/IoOptimizationTests.cs
@@ -81,8 +81,8 @@ public sealed class IoOptimizationTests
 
         Assert.IsTrue(first.IsSafe);
         Assert.IsTrue(second.IsSafe);
-        Assert.AreEqual(2, hasher.CallCount(destination),
-            "Destination bytes must be freshly hashed on every reuse-verification invocation.");
+        Assert.AreEqual(4, hasher.CallCount(destination),
+            "Each fresh reuse-verification invocation must read the destination before and after durable synchronization; the post-durability proof may be reused only within that invocation.");
     }
 
     private sealed class CountingHasher : IFileHasher

--- a/tools/PhotoOrganizer.IoBenchmark/Program.cs
+++ b/tools/PhotoOrganizer.IoBenchmark/Program.cs
@@ -101,11 +101,15 @@ static async Task RunCandidateCacheScenario(
         .VerifyAsync(matchingSources, destinationRoot);
     stopwatch.Stop();
 
-    var maximumExpectedVerificationBytes = (long)(matchingSources.Count + destinationCandidateCount) * fileSize;
+    // Final reuse verification must read each successful destination candidate once
+    // as a prefilter and once again after durable synchronization. A post-durability
+    // proof may then be reused for identical sources within the same invocation.
+    var maximumExpectedVerificationBytes =
+        (long)(matchingSources.Count + (destinationCandidateCount * 2)) * fileSize;
     Console.WriteLine(
         $"fresh-verification: safe={verification.IsSafe}, verified={verification.Verified}/{verification.Total}, " +
         $"hashCalls={verificationHasher.HashCalls}, hashBytesRead={verificationHasher.BytesRead:N0}, " +
-        $"maxExpectedWithPer-operationCache={maximumExpectedVerificationBytes:N0}, " +
+        $"maxExpectedWithPostDurabilityRehash={maximumExpectedVerificationBytes:N0}, " +
         $"elapsedMs={stopwatch.Elapsed.TotalMilliseconds:F1}");
 
     if (!verification.IsSafe)
@@ -115,7 +119,7 @@ static async Task RunCandidateCacheScenario(
 
     if (verificationHasher.BytesRead > maximumExpectedVerificationBytes)
     {
-        throw new InvalidOperationException("A destination candidate appears to have been rehashed within one fresh verification.");
+        throw new InvalidOperationException("A destination candidate exceeded the expected pre/post-durability hashing budget.");
     }
 }
 


### PR DESCRIPTION
Closes #43.

## What changed
- final reuse verification treats the pre-durability destination SHA only as a candidate prefilter;
- after durable synchronization succeeds, the destination is hashed again from a fresh file handle;
- SD reuse is blocked if the post-durability SHA differs from the source;
- the within-run destination hash cache is updated only with the fresh post-durability result;
- adds a regression test that mutates the destination inside the durability operation and proves the old matching SHA cannot produce green approval.

## Safety
This closes the gap between first SHA verification and durable synchronization. Source media is still never modified, and destination data is not deleted or overwritten by production code.

## Validation
Shared safety tests, Windows/macOS platform tests, builds, package smoke and CodeQL must pass.