### PR TITLE
Use one mounted-volume snapshot per storage identity capture

### DIFF
--- a/src/PhotoOrganizer.Core/StorageIdentity.cs
+++ b/src/PhotoOrganizer.Core/StorageIdentity.cs
@@ -189,17 +189,17 @@ public sealed class StorageSessionTracker
     public event Action<string>? VolumeMounted;
     public event Action<string>? VolumeRemoved;
 
-    public void Refresh()
+    public void Refresh() => _ = RefreshAndGetSnapshot();
+
+    private Dictionary<string, MountedVolumeInfo> RefreshAndGetSnapshot()
     {
+        var comparer = _provider.PathComparison == StringComparison.OrdinalIgnoreCase
+            ? StringComparer.OrdinalIgnoreCase
+            : StringComparer.Ordinal;
         var mounted = _provider.GetMountedVolumes()
             .Where(v => !string.IsNullOrWhiteSpace(v.RootPath) && !string.IsNullOrWhiteSpace(v.Fingerprint))
             .Select(v => v with { RootPath = PathSafety.Normalize(v.RootPath) })
-            .ToDictionary(
-                v => v.RootPath,
-                v => v,
-                _provider.PathComparison == StringComparison.OrdinalIgnoreCase
-                    ? StringComparer.OrdinalIgnoreCase
-                    : StringComparer.Ordinal);
+            .ToDictionary(v => v.RootPath, v => v, comparer);
 
         List<string> removed = [];
         List<string> added = [];
@@ -233,6 +233,7 @@ public sealed class StorageSessionTracker
 
         foreach (var root in removed) VolumeRemoved?.Invoke(root);
         foreach (var root in added) VolumeMounted?.Invoke(root);
+        return mounted;
     }
 
     public void MarkRemoved(string rootPath)
@@ -251,12 +252,28 @@ public sealed class StorageSessionTracker
     {
         if (string.IsNullOrWhiteSpace(path)) return null;
         if (!PathSafety.TryValidateDirectFilesystemPath(path, out _)) return null;
-        Refresh();
 
-        var volume = _provider.ResolveVolumeForPath(path);
+        string normalizedPath;
+        try
+        {
+            normalizedPath = PathSafety.Normalize(path);
+        }
+        catch
+        {
+            return null;
+        }
+
+        // Resolve the path from the exact same mounted-volume snapshot that refreshed
+        // the process-local sessions. This avoids both a second expensive platform
+        // enumeration and a split-brain result from two different mount snapshots.
+        var mounted = RefreshAndGetSnapshot();
+        var volume = mounted.Values
+            .Where(v => PathSafety.IsSameOrDescendant(normalizedPath, v.RootPath, _provider.PathComparison))
+            .OrderByDescending(v => v.RootPath.Length)
+            .FirstOrDefault();
         if (volume is null || string.IsNullOrWhiteSpace(volume.Fingerprint)) return null;
 
-        var root = PathSafety.Normalize(volume.RootPath);
+        var root = volume.RootPath;
         lock (_gate)
         {
             if (!_sessions.TryGetValue(root, out var entry)) return null;

--- a/tests/PhotoOrganizer.Core.Tests/StorageIdentityTests.cs
+++ b/tests/PhotoOrganizer.Core.Tests/StorageIdentityTests.cs
@@ -21,6 +21,25 @@ public sealed class StorageIdentityTests
     }
 
     [TestMethod]
+    public void Capture_UsesOneMountedSnapshotAndDoesNotResolveAgain()
+    {
+        using var temp = new TempDirectory();
+        var provider = new FakeProvider(temp.Path, "volume-a");
+        var tracker = new StorageSessionTracker(provider);
+
+        var snapshot = tracker.Capture(Path.Combine(temp.Path, "future", "destination"));
+
+        Assert.IsNotNull(snapshot);
+        Assert.AreEqual(1, provider.GetMountedVolumesCallCount);
+        Assert.AreEqual(0, provider.ResolveVolumeForPathCallCount);
+
+        Assert.IsTrue(tracker.Matches(snapshot, temp.Path));
+        Assert.AreEqual(2, provider.GetMountedVolumesCallCount,
+            "Matches should perform one fresh mounted-volume snapshot, not two enumerations.");
+        Assert.AreEqual(0, provider.ResolveVolumeForPathCallCount);
+    }
+
+    [TestMethod]
     public void RemovalAndReinsert_InvalidatesOldSessionEvenForSameFingerprint()
     {
         using var temp = new TempDirectory();
@@ -151,12 +170,15 @@ public sealed class StorageIdentityTests
         public bool Mounted { get; set; } = true;
         public string Fingerprint { get; set; }
         public string? PhysicalDeviceFingerprint { get; set; }
+        public int GetMountedVolumesCallCount { get; private set; }
+        public int ResolveVolumeForPathCallCount { get; private set; }
         public StringComparison PathComparison => OperatingSystem.IsWindows()
             ? StringComparison.OrdinalIgnoreCase
             : StringComparison.Ordinal;
 
         public IReadOnlyList<MountedVolumeInfo> GetMountedVolumes()
         {
+            GetMountedVolumesCallCount++;
             if (!Mounted) return [];
             return [new MountedVolumeInfo(
                 _root,
@@ -168,6 +190,7 @@ public sealed class StorageIdentityTests
 
         public MountedVolumeInfo? ResolveVolumeForPath(string path)
         {
+            ResolveVolumeForPathCallCount++;
             if (!Mounted || string.IsNullOrWhiteSpace(Fingerprint)) return null;
             if (!PathSafety.IsSameOrDescendant(path, _root, PathComparison)) return null;
             return new MountedVolumeInfo(


### PR DESCRIPTION
Closes #45.

## What changed
- `StorageSessionTracker.Capture()` now refreshes sessions and resolves the target path from that exact mounted-volume snapshot;
- removes the second provider `ResolveVolumeForPath()` enumeration from Capture/Matches;
- chooses the deepest matching mounted root, including for safe missing destination leaf components;
- retains removal, volume-fingerprint and physical-device replacement invalidation semantics;
- adds call-count regression coverage proving one provider enumeration per Capture/Matches check.

## Impact
On macOS this avoids a second full set of `diskutil info -plist` calls for every storage identity check and removes the consistency window between two separate mount snapshots.

## Validation
Shared safety tests, platform storage identity tests, Windows/macOS builds, package smoke and CodeQL must pass.