### PR TITLE
プラットフォームアダプタのテストを大幅拡充

### DIFF
--- a/src/PhotoOrganizer.App/BoundedProcessRunner.cs
+++ b/src/PhotoOrganizer.App/BoundedProcessRunner.cs
@@ -1,0 +1,68 @@
+using System.Diagnostics;
+
+namespace PhotoOrganizer.App;
+
+internal sealed record BoundedProcessResult(
+    int ExitCode,
+    string StandardOutput,
+    string StandardError,
+    bool TimedOut);
+
+internal static class BoundedProcessRunner
+{
+    public static BoundedProcessResult? Run(
+        string fileName,
+        IEnumerable<string> arguments,
+        TimeSpan timeout)
+    {
+        if (string.IsNullOrWhiteSpace(fileName)) return null;
+        if (timeout <= TimeSpan.Zero) return null;
+
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = fileName,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+
+            foreach (var argument in arguments)
+            {
+                process.StartInfo.ArgumentList.Add(argument);
+            }
+
+            if (!process.Start()) return null;
+
+            // Drain both pipes concurrently before waiting. This prevents a child with
+            // enough stderr/stdout output to fill an OS pipe from deadlocking the parent.
+            var stdout = process.StandardOutput.ReadToEndAsync();
+            var stderr = process.StandardError.ReadToEndAsync();
+            var timeoutMilliseconds = timeout.TotalMilliseconds >= int.MaxValue
+                ? int.MaxValue
+                : Math.Max(1, (int)Math.Ceiling(timeout.TotalMilliseconds));
+
+            if (!process.WaitForExit(timeoutMilliseconds))
+            {
+                try { process.Kill(entireProcessTree: true); } catch { }
+                try { process.WaitForExit(1000); } catch { }
+                return new BoundedProcessResult(-1, string.Empty, string.Empty, TimedOut: true);
+            }
+
+            return new BoundedProcessResult(
+                process.ExitCode,
+                stdout.GetAwaiter().GetResult(),
+                stderr.GetAwaiter().GetResult(),
+                TimedOut: false);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/src/PhotoOrganizer.App/MacDiskutilInfoParser.cs
+++ b/src/PhotoOrganizer.App/MacDiskutilInfoParser.cs
@@ -1,0 +1,97 @@
+using System.Xml.Linq;
+
+namespace PhotoOrganizer.App;
+
+internal sealed record MacStorageIdentity(
+    string VolumeFingerprint,
+    string? PhysicalDeviceFingerprint);
+
+internal static class MacDiskutilInfoParser
+{
+    public static MacStorageIdentity? Parse(string? output)
+    {
+        if (string.IsNullOrWhiteSpace(output)) return null;
+
+        try
+        {
+            var document = XDocument.Parse(output, LoadOptions.None);
+            var dictionary = document.Root?.Name.LocalName == "dict"
+                ? document.Root
+                : document.Root?.Elements().FirstOrDefault(element => element.Name.LocalName == "dict");
+            if (dictionary is null) return null;
+
+            // Prefer persistent filesystem/partition identities. DeviceIdentifier is
+            // intentionally the last fallback because BSD disk numbers are ephemeral.
+            var persistentVolumeId = FirstNonEmpty(
+                GetPlistString(dictionary, "VolumeUUID"),
+                GetPlistString(dictionary, "APFSVolumeUUID"),
+                GetPlistString(dictionary, "DiskUUID"),
+                GetPlistString(dictionary, "MediaUUID"));
+            var deviceIdentifier = Clean(GetPlistString(dictionary, "DeviceIdentifier"));
+            var volumeIdentity = FirstNonEmpty(persistentVolumeId, deviceIdentifier);
+            if (volumeIdentity is null) return null;
+
+            var parentWholeDisk = Clean(GetPlistString(dictionary, "ParentWholeDisk"));
+            var wholeDisk = GetPlistBoolean(dictionary, "WholeDisk") == true
+                ? deviceIdentifier
+                : null;
+            var physicalIdentity = FirstNonEmpty(parentWholeDisk, wholeDisk);
+
+            return new MacStorageIdentity(
+                "mac-volume:" + volumeIdentity,
+                physicalIdentity is null
+                    ? null
+                    : "mac-whole-disk:" + physicalIdentity);
+        }
+        catch
+        {
+            // Malformed or unexpected diskutil output is a failed identity proof.
+            return null;
+        }
+    }
+
+    private static string? FirstNonEmpty(params string?[] values)
+    {
+        foreach (var value in values)
+        {
+            var cleaned = Clean(value);
+            if (cleaned is not null) return cleaned;
+        }
+
+        return null;
+    }
+
+    private static string? Clean(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string? GetPlistString(XElement dictionary, string key)
+    {
+        var elements = dictionary.Elements().ToArray();
+        for (var index = 0; index + 1 < elements.Length; index++)
+        {
+            if (elements[index].Name.LocalName != "key" || elements[index].Value != key) continue;
+            return elements[index + 1].Name.LocalName == "string"
+                ? elements[index + 1].Value
+                : null;
+        }
+
+        return null;
+    }
+
+    private static bool? GetPlistBoolean(XElement dictionary, string key)
+    {
+        var elements = dictionary.Elements().ToArray();
+        for (var index = 0; index + 1 < elements.Length; index++)
+        {
+            if (elements[index].Name.LocalName != "key" || elements[index].Value != key) continue;
+            return elements[index + 1].Name.LocalName switch
+            {
+                "true" => true,
+                "false" => false,
+                _ => null
+            };
+        }
+
+        return null;
+    }
+}

--- a/src/PhotoOrganizer.App/PhotoOrganizer.App.csproj
+++ b/src/PhotoOrganizer.App/PhotoOrganizer.App.csproj
@@ -17,4 +17,8 @@
     <AvaloniaResource Include="Assets/**" />
     <ProjectReference Include="../PhotoOrganizer.Core/PhotoOrganizer.Core.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="PhotoOrganizer.App.Tests" />
+  </ItemGroup>
 </Project>

--- a/src/PhotoOrganizer.App/PlatformStorageVolumeProvider.cs
+++ b/src/PhotoOrganizer.App/PlatformStorageVolumeProvider.cs
@@ -4,17 +4,12 @@ using System.Management;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using System.Text;
-using System.Xml.Linq;
 using PhotoOrganizer.Core;
 
 namespace PhotoOrganizer.App;
 
 public sealed class PlatformStorageVolumeProvider : IStorageVolumeProvider
 {
-    private sealed record MacStorageIdentity(
-        string VolumeFingerprint,
-        string? PhysicalDeviceFingerprint);
-
     public StringComparison PathComparison => OperatingSystem.IsWindows()
         ? StringComparison.OrdinalIgnoreCase
         : StringComparison.Ordinal;
@@ -61,7 +56,7 @@ public sealed class PlatformStorageVolumeProvider : IStorageVolumeProvider
                 }
                 else if (OperatingSystem.IsMacOS())
                 {
-                    // diskutil already exposes both persistent volume identity and the
+                    // diskutil exposes both persistent volume identity and the
                     // containing whole-disk identity. Resolve them together so a safety
                     // refresh never launches a second subprocess for the same volume.
                     var identity = TryGetMacStorageIdentity(root);
@@ -212,72 +207,13 @@ public sealed class PlatformStorageVolumeProvider : IStorageVolumeProvider
             _ = stderr.GetAwaiter().GetResult();
             if (process.ExitCode != 0 || string.IsNullOrWhiteSpace(output)) return null;
 
-            var document = XDocument.Parse(output, LoadOptions.None);
-            var dictionary = document.Root?.Elements().FirstOrDefault(element => element.Name.LocalName == "dict");
-            if (dictionary is null) return null;
-
-            // Prefer a persistent filesystem/partition identity. DeviceIdentifier is
-            // only a last-resort fallback because BSD disk numbers are ephemeral.
-            var persistentVolumeId = FirstNonEmpty(
-                GetPlistString(dictionary, "VolumeUUID"),
-                GetPlistString(dictionary, "APFSVolumeUUID"),
-                GetPlistString(dictionary, "DiskUUID"),
-                GetPlistString(dictionary, "MediaUUID"));
-            var deviceIdentifier = GetPlistString(dictionary, "DeviceIdentifier");
-            var volumeIdentity = FirstNonEmpty(persistentVolumeId, deviceIdentifier);
-            if (string.IsNullOrWhiteSpace(volumeIdentity)) return null;
-
-            var parentWholeDisk = GetPlistString(dictionary, "ParentWholeDisk");
-            var wholeDisk = GetPlistBoolean(dictionary, "WholeDisk") == true
-                ? deviceIdentifier
-                : null;
-            var physicalIdentity = FirstNonEmpty(parentWholeDisk, wholeDisk);
-
-            return new MacStorageIdentity(
-                "mac-volume:" + volumeIdentity,
-                string.IsNullOrWhiteSpace(physicalIdentity)
-                    ? null
-                    : "mac-whole-disk:" + physicalIdentity);
+            return MacDiskutilInfoParser.Parse(output);
         }
         catch
         {
             // Storage identity is a safety signal. Callers fail closed when unavailable.
             return null;
         }
-    }
-
-    private static string? FirstNonEmpty(params string?[] values) =>
-        values.FirstOrDefault(value => !string.IsNullOrWhiteSpace(value));
-
-    private static string? GetPlistString(XElement dictionary, string key)
-    {
-        var elements = dictionary.Elements().ToArray();
-        for (var index = 0; index + 1 < elements.Length; index++)
-        {
-            if (elements[index].Name.LocalName != "key" || elements[index].Value != key) continue;
-            return elements[index + 1].Name.LocalName == "string"
-                ? elements[index + 1].Value
-                : null;
-        }
-
-        return null;
-    }
-
-    private static bool? GetPlistBoolean(XElement dictionary, string key)
-    {
-        var elements = dictionary.Elements().ToArray();
-        for (var index = 0; index + 1 < elements.Length; index++)
-        {
-            if (elements[index].Name.LocalName != "key" || elements[index].Value != key) continue;
-            return elements[index + 1].Name.LocalName switch
-            {
-                "true" => true,
-                "false" => false,
-                _ => null
-            };
-        }
-
-        return null;
     }
 
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]

--- a/src/PhotoOrganizer.App/PlatformStorageVolumeProvider.cs
+++ b/src/PhotoOrganizer.App/PlatformStorageVolumeProvider.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Globalization;
 using System.Management;
 using System.Runtime.InteropServices;
@@ -172,48 +171,19 @@ public sealed class PlatformStorageVolumeProvider : IStorageVolumeProvider
     [SupportedOSPlatform("macos")]
     private static MacStorageIdentity? TryGetMacStorageIdentity(string root)
     {
-        try
+        var result = BoundedProcessRunner.Run(
+            "/usr/sbin/diskutil",
+            ["info", "-plist", root],
+            TimeSpan.FromSeconds(5));
+        if (result is null
+            || result.TimedOut
+            || result.ExitCode != 0
+            || string.IsNullOrWhiteSpace(result.StandardOutput))
         {
-            using var process = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "/usr/sbin/diskutil",
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    UseShellExecute = false,
-                    CreateNoWindow = true
-                }
-            };
-            process.StartInfo.ArgumentList.Add("info");
-            process.StartInfo.ArgumentList.Add("-plist");
-            process.StartInfo.ArgumentList.Add(root);
-
-            if (!process.Start()) return null;
-
-            // Begin draining both redirected pipes before waiting. Reading either
-            // pipe synchronously first can deadlock if the child blocks or fills the
-            // other pipe, which would make the nominal timeout ineffective.
-            var stdout = process.StandardOutput.ReadToEndAsync();
-            var stderr = process.StandardError.ReadToEndAsync();
-            if (!process.WaitForExit(5000))
-            {
-                try { process.Kill(entireProcessTree: true); } catch { }
-                try { process.WaitForExit(1000); } catch { }
-                return null;
-            }
-
-            var output = stdout.GetAwaiter().GetResult();
-            _ = stderr.GetAwaiter().GetResult();
-            if (process.ExitCode != 0 || string.IsNullOrWhiteSpace(output)) return null;
-
-            return MacDiskutilInfoParser.Parse(output);
-        }
-        catch
-        {
-            // Storage identity is a safety signal. Callers fail closed when unavailable.
             return null;
         }
+
+        return MacDiskutilInfoParser.Parse(result.StandardOutput);
     }
 
     [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]

--- a/src/PhotoOrganizer.App/StartupRegistrationFormatter.cs
+++ b/src/PhotoOrganizer.App/StartupRegistrationFormatter.cs
@@ -1,0 +1,44 @@
+using System.Security;
+
+namespace PhotoOrganizer.App;
+
+internal static class StartupRegistrationFormatter
+{
+    public static string BuildWindowsCommand(string executable, bool startInBackground)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executable);
+        return $"\"{executable}\"" + (startInBackground ? " --background" : string.Empty);
+    }
+
+    public static string BuildMacLaunchAgentPlist(
+        string label,
+        string executable,
+        bool startInBackground)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(label);
+        ArgumentException.ThrowIfNullOrWhiteSpace(executable);
+
+        var escapedLabel = SecurityElement.Escape(label) ?? label;
+        var escapedExecutable = SecurityElement.Escape(executable) ?? executable;
+        var arguments = new List<string>
+        {
+            $"    <string>{escapedExecutable}</string>"
+        };
+        if (startInBackground) arguments.Add("    <string>--background</string>");
+
+        return string.Join('\n',
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+            "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">",
+            "<plist version=\"1.0\">",
+            "<dict>",
+            $"  <key>Label</key><string>{escapedLabel}</string>",
+            "  <key>ProgramArguments</key>",
+            "  <array>",
+            string.Join('\n', arguments),
+            "  </array>",
+            "  <key>RunAtLoad</key><true/>",
+            "</dict>",
+            "</plist>",
+            string.Empty);
+    }
+}

--- a/src/PhotoOrganizer.App/StartupRegistrationService.cs
+++ b/src/PhotoOrganizer.App/StartupRegistrationService.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
 using Microsoft.Win32;
@@ -147,27 +146,12 @@ public sealed class StartupRegistrationService : IStartupRegistrationService
     private static void RunLaunchctl(params string[] arguments)
     {
         if (!File.Exists("/bin/launchctl")) return;
-        try
-        {
-            using var process = new Process
-            {
-                StartInfo = new ProcessStartInfo
-                {
-                    FileName = "/bin/launchctl",
-                    UseShellExecute = false,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
-                    CreateNoWindow = true
-                }
-            };
-            foreach (var argument in arguments) process.StartInfo.ArgumentList.Add(argument);
-            if (!process.Start()) return;
-            process.WaitForExit(3000);
-        }
-        catch
-        {
-            // The LaunchAgent file still controls the next-login state.
-        }
+        _ = BoundedProcessRunner.Run(
+            "/bin/launchctl",
+            arguments,
+            TimeSpan.FromSeconds(3));
+        // Failure is intentionally non-fatal here: the LaunchAgent file still controls
+        // the next-login state, while the settings UI will report the persisted state.
     }
 
     [DllImport("libSystem.B.dylib")]

--- a/src/PhotoOrganizer.App/StartupRegistrationService.cs
+++ b/src/PhotoOrganizer.App/StartupRegistrationService.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
-using System.Security;
 using Microsoft.Win32;
 
 namespace PhotoOrganizer.App;
@@ -84,7 +83,7 @@ public sealed class StartupRegistrationService : IStartupRegistrationService
             return false;
         }
 
-        var command = $"\"{executable}\"" + (startInBackground ? " --background" : string.Empty);
+        var command = StartupRegistrationFormatter.BuildWindowsCommand(executable, startInBackground);
         key.SetValue(WindowsValueName, command, RegistryValueKind.String);
         error = null;
         return true;
@@ -111,27 +110,10 @@ public sealed class StartupRegistrationService : IStartupRegistrationService
 
         var directory = Path.GetDirectoryName(plistPath)!;
         Directory.CreateDirectory(directory);
-        var escapedExecutable = SecurityElement.Escape(executable) ?? executable;
-        var arguments = new List<string>
-        {
-            $"    <string>{escapedExecutable}</string>"
-        };
-        if (startInBackground) arguments.Add("    <string>--background</string>");
-
-        var plist = string.Join('\n',
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
-            "<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">",
-            "<plist version=\"1.0\">",
-            "<dict>",
-            $"  <key>Label</key><string>{MacLabel}</string>",
-            "  <key>ProgramArguments</key>",
-            "  <array>",
-            string.Join('\n', arguments),
-            "  </array>",
-            "  <key>RunAtLoad</key><true/>",
-            "</dict>",
-            "</plist>",
-            string.Empty);
+        var plist = StartupRegistrationFormatter.BuildMacLaunchAgentPlist(
+            MacLabel,
+            executable,
+            startInBackground);
 
         var temporary = plistPath + ".tmp-" + Guid.NewGuid().ToString("N");
         File.WriteAllText(temporary, plist);

--- a/tests/PhotoOrganizer.App.Tests/BoundedProcessRunnerTests.cs
+++ b/tests/PhotoOrganizer.App.Tests/BoundedProcessRunnerTests.cs
@@ -1,0 +1,108 @@
+using System.Diagnostics;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PhotoOrganizer.App.Tests;
+
+[TestClass]
+public sealed class BoundedProcessRunnerTests
+{
+    [TestMethod]
+    public void SuccessfulCommand_CapturesStdoutAndExitCode()
+    {
+        var result = RunShell(
+            OperatingSystem.IsWindows() ? "echo hello" : "printf hello",
+            TimeSpan.FromSeconds(5));
+
+        Assert.IsNotNull(result);
+        Assert.IsFalse(result.TimedOut);
+        Assert.AreEqual(0, result.ExitCode);
+        Assert.AreEqual("hello", result.StandardOutput.Trim());
+    }
+
+    [TestMethod]
+    public void NonZeroCommand_CapturesStderrAndExitCode()
+    {
+        var script = OperatingSystem.IsWindows()
+            ? "echo problem 1>&2 & exit /b 7"
+            : "printf problem >&2; exit 7";
+
+        var result = RunShell(script, TimeSpan.FromSeconds(5));
+
+        Assert.IsNotNull(result);
+        Assert.IsFalse(result.TimedOut);
+        Assert.AreEqual(7, result.ExitCode);
+        StringAssert.Contains(result.StandardError, "problem");
+    }
+
+    [TestMethod]
+    public void SlowCommand_TimesOutAndReturnsPromptly()
+    {
+        var script = OperatingSystem.IsWindows()
+            ? "ping 127.0.0.1 -n 6 >nul"
+            : "sleep 5";
+        var stopwatch = Stopwatch.StartNew();
+
+        var result = RunShell(script, TimeSpan.FromMilliseconds(150));
+
+        stopwatch.Stop();
+        Assert.IsNotNull(result);
+        Assert.IsTrue(result.TimedOut);
+        Assert.IsTrue(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(4),
+            $"Timed command took too long to return: {stopwatch.Elapsed}.");
+    }
+
+    [TestMethod]
+    public void LargeStderr_DoesNotDeadlockRedirectedPipes()
+    {
+        var script = OperatingSystem.IsWindows()
+            ? "for /L %i in (1,1,12000) do @echo error-line 1>&2"
+            : "i=0; while [ $i -lt 12000 ]; do echo error-line >&2; i=$((i+1)); done";
+
+        var result = RunShell(script, TimeSpan.FromSeconds(15));
+
+        Assert.IsNotNull(result);
+        Assert.IsFalse(result.TimedOut);
+        Assert.AreEqual(0, result.ExitCode);
+        Assert.IsTrue(result.StandardError.Length > 64 * 1024);
+        StringAssert.Contains(result.StandardError, "error-line");
+    }
+
+    [TestMethod]
+    public void MissingExecutable_ReturnsNullInsteadOfThrowing()
+    {
+        var result = BoundedProcessRunner.Run(
+            Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"), "does-not-exist"),
+            [],
+            TimeSpan.FromSeconds(1));
+
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void NonPositiveTimeout_IsRejected()
+    {
+        var result = BoundedProcessRunner.Run(
+            OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sh",
+            [],
+            TimeSpan.Zero);
+
+        Assert.IsNull(result);
+    }
+
+    private static BoundedProcessResult? RunShell(string script, TimeSpan timeout)
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return BoundedProcessRunner.Run(
+                "cmd.exe",
+                ["/d", "/s", "/c", script],
+                timeout);
+        }
+
+        return BoundedProcessRunner.Run(
+            "/bin/sh",
+            ["-c", script],
+            timeout);
+    }
+}

--- a/tests/PhotoOrganizer.App.Tests/MacDiskutilInfoParserTests.cs
+++ b/tests/PhotoOrganizer.App.Tests/MacDiskutilInfoParserTests.cs
@@ -1,0 +1,217 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PhotoOrganizer.App.Tests;
+
+[TestClass]
+public sealed class MacDiskutilInfoParserTests
+{
+    [TestMethod]
+    public void VolumeUuid_IsPreferredOverAllFallbacks()
+    {
+        var result = Parse(
+            String("VolumeUUID", "volume-uuid"),
+            String("APFSVolumeUUID", "apfs-uuid"),
+            String("DiskUUID", "disk-uuid"),
+            String("MediaUUID", "media-uuid"),
+            String("DeviceIdentifier", "disk9s1"),
+            String("ParentWholeDisk", "disk9"));
+
+        AssertIdentity(result, "mac-volume:volume-uuid", "mac-whole-disk:disk9");
+    }
+
+    [TestMethod]
+    public void ApfsVolumeUuid_IsUsedWhenVolumeUuidMissing()
+    {
+        var result = Parse(
+            String("APFSVolumeUUID", "apfs-uuid"),
+            String("DeviceIdentifier", "disk3s2"),
+            String("ParentWholeDisk", "disk3"));
+
+        AssertIdentity(result, "mac-volume:apfs-uuid", "mac-whole-disk:disk3");
+    }
+
+    [TestMethod]
+    public void DiskUuid_IsUsedWhenHigherPriorityIdsMissing()
+    {
+        var result = Parse(
+            String("DiskUUID", "disk-uuid"),
+            String("DeviceIdentifier", "disk4s1"),
+            String("ParentWholeDisk", "disk4"));
+
+        AssertIdentity(result, "mac-volume:disk-uuid", "mac-whole-disk:disk4");
+    }
+
+    [TestMethod]
+    public void MediaUuid_IsUsedWhenHigherPriorityIdsMissing()
+    {
+        var result = Parse(
+            String("MediaUUID", "media-uuid"),
+            String("DeviceIdentifier", "disk5s1"),
+            String("ParentWholeDisk", "disk5"));
+
+        AssertIdentity(result, "mac-volume:media-uuid", "mac-whole-disk:disk5");
+    }
+
+    [TestMethod]
+    public void DeviceIdentifier_IsLastResortVolumeIdentity()
+    {
+        var result = Parse(
+            String("DeviceIdentifier", "disk6s1"),
+            String("ParentWholeDisk", "disk6"));
+
+        AssertIdentity(result, "mac-volume:disk6s1", "mac-whole-disk:disk6");
+    }
+
+    [TestMethod]
+    public void ParentWholeDisk_IsPreferredPhysicalIdentity()
+    {
+        var result = Parse(
+            String("VolumeUUID", "volume"),
+            String("DeviceIdentifier", "disk7"),
+            String("ParentWholeDisk", "disk-parent"),
+            Boolean("WholeDisk", true));
+
+        AssertIdentity(result, "mac-volume:volume", "mac-whole-disk:disk-parent");
+    }
+
+    [TestMethod]
+    public void WholeDiskTrue_UsesDeviceIdentifierAsPhysicalIdentity()
+    {
+        var result = Parse(
+            String("VolumeUUID", "whole-volume"),
+            String("DeviceIdentifier", "disk8"),
+            Boolean("WholeDisk", true));
+
+        AssertIdentity(result, "mac-volume:whole-volume", "mac-whole-disk:disk8");
+    }
+
+    [TestMethod]
+    public void WholeDiskFalse_DoesNotInventPhysicalIdentity()
+    {
+        var result = Parse(
+            String("VolumeUUID", "partition-volume"),
+            String("DeviceIdentifier", "disk8s1"),
+            Boolean("WholeDisk", false));
+
+        AssertIdentity(result, "mac-volume:partition-volume", null);
+    }
+
+    [TestMethod]
+    public void MissingPhysicalIdentity_PreservesVolumeButFailsPhysicalProofUpstream()
+    {
+        var result = Parse(String("VolumeUUID", "volume-only"));
+
+        AssertIdentity(result, "mac-volume:volume-only", null);
+    }
+
+    [TestMethod]
+    public void WhitespaceValues_AreTrimmedAndBlankFallbacksAreSkipped()
+    {
+        var result = Parse(
+            String("VolumeUUID", "   "),
+            String("APFSVolumeUUID", "  apfs-trimmed  "),
+            String("ParentWholeDisk", "  disk10  "));
+
+        AssertIdentity(result, "mac-volume:apfs-trimmed", "mac-whole-disk:disk10");
+    }
+
+    [TestMethod]
+    public void WrongValueType_IsIgnoredAndFallsBackSafely()
+    {
+        var result = Parse(
+            Integer("VolumeUUID", 123),
+            String("DiskUUID", "valid-disk-uuid"),
+            String("ParentWholeDisk", "disk11"));
+
+        AssertIdentity(result, "mac-volume:valid-disk-uuid", "mac-whole-disk:disk11");
+    }
+
+    [TestMethod]
+    public void WrongWholeDiskType_DoesNotTreatPartitionAsWholeDisk()
+    {
+        var result = Parse(
+            String("VolumeUUID", "volume"),
+            String("DeviceIdentifier", "disk12s1"),
+            String("WholeDisk", "true"));
+
+        AssertIdentity(result, "mac-volume:volume", null);
+    }
+
+    [TestMethod]
+    public void MissingVolumeIdentity_ReturnsNull()
+    {
+        var result = Parse(
+            String("ParentWholeDisk", "disk13"),
+            Boolean("WholeDisk", false));
+
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public void EmptyOutput_ReturnsNull()
+    {
+        Assert.IsNull(MacDiskutilInfoParser.Parse(string.Empty));
+        Assert.IsNull(MacDiskutilInfoParser.Parse("   \n\t"));
+        Assert.IsNull(MacDiskutilInfoParser.Parse(null));
+    }
+
+    [TestMethod]
+    public void MalformedXml_ReturnsNull()
+    {
+        Assert.IsNull(MacDiskutilInfoParser.Parse("<plist><dict><key>VolumeUUID</key>"));
+    }
+
+    [TestMethod]
+    public void MissingDictionary_ReturnsNull()
+    {
+        Assert.IsNull(MacDiskutilInfoParser.Parse("<plist version=\"1.0\"><array/></plist>"));
+    }
+
+    [TestMethod]
+    public void DirectDictionaryRoot_IsAccepted()
+    {
+        var result = MacDiskutilInfoParser.Parse(
+            "<dict><key>VolumeUUID</key><string>direct</string>" +
+            "<key>ParentWholeDisk</key><string>disk14</string></dict>");
+
+        AssertIdentity(result, "mac-volume:direct", "mac-whole-disk:disk14");
+    }
+
+    [TestMethod]
+    public void UnknownKeys_DoNotChangeIdentitySelection()
+    {
+        var result = Parse(
+            String("Unrelated", "value"),
+            Boolean("Writable", true),
+            String("VolumeUUID", "known"),
+            String("ParentWholeDisk", "disk15"));
+
+        AssertIdentity(result, "mac-volume:known", "mac-whole-disk:disk15");
+    }
+
+    private static MacStorageIdentity? Parse(params string[] entries) =>
+        MacDiskutilInfoParser.Parse(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" +
+            "<plist version=\"1.0\"><dict>" +
+            string.Concat(entries) +
+            "</dict></plist>");
+
+    private static string String(string key, string value) =>
+        $"<key>{key}</key><string>{value}</string>";
+
+    private static string Integer(string key, int value) =>
+        $"<key>{key}</key><integer>{value}</integer>";
+
+    private static string Boolean(string key, bool value) =>
+        $"<key>{key}</key><{(value ? "true" : "false")}/>";
+
+    private static void AssertIdentity(
+        MacStorageIdentity? actual,
+        string expectedVolume,
+        string? expectedPhysical)
+    {
+        Assert.IsNotNull(actual);
+        Assert.AreEqual(expectedVolume, actual.VolumeFingerprint);
+        Assert.AreEqual(expectedPhysical, actual.PhysicalDeviceFingerprint);
+    }
+}

--- a/tests/PhotoOrganizer.App.Tests/PlatformStorageIdentityTests.cs
+++ b/tests/PhotoOrganizer.App.Tests/PlatformStorageIdentityTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PhotoOrganizer.Core;
 
 namespace PhotoOrganizer.App.Tests;
 
@@ -9,9 +10,7 @@ public sealed class PlatformStorageIdentityTests
     public void SystemVolume_ResolvesVolumeAndPhysicalDeviceIdentity()
     {
         var provider = new PlatformStorageVolumeProvider();
-        var path = OperatingSystem.IsWindows()
-            ? Path.GetPathRoot(Environment.SystemDirectory)!
-            : "/";
+        var path = GetSystemVolumePath();
 
         var volume = provider.ResolveVolumeForPath(path);
 
@@ -26,9 +25,7 @@ public sealed class PlatformStorageIdentityTests
     public void SystemVolume_RepeatedResolutionKeepsSameIdentity()
     {
         var provider = new PlatformStorageVolumeProvider();
-        var path = OperatingSystem.IsWindows()
-            ? Path.GetPathRoot(Environment.SystemDirectory)!
-            : "/";
+        var path = GetSystemVolumePath();
 
         var first = provider.ResolveVolumeForPath(path);
         var second = provider.ResolveVolumeForPath(path);
@@ -37,5 +34,127 @@ public sealed class PlatformStorageIdentityTests
         Assert.IsNotNull(second);
         Assert.AreEqual(first.Fingerprint, second.Fingerprint);
         Assert.AreEqual(first.PhysicalDeviceFingerprint, second.PhysicalDeviceFingerprint);
+    }
+
+    [TestMethod]
+    public void SystemVolume_AppearsInMountedVolumeSnapshotAndIsMarkedSystem()
+    {
+        var provider = new PlatformStorageVolumeProvider();
+        var resolved = provider.ResolveVolumeForPath(GetSystemVolumePath());
+
+        Assert.IsNotNull(resolved);
+        var snapshot = provider.GetMountedVolumes();
+        var sameRoot = snapshot.SingleOrDefault(volume =>
+            string.Equals(
+                PathSafety.Normalize(volume.RootPath),
+                PathSafety.Normalize(resolved.RootPath),
+                provider.PathComparison));
+
+        Assert.IsNotNull(sameRoot);
+        Assert.IsTrue(sameRoot.IsSystem);
+        Assert.AreEqual(resolved.Fingerprint, sameRoot.Fingerprint);
+        Assert.AreEqual(resolved.PhysicalDeviceFingerprint, sameRoot.PhysicalDeviceFingerprint);
+    }
+
+    [TestMethod]
+    public void SystemVolume_UsesPlatformSpecificIdentityPrefixes()
+    {
+        var provider = new PlatformStorageVolumeProvider();
+        var volume = provider.ResolveVolumeForPath(GetSystemVolumePath());
+
+        Assert.IsNotNull(volume);
+        if (OperatingSystem.IsWindows())
+        {
+            StringAssert.StartsWith(volume.Fingerprint, "windows-volume:");
+            StringAssert.StartsWith(volume.PhysicalDeviceFingerprint!, "windows-physical-disk:");
+        }
+        else if (OperatingSystem.IsMacOS())
+        {
+            StringAssert.StartsWith(volume.Fingerprint, "mac-volume:");
+            StringAssert.StartsWith(volume.PhysicalDeviceFingerprint!, "mac-whole-disk:");
+        }
+    }
+
+    [TestMethod]
+    public void ExistingFile_ResolvesToSameIdentityAsItsDirectory()
+    {
+        var provider = new PlatformStorageVolumeProvider();
+        var directory = CreateTemporaryDirectory();
+        var file = Path.Combine(directory, "probe.txt");
+        File.WriteAllText(file, "identity-probe");
+
+        try
+        {
+            var parentVolume = provider.ResolveVolumeForPath(directory);
+            var fileVolume = provider.ResolveVolumeForPath(file);
+
+            Assert.IsNotNull(parentVolume);
+            Assert.IsNotNull(fileVolume);
+            Assert.AreEqual(parentVolume.Fingerprint, fileVolume.Fingerprint);
+            Assert.AreEqual(parentVolume.PhysicalDeviceFingerprint, fileVolume.PhysicalDeviceFingerprint);
+            Assert.IsTrue(string.Equals(parentVolume.RootPath, fileVolume.RootPath, provider.PathComparison));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void MissingDestinationLeaf_UsesNearestExistingVolume()
+    {
+        var provider = new PlatformStorageVolumeProvider();
+        var directory = CreateTemporaryDirectory();
+
+        try
+        {
+            var missing = Path.Combine(directory, "future", "event", "JPG");
+            var parentVolume = provider.ResolveVolumeForPath(directory);
+            var missingVolume = provider.ResolveVolumeForPath(missing);
+
+            Assert.IsNotNull(parentVolume);
+            Assert.IsNotNull(missingVolume);
+            Assert.AreEqual(parentVolume.Fingerprint, missingVolume.Fingerprint);
+            Assert.AreEqual(parentVolume.PhysicalDeviceFingerprint, missingVolume.PhysicalDeviceFingerprint);
+            Assert.IsTrue(string.Equals(parentVolume.RootPath, missingVolume.RootPath, provider.PathComparison));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public void BlankPath_CannotResolveVolume()
+    {
+        var provider = new PlatformStorageVolumeProvider();
+
+        Assert.IsNull(provider.ResolveVolumeForPath(string.Empty));
+        Assert.IsNull(provider.ResolveVolumeForPath("   "));
+    }
+
+    [TestMethod]
+    public void MountedVolumeSnapshot_NeverContainsBlankFingerprintOrRoot()
+    {
+        var provider = new PlatformStorageVolumeProvider();
+        var snapshot = provider.GetMountedVolumes();
+
+        Assert.IsTrue(snapshot.Count > 0);
+        foreach (var volume in snapshot)
+        {
+            Assert.IsFalse(string.IsNullOrWhiteSpace(volume.RootPath));
+            Assert.IsFalse(string.IsNullOrWhiteSpace(volume.Fingerprint));
+        }
+    }
+
+    private static string GetSystemVolumePath() => OperatingSystem.IsWindows()
+        ? Path.GetPathRoot(Environment.SystemDirectory)!
+        : "/";
+
+    private static string CreateTemporaryDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "PhotoOrganizer-AppTests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
     }
 }

--- a/tests/PhotoOrganizer.App.Tests/StartupRegistrationFormatterTests.cs
+++ b/tests/PhotoOrganizer.App.Tests/StartupRegistrationFormatterTests.cs
@@ -1,0 +1,122 @@
+using System.Xml.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PhotoOrganizer.App.Tests;
+
+[TestClass]
+public sealed class StartupRegistrationFormatterTests
+{
+    [TestMethod]
+    public void WindowsCommand_AlwaysQuotesExecutablePath()
+    {
+        var command = StartupRegistrationFormatter.BuildWindowsCommand(
+            @"C:\Program Files\Photo Organizer\PhotoOrganizer.exe",
+            startInBackground: false);
+
+        Assert.AreEqual(
+            "\"C:\\Program Files\\Photo Organizer\\PhotoOrganizer.exe\"",
+            command);
+    }
+
+    [TestMethod]
+    public void WindowsCommand_BackgroundFlagIsExplicit()
+    {
+        var foreground = StartupRegistrationFormatter.BuildWindowsCommand(
+            @"C:\PhotoOrganizer.exe",
+            startInBackground: false);
+        var background = StartupRegistrationFormatter.BuildWindowsCommand(
+            @"C:\PhotoOrganizer.exe",
+            startInBackground: true);
+
+        Assert.IsFalse(foreground.Contains("--background", StringComparison.Ordinal));
+        Assert.AreEqual("\"C:\\PhotoOrganizer.exe\" --background", background);
+    }
+
+    [TestMethod]
+    public void WindowsCommand_RejectsBlankExecutable()
+    {
+        Assert.ThrowsExactly<ArgumentException>(() =>
+            StartupRegistrationFormatter.BuildWindowsCommand("   ", false));
+    }
+
+    [TestMethod]
+    public void MacPlist_IsValidXmlWithExpectedLabelAndExecutable()
+    {
+        var plist = StartupRegistrationFormatter.BuildMacLaunchAgentPlist(
+            "com.peachgumi.photoorganizer",
+            "/Applications/Photo Organizer.app/Contents/MacOS/PhotoOrganizer",
+            startInBackground: false);
+
+        var document = XDocument.Parse(plist, LoadOptions.None);
+        var strings = document.Descendants().Where(e => e.Name.LocalName == "string").Select(e => e.Value).ToArray();
+
+        CollectionAssert.Contains(strings, "com.peachgumi.photoorganizer");
+        CollectionAssert.Contains(strings, "/Applications/Photo Organizer.app/Contents/MacOS/PhotoOrganizer");
+    }
+
+    [TestMethod]
+    public void MacPlist_XmlEscapesSpecialCharactersWithoutChangingParsedValues()
+    {
+        const string label = "com.example.photo&organizer";
+        const string executable = "/Applications/A&B <Photo>.app/Contents/MacOS/PhotoOrganizer";
+
+        var plist = StartupRegistrationFormatter.BuildMacLaunchAgentPlist(label, executable, false);
+        var document = XDocument.Parse(plist, LoadOptions.None);
+        var strings = document.Descendants().Where(e => e.Name.LocalName == "string").Select(e => e.Value).ToArray();
+
+        CollectionAssert.Contains(strings, label);
+        CollectionAssert.Contains(strings, executable);
+        StringAssert.Contains(plist, "&amp;");
+        StringAssert.Contains(plist, "&lt;");
+    }
+
+    [TestMethod]
+    public void MacPlist_BackgroundArgumentIsIncludedOnlyWhenRequested()
+    {
+        var foreground = StartupRegistrationFormatter.BuildMacLaunchAgentPlist(
+            "com.example.foreground",
+            "/tmp/PhotoOrganizer",
+            false);
+        var background = StartupRegistrationFormatter.BuildMacLaunchAgentPlist(
+            "com.example.background",
+            "/tmp/PhotoOrganizer",
+            true);
+
+        Assert.IsFalse(foreground.Contains("--background", StringComparison.Ordinal));
+        Assert.AreEqual(1, CountStringValue(background, "--background"));
+    }
+
+    [TestMethod]
+    public void MacPlist_RunAtLoadIsTrue()
+    {
+        var plist = StartupRegistrationFormatter.BuildMacLaunchAgentPlist(
+            "com.example.app",
+            "/tmp/PhotoOrganizer",
+            false);
+        var document = XDocument.Parse(plist, LoadOptions.None);
+        var elements = document.Descendants().ToArray();
+        var runAtLoadKey = Array.FindIndex(
+            elements,
+            e => e.Name.LocalName == "key" && e.Value == "RunAtLoad");
+
+        Assert.IsTrue(runAtLoadKey >= 0);
+        Assert.IsTrue(runAtLoadKey + 1 < elements.Length);
+        Assert.AreEqual("true", elements[runAtLoadKey + 1].Name.LocalName);
+    }
+
+    [TestMethod]
+    public void MacPlist_RejectsBlankLabelOrExecutable()
+    {
+        Assert.ThrowsExactly<ArgumentException>(() =>
+            StartupRegistrationFormatter.BuildMacLaunchAgentPlist(" ", "/tmp/app", false));
+        Assert.ThrowsExactly<ArgumentException>(() =>
+            StartupRegistrationFormatter.BuildMacLaunchAgentPlist("com.example.app", " ", false));
+    }
+
+    private static int CountStringValue(string plist, string value)
+    {
+        var document = XDocument.Parse(plist, LoadOptions.None);
+        return document.Descendants()
+            .Count(element => element.Name.LocalName == "string" && element.Value == value);
+    }
+}


### PR DESCRIPTION
## 背景

`PhotoOrganizer.App.Tests` はこれまで `PlatformStorageIdentityTests` の2ケースだけで、shared Coreに比べてOS境界の回帰検出が薄い状態でした。旧mac版で蓄積したテストのうち、Coreへ既に移行済みの安全ロジックは重複させず、platform adapter固有の責務を重点的に増やします。

## 変更内容

### macOS diskutil
- `diskutil info -plist` の解釈を `MacDiskutilInfoParser` へ純粋ロジックとして分離
- `VolumeUUID → APFSVolumeUUID → DiskUUID → MediaUUID → DeviceIdentifier` のfallback順を固定
- `ParentWholeDisk` / `WholeDisk` からphysical-device identityを構築
- malformed XML、dict欠落、identifier欠落、値型違い、空白、whole-disk型違いをfail-closedで検証
- parserを全OS CIでfixtureベースにテスト可能化

### 外部コマンド実行
- `BoundedProcessRunner` を追加
- stdout/stderrを同時drainしながらtimeoutする共通処理へ `diskutil` と `launchctl` を統一
- success / stderr+nonzero / timeout / 64KiB超stderr / missing executable / invalid timeoutをテスト

### startup registration
- Windows Run keyへ書くcommandとmacOS LaunchAgent plist生成を `StartupRegistrationFormatter` へ分離
- executable quoting、`--background`、XML escaping、Label、RunAtLoad、invalid inputをunit test
- 実際のRegistry / LaunchAgent mutationは引き続き実OS境界として扱い、CIでは副作用を起こさない

### platform storage integration
- system volume identityの実OS解決
- repeated resolutionの安定性
- mounted-volume snapshotとの一致
- platform-specific fingerprint prefix
- existing file / parent directoryの同一volume判定
- 未作成destination leafがnearest existing volumeを使うこと
- blank path rejection
- snapshotがblank root/fingerprintを含まないこと

## テスト方針

mount eventそのものやLogin Itemの実際のOS反映はunit testで無理にmockせず、実機release acceptanceの責務として残します。一方、OS API/command出力を安全判定へ変換するロジックは可能な限りpure unit testへ落としています。

PR CIでWindows/macOSのApp.Tests、Core safety tests、build、package smoke、release contract、CodeQLを全て通してからマージします。