### PR TITLE
Aboutを日本語化しREADMEを全面強化

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,34 @@
 # Photo Organizer
 
-> **撮影データを、SDカードからWindows / macOSへ安全に取り込み、日付とイベント単位で整理するデスクトップアプリ。**  
-> コピーが終わっただけでは「SDカードを再利用してよい」と判定せず、保存先の実データ検証と永続化まで確認してから明示的に再利用可能状態へ移行します。
+> **SDカードの写真・動画を Windows / macOS へ安全に取り込み、日付とイベント単位で整理するデスクトップアプリ。**  
+> 単に「コピーが終わった」だけでは SD カードを再利用可能と判定せず、保存先の実データ・永続化・ストレージ識別まで確認してから明示的に安全状態へ移行します。
 
 [![CI](https://github.com/PeachGumi/PhotoOrganizer/actions/workflows/ci.yml/badge.svg)](https://github.com/PeachGumi/PhotoOrganizer/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/PeachGumi/PhotoOrganizer/actions/workflows/codeql.yml/badge.svg)](https://github.com/PeachGumi/PhotoOrganizer/actions/workflows/codeql.yml)
 [![I/O Benchmark](https://github.com/PeachGumi/PhotoOrganizer/actions/workflows/io-benchmark.yml/badge.svg)](https://github.com/PeachGumi/PhotoOrganizer/actions/workflows/io-benchmark.yml)
+[![.NET 10](https://img.shields.io/badge/.NET-10.0-512BD4.svg)](https://dotnet.microsoft.com/)
+[![Windows / macOS](https://img.shields.io/badge/platform-Windows%20%7C%20macOS-lightgrey.svg)](#対応環境)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
-Photo Organizerは、カメラのSDカードにある写真・動画を指定した保存先へ取り込み、次の形式で整理するWindows / macOS共通アプリです。
+Photo Organizer は、カメラの SD カードにある JPG / RAW / MOV / MP4 を指定した保存先へ取り込み、次のような構造へ整理する Windows / macOS 共通アプリです。
 
 ```text
 [保存先]/[YYYY]/[YYYY-MM-DD]_[イベント名]/[RAW|JPG|MP4]/
 ```
 
-単なるファイルコピーではなく、**「元データを変更しない」「既存データを上書きしない」「コピー済みとSDカード再利用可能を分ける」**ことを設計の中心に置いています。
+設計の中心にあるのは、次の3つです。
 
-Windows版とmacOS版を別々に保守するのではなく、取り込み・重複判定・コピー整合性・SD再利用判定を共有Coreへ集約し、OS固有処理だけを薄いplatform adapterへ分離しています。
+- **SDカード上の元データを変更しない**
+- **保存先にある既存データを上書きしない**
+- **「コピー完了」と「SDカード再利用可能」を別の状態として扱う**
+
+Windows 版と macOS 版を別々に実装するのではなく、取り込み・重複判定・コピー整合性・SD 再利用判定を共有 Core へ集約し、OS 固有処理だけを薄い platform adapter に分離しています。
+
+[まず知りたいこと](#まず知りたいこと) ・ [クイックスタート](#クイックスタート) ・ [対応環境](#対応環境) ・ [対応形式](#対応形式) ・ [安全設計](#データ安全性) ・ [インストール](#インストールと配布状況) ・ [開発](#ソースから実行する) ・ [品質保証](#テストとci) ・ [FAQ](#よくある質問)
+
+> **現在の配布状態**
+>
+> まだ一般利用者向けの stable release は公開していません。署名済み Prerelease → 実機受け入れ試験 → 同一成果物の stable promotion という手順を完了したものだけを正式版として公開する方針です。
 
 ---
 
@@ -24,72 +36,128 @@ Windows版とmacOS版を別々に保守するのではなく、取り込み・�
 
 ### できること
 
-- **SDカードを自動検知**し、`DCIM` / `PRIVATE` を持つカメラメディアを認識
-- 手動で `DCIM/100NIKON` などの下位フォルダを選んでも、**カード全体の安全なrootまで広げてスキャン**
-- JPG / JPEG、設定済みRAW、MOV / MP4を自動分類
-- 撮影日とイベント名から保存フォルダを自動作成
-- 保存先全体を対象に、**ファイルサイズ + SHA-256**で内容ベースの重複判定
-- 同名・異内容ファイルを `_2`, `_3` ... で保持し、既存ファイルを上書きしない
-- `.partial-*` 一時ファイルを使った検証付きコピー
-- コピー後にSDカードを再スキャンし、保存先の実ファイルを再検証
-- Windows / macOSそれぞれで保存先への**durable commit（永続媒体への同期）**を要求
-- コピー元・保存先のvolume / physical device / mount session identityを追跡
-- SDカード差し替え、保存先取り外し、コピー失敗、検証失敗などで**fail-closed**
-- 2枚目のSDカードが挿入されても、処理中のカードを勝手に切り替えず待機キューへ保持
-- Windowsではトレイ、macOSではメニューバーに常駐
-- ログイン時自動起動とバックグラウンド起動
+| 機能 | 内容 |
+|---|---|
+| SDカード検知 | `DCIM` / `PRIVATE` を持つカメラメディアを検知 |
+| カード全体の安全スキャン | `DCIM/100NIKON` などの下位フォルダを選んでも、安全なカード root まで広げて確認 |
+| メディア分類 | JPG / JPEG、設定済み RAW、MOV / MP4 を自動分類 |
+| 日付・イベント整理 | 撮影日とイベント名から保存フォルダを作成 |
+| 内容ベース重複判定 | ファイル名ではなく **サイズ + SHA-256** で既存データと照合 |
+| 上書き防止 | 同名・異内容は `_2`, `_3` ... として別ファイルで保存 |
+| 検証付きコピー | `.partial-*` 一時ファイル、再ハッシュ、no-replace final move を使用 |
+| 保存先永続化確認 | Windows / macOS の durability primitive で保存先への永続化を要求 |
+| SD再利用判定 | 取り込み後に SD カードを再スキャンし、全対応メディアをもう一度検証 |
+| ストレージ差し替え検知 | volume / physical device / mount session identity を追跡 |
+| 常駐動作 | Windows はトレイ、macOS はメニューバーに常駐可能 |
+| 複数カード | 処理中のカードを固定し、2枚目は待機キューへ保持 |
+| 自動起動 | ログイン時起動とバックグラウンド起動に対応 |
 
 ### しないこと / できないこと
 
 - **SDカード上の元ファイルを削除・移動・rename・書き換えしません**
 - SDカードをアプリからフォーマット・消去する機能はありません
-- XMP / XML / TXT / カメラDBなど、対応範囲外のsidecar・補助ファイルは取り込みません
-- 緑の再利用可能表示は、**指定保存先1か所への検証済みコピー**を意味します。3-2-1バックアップや二重バックアップ完了を意味しません
-- symlink / junction / reparse point経由の保存先を独立したバックアップ先として扱いません
-- 同じ物理ディスク・SDカード上の別partitionを「別の保存先」とは認めません
-- OSから物理ストレージidentityを安全に取得できない保存先では、取り込み・再利用判定を拒否する場合があります
-- 故障したストレージや、flush完了を正しく報告しないハードウェア/firmwareまで完全に保証するものではありません
+- XMP / XML / TXT / カメラDBなど、未対応 sidecar・補助ファイルは取り込みません
+- 緑の再利用可能表示は、**指定保存先1か所への検証済みコピー**を意味します。3-2-1 バックアップや二重バックアップ完了を意味しません
+- symlink / junction / reparse point 経由の保存先を独立したバックアップ先として扱いません
+- 同じ物理ディスク・SDカード上の別 partition を「別の保存先」とは認めません
+- OS からストレージの物理 identity を安全に取得できない構成では fail-closed で拒否する場合があります
+- 故障したストレージや、flush 完了を不正に報告する hardware / firmware まで完全に保証するものではありません
+
+### こんな使い方を想定しています
+
+- 撮影のたびに SD カードを Mac / PC へ挿して写真を取り込みたい
+- 取り込み後は次回撮影前にカメラ側で SD カードをフォーマットする
+- RAW / JPG / 動画をイベントごとに自動で整理したい
+- 前回分が SD カードに残っていても、新しいデータだけ安全に追加したい
+- カメラが `DSC_0001.JPG` のようなファイル名を再利用しても事故らないようにしたい
+- Finder / Explorer の手動コピーより厳格に「消してよいタイミング」を判断したい
 
 ---
 
-## Photo Organizerが解決したいこと
+## クイックスタート
 
-写真を取り込むだけなら、FinderやExplorerでコピーするだけでもできます。
+一般利用者向けの正式配布物が公開された後は、GitHub Releases から自分の OS / CPU に合うパッケージを取得します。
 
-問題になるのは、その後です。
+基本操作は次の流れです。
+
+1. Photo Organizer を起動する
+2. 写真ライブラリの保存先を選ぶ
+3. カメラの SD カードを接続する
+4. 自動検知を待つ。必要なら SD カードまたはカード内フォルダを手動選択する
+5. RAW / JPG / MP4 の件数と完全スキャン成功を確認する
+6. イベント名を入力する
+7. 保存先プレビューを確認する
+8. **取り込み開始**を押す
+9. コピー表示が100%になっても SD カードを抜かず、最終検証を待つ
+10. 緑の **「保存先コピー検証済み — SDカード再利用可能」** を確認する
+11. 必要なら保存先側の写真を別アプリでも確認する
+12. SD カードをカメラへ戻し、次回撮影前にカメラ側で再利用 / フォーマットする
+
+```text
+撮影
+  ↓
+SDカードをPC / Macへ接続
+  ↓
+カード全体を完全スキャン
+  ↓
+保存先が別volume・別physical deviceか確認
+  ↓
+既存データとsize + SHA-256で重複照合
+  ↓
+新規メディアを検証付きコピー
+  ↓
+SDカード全体をもう一度完全スキャン
+  ↓
+保存先の実bytes + durable commitを検証
+  ↓
+source / destination identityを最終確認
+  ↓
+「SDカード再利用可能」
+```
+
+**どこか1つでも確認できなければ green にはなりません。**
+
+---
+
+## Photo Organizer が解決したいこと
+
+写真を取り込むだけなら、Finder や Explorer でコピーするだけでもできます。
+
+難しいのは、その後です。
 
 - コピーが本当に最後まで成功したのか
 - 同名ファイルが既にあった場合に上書きされていないか
 - カメラがファイル番号を再利用したとき、別写真を「重複」と誤判定しないか
-- SDカードに前回分が残っていても、新しい写真だけを安全に取り込めるか
-- コピー後に保存先が破損・取り外しされた状態で、誤って「SDカードを消してよい」と表示しないか
-- OSやストレージのwrite cacheにしか存在しないデータを「保存済み」と誤認しないか
+- SD カードに前回分が残っていても、新しい写真だけを安全に取り込めるか
+- コピー後に保存先が取り外された状態で、誤って「SDカードを消してよい」と表示しないか
+- OS や storage device の write cache にしか存在しないデータを「保存済み」と誤認しないか
+- 同じ mount path に別の SD カードが差し替わっても、以前の承認を使い回してしまわないか
 
-Photo Organizerは、この最後の **「いつSDカードを再利用してよいか」** までをひとつの取り込みトランザクションとして扱います。
+Photo Organizer は、**「いつ SD カードを再利用してよいか」までを1つの取り込みトランザクションとして扱う**ことを目的にしています。
 
-```text
-カメラで撮影
-    ↓
-SDカードをPC / Macへ接続
-    ↓
-カード全体を完全スキャン
-    ↓
-保存先が別volume・別physical deviceか確認
-    ↓
-既存の実データとSHA-256で重複照合
-    ↓
-新規メディアを検証付きでコピー
-    ↓
-SDカード全体をもう一度スキャン
-    ↓
-保存先のsize + SHA-256 + durable commitを確認
-    ↓
-source / destination identityを最終確認
-    ↓
-「保存先コピー検証済み — SDカード再利用可能」
-```
+---
 
-どこか1つでも証明できなければ、再利用可能状態にはなりません。
+## 対応環境
+
+### 利用環境
+
+| OS | Architecture | 想定配布形式 | 状態 |
+|---|---|---|---|
+| Windows | x64 | self-contained ZIP | 対応 |
+| Windows | ARM64 | self-contained ZIP | 対応 |
+| macOS | Apple Silicon / arm64 | signed + notarized DMG | 対応 |
+| macOS | Intel / x64 | signed + notarized DMG | 対応 |
+| Linux | - | - | 非対応 |
+
+正式配布時は、Windows 成果物に Authenticode、macOS 成果物に Developer ID Application 署名・Hardened Runtime・Apple Notarization・stapling を要求します。
+
+### 開発環境
+
+- .NET 10 SDK
+- Windows または macOS
+- Avalonia 12
+
+Linux 上で Core を扱える部分はありますが、製品としての desktop platform adapter と release acceptance の対象は Windows / macOS です。
 
 ---
 
@@ -97,13 +165,13 @@ source / destination identityを最終確認
 
 ### RAW
 
-初期設定では次の拡張子をRAWとして扱います。
+初期設定では次の拡張子を RAW として扱います。
 
 ```text
 .arw  .cr2  .cr3  .nef  .dng  .raf  .rw2  .orf  .pef
 ```
 
-RAW拡張子はアプリ設定から変更できます。
+RAW 拡張子はアプリ設定から変更できます。
 
 ### JPEG
 
@@ -117,11 +185,11 @@ RAW拡張子はアプリ設定から変更できます。
 .mov  .mp4
 ```
 
-`.jpg` / `.jpeg` / `.mov` / `.mp4` は標準分類として予約されており、RAW設定へ追加してもRAWとして再分類されません。
+`.jpg` / `.jpeg` / `.mov` / `.mp4` は標準分類として予約されており、RAW 設定へ追加しても RAW として再分類されません。
 
 ### 対象外ファイル
 
-たとえば次のようなファイルは、取り込みとSD再利用判定の対象外です。
+たとえば次のようなファイルは、取り込みと SD 再利用判定の対象外です。
 
 ```text
 .xmp  .xml  .txt  カメラ固有DB  sidecar  その他の未対応形式
@@ -129,13 +197,13 @@ RAW拡張子はアプリ設定から変更できます。
 
 対象外ファイルがカードに存在すること自体は、対応メディアの再利用判定を妨げません。
 
-一方、**対応形式の0-byteファイル**は正常な撮影データとして確認できないため、スキャンをfail-closedで停止します。
+一方、**対応形式の 0-byte ファイル**は正常な撮影データとして確認できないため、スキャンを fail-closed で停止します。
 
 ---
 
 ## 保存先の構造
 
-保存先には年・日付・イベント名・メディア種別の順で整理されます。
+保存先には、年・日付・イベント名・メディア種別の順で整理されます。
 
 ```text
 Pictures/
@@ -151,9 +219,11 @@ Pictures/
          └─ DSC_0003.MP4
 ```
 
-イベント日付は、今回新しく取り込むメディアがある場合はその対象を基準に決定します。
+### イベント日付の決め方
 
-日付取得は次の優先順位です。
+今回新しく取り込むメディアがある場合は、そのメディアを基準にイベント日付を決定します。
+
+日付取得の優先順位は次のとおりです。
 
 1. EXIF `DateTimeOriginal`
 2. EXIF `DateTimeDigitized`
@@ -161,40 +231,19 @@ Pictures/
 
 複数の撮影日が含まれる場合は最も古い日付をイベント日として採用し、警告を残します。
 
-イベント名にOS上ファイル名として使用できない文字が含まれる場合は、安全な文字へ置換します。
+イベント名に OS 上ファイル名として使用できない文字が含まれる場合は、安全な文字へ置換します。
 
----
-
-## 使い方
-
-基本操作は次の流れです。
-
-1. Photo Organizerを起動
-2. 保存先を選択
-3. カメラのSDカードを接続
-4. 自動検知を待つか、必要なら手動でSDカード / カード内フォルダを選択
-5. RAW / JPG / MP4の件数と、完全スキャン成功を確認
-6. イベント名を入力
-7. 保存先previewを確認
-8. **取り込み開始**を押す
-9. コピーが終わってもSDカードを抜かず、再スキャンと最終検証を待つ
-10. 緑色の **「保存先コピー検証済み — SDカード再利用可能」** を確認
-11. 必要に応じて保存先の写真を画像ビューアやRAW現像ソフトで確認
-12. SDカードをカメラへ戻し、次回撮影時にカメラ側で再利用 / フォーマット
-
-### 前回の写真がSDカードに残っている場合
+### 前回の写真が SD カードに残っている場合
 
 問題ありません。
 
-保存先全体から同じサイズ・同じSHA-256の実ファイルが見つかった写真は、既に保存済みとして再コピーを省略します。
-
-新しい内容だけが今回のイベントへ取り込まれます。
+保存先全体から同じサイズ・同じ SHA-256 の実ファイルが見つかった写真は、既に保存済みとして再コピーを省略します。新しい内容だけが今回のイベントへ取り込まれます。
 
 ### カメラが同じファイル名を再利用した場合
 
 ファイル名だけでは重複判定しません。
 
-たとえば、以前の `DSC_0001.JPG` と今回の `DSC_0001.JPG` が同名・同サイズでも、SHA-256が異なれば別の写真として扱います。
+以前の `DSC_0001.JPG` と今回の `DSC_0001.JPG` が同名・同サイズでも、SHA-256 が異なれば別の写真として扱います。
 
 保存先に同名の別データが存在する場合は、既存ファイルを残したまま次のように保存します。
 
@@ -208,13 +257,25 @@ DSC_0001_3.JPG
 
 ## データ安全性
 
-Photo Organizerでは、データ安全性に関するルールを通常の実装詳細ではなく**契約**として扱っています。
+Photo Organizer では、データ安全性に関するルールを通常の実装詳細ではなく**契約**として扱っています。
 
-厳密な仕様は [`docs/DATA_SAFETY.md`](docs/DATA_SAFETY.md) が正です。READMEでは重要な考え方を要約します。
+厳密な仕様は [`docs/DATA_SAFETY.md`](docs/DATA_SAFETY.md) が正です。ここでは利用者が知るべき要点をまとめます。
 
-### 1. コピー元はimmutable
+### 安全判定の要約
 
-SDカード上の対応メディアに対して、アプリは次の操作を行いません。
+| 条件 | green に必要か |
+|---|---:|
+| SDカード全体を完全スキャンできた | 必須 |
+| 保存先が source と別 volume / 別 physical device | 必須 |
+| 全対応メディアに size + SHA-256 一致の保存先コピーがある | 必須 |
+| 保存先コピーを durable synchronization できた | 必須 |
+| durable sync 後の fresh SHA-256 が source と一致 | 必須 |
+| source / destination の mount identity が途中で変わっていない | 必須 |
+| 2か所以上にバックアップ済み | 対象外 |
+
+### 1. コピー元は immutable
+
+SD カード上の対応メディアに対して、アプリは次の操作を行いません。
 
 - delete
 - move
@@ -222,88 +283,90 @@ SDカード上の対応メディアに対して、アプリは次の操作を行
 - truncate
 - replace
 - overwrite
-- metadata書き換え
+- metadata 書き換え
 
 アプリが自動削除する可能性があるのは、アプリ自身が作成し、まだ最終ファイルになっていない `.partial-*` 一時ファイルだけです。
 
 ### 2. カード全体を完全に読めなければ進めない
 
-SDカードの列挙中にI/Oエラー、権限エラー、metadata取得エラーなどが発生した場合、「見えたファイルだけ」を取り込んで安全とは判定しません。
+SD カードの列挙中に I/O エラー、権限エラー、metadata 取得エラーなどが発生した場合、「見えたファイルだけ」を取り込んで安全とは判定しません。
 
 対応メディアをカード全体から確認できたことが安全判定の前提です。
 
-hidden directory内の対応メディアも対象です。一方、symlink / reparse pointや別mounted volumeはカード外へスキャンが逃げないよう追跡しません。
+hidden directory 内の対応メディアも対象です。一方、symlink / reparse point や別 mounted volume はカード外へスキャンが逃げないよう追跡しません。
 
-### 3. 保存先はSDカードと物理的に別でなければならない
+### 3. 保存先は SD カードと物理的に別でなければならない
 
-path文字列が違うだけでは不十分です。
+path 文字列が違うだけでは不十分です。
 
-Photo Organizerは、sourceとdestinationについて次を確認します。
+Photo Organizer は source と destination について次を確認します。
 
 - mounted volume identity
 - physical storage-device identity
 - process-local mount-session identity
 
-同じSDカードの別partitionや、同じ物理ディスク上の別volumeは独立したバックアップ先として認めません。
+同じ SD カードの別 partition や、同じ物理ディスク上の別 volume は独立したバックアップ先として認めません。
 
-また、destination pathにsymlink / junction / reparse pointなどのaliasが含まれる場合もfail-closedで拒否します。
+また、destination path に symlink / junction / reparse point などの alias が含まれる場合も fail-closed で拒否します。
 
-### 4. 重複はtimestampやファイル名ではなく実bytesで判定
+### 4. 重複は timestamp やファイル名ではなく実 bytes で判定
 
-既存保存データとの重複判定は、基本的に次の組み合わせです。
+重複判定は原則として、
 
 ```text
 file size + SHA-256
 ```
 
-カメラ側のファイル番号再利用やtimestampの一致だけで、別写真を捨てないためです。
+で行います。
+
+同名でも内容が違えば別ファイルです。別名でも内容が完全一致すれば既に保存済みのデータとして扱えます。
 
 ### 5. 新規コピーは一時ファイル経由で確定
 
-新しいファイルは、概ね次の順序で処理します。
+新しいファイルは概ね次の順序で処理します。
 
-1. sourceのサイズとSHA-256を取得
-2. 保存先と同じdirectoryに `.partial-*` を `CreateNew` で作成
-3. sourceから一時ファイルへコピー
-4. 一時ファイルをflush
-5. 一時ファイルのサイズとSHA-256をsourceと比較
-6. sourceを再度読み、コピー中に内容が変化していないことを確認
-7. 既存ファイルを上書きしないfinal moveを実行
-8. final metadataを設定
-9. OSごとのdurable commitを実行
-10. final pathをもう一度サイズ・SHA-256検証
+1. source のサイズと SHA-256 を取得
+2. 保存先と同じ directory に `.partial-*` を `CreateNew` で作成
+3. source から一時ファイルへコピー
+4. 一時ファイルを flush
+5. 一時ファイルのサイズと SHA-256 を source と比較
+6. source を再度読み、コピー中に内容が変化していないことを確認
+7. 既存ファイルを上書きしない final move を実行
+8. final metadata を設定
+9. OS ごとの durable commit を実行
+10. final path をもう一度サイズ・SHA-256 検証
 
-途中で失敗しても、既存のlibrary fileを削除して帳尻を合わせることはしません。
+途中で失敗しても、既存の library file を削除して帳尻を合わせることはしません。
 
-### 6. 「SHAが一致した」だけではgreenにしない
+### 6. 「SHAが一致した」だけでは green にしない
 
-OSやストレージdeviceのcacheから読み出せたデータが、必ずしも電源断後も永続媒体に残っているとは限りません。
+OS や storage device の cache から読み出せたデータが、必ずしも電源断後も永続媒体に残っているとは限りません。
 
-そのためPhoto Organizerは、greenのSD再利用判定に**durable destination commit**を要求します。
+そのため green の SD 再利用判定に **durable destination commit** を要求します。
 
 #### Windows
 
-- final moveはno-replaceで実行
+- final move は no-replace
 - `MOVEFILE_WRITE_THROUGH` を使用
-- final metadata設定後、final file handleをdiskへflush
+- final metadata 設定後、final file handle を disk へ flush
 
 #### macOS
 
 - no-clobber final move
-- parent directory entryを同期
-- final fileへ `F_FULLFSYNC`
+- parent directory entry を同期
+- final file へ `F_FULLFSYNC`
 
-durabilityをOSへ要求できなかった場合は、現在SHA-256が一致していても再利用可能とは判定しません。
+durability を OS へ要求できなかった場合は、現在 SHA-256 が一致していても再利用可能とは判定しません。
 
-### 7. durable sync後にもう一度SHA-256を読む
+### 7. durable sync 後にもう一度 SHA-256 を読む
 
-最終再利用判定では、destinationをhashした後にdurable syncして終わりではありません。
+destination を hash した後に durable sync して終わりではありません。
 
-外部プロセスがその隙間で保存先を変更する可能性まで考慮し、**durable synchronization後にfresh handleからdestination SHA-256を再計算**します。
+外部プロセスがその隙間で保存先を変更する可能性まで考慮し、**durable synchronization 後に fresh handle から destination SHA-256 を再計算**します。
 
-古いhashと新しいbytesの組み合わせでgreenになることを防ぎます。
+これにより、古い hash と新しい bytes の組み合わせで green になる TOCTOU を防ぎます。
 
-### 8. コピー後にSDカードをもう一度完全スキャン
+### 8. コピー後に SD カードをもう一度完全スキャン
 
 コピー開始時に見えていたファイルだけを確認して終わりではありません。
 
@@ -311,48 +374,59 @@ durabilityをOSへ要求できなかった場合は、現在SHA-256が一致し�
 
 - 最初に見えていた対応メディアが消えていない
 - 新たに対応メディアが増えていれば、それも最終検証対象に含める
-- 現在カードに見えている対応メディア全件について、独立したdestination copyが存在する
-- destination copyがsize + SHA-256一致する
-- destination copyがdurably synchronizedされている
-- source / destination storage identityが途中で変化していない
+- 現在カードに見えている対応メディア全件について独立した destination copy が存在する
+- destination copy が size + SHA-256 一致する
+- destination copy が durably synchronized されている
+- source / destination storage identity が途中で変化していない
 
-すべて成立した場合だけgreenになります。
+すべて成立した場合だけ green になります。
 
 ---
 
 ## 緑の「SDカード再利用可能」が意味するもの
 
-緑色の状態は、Photo Organizerが対応対象としている現在のJPG / JPEG・設定済みRAW・MOV / MP4について、**指定保存先1か所への独立コピーを実bytesで検証し、永続媒体への同期まで要求できた**ことを意味します。
+緑色の状態は、Photo Organizer が対応対象としている現在の JPG / JPEG・設定済み RAW・MOV / MP4 について、**指定保存先1か所への独立コピーを実 bytes で検証し、永続媒体への同期まで要求できた**ことを意味します。
 
-意味しないもの:
+### green が保証する範囲
+
+- カード上で現在見えている対応メディアを完全スキャン済み
+- 対応メディアごとに独立した destination file を確認済み
+- destination size / SHA-256 を確認済み
+- durable synchronization を OS へ要求済み
+- durable sync 後に fresh SHA-256 を再確認済み
+- storage identity の途中差し替えを検出していない
+
+### green が意味しないこと
 
 - 2か所以上にバックアップ済み
 - クラウドへ同期済み
-- ストレージ自体の故障耐性がある
-- RAID / 3-2-1バックアップが完成した
-- 将来のbit rotまで保証される
+- 保存先ストレージ自体が壊れない
+- RAID / 3-2-1 バックアップが完成した
+- 将来の bit rot まで保証される
 
-重要な撮影データでは、green確認後も別媒体やクラウドなどへの追加バックアップを推奨します。
+重要な撮影データでは、green 確認後も別媒体・NAS・クラウドなどへの追加バックアップを推奨します。
 
 ---
 
 ## ストレージ差し替えへの対策
 
-`D:\` や `/Volumes/CAMERA` といったpathは、同じ文字列でも途中で別deviceへ差し替わることがあります。
+`D:\` や `/Volumes/CAMERA` といった path は、同じ文字列でも途中で別 device へ差し替わることがあります。
 
-Photo Organizerではpathだけをidentityとして使いません。
+Photo Organizer では path だけを identity として使いません。
 
 ### Windows
 
-volume identityに加えて、logical volume → partition → physical diskの対応を追跡します。
+volume identity に加えて、logical volume → partition → physical disk の対応を追跡します。
 
 ### macOS
 
-`diskutil info -plist` からvolume / partition identityとwhole-disk identityを取得します。
+`diskutil info -plist` から persistent volume identity と whole-disk identity を取得します。
 
-外部commandはbounded executionとし、取得に失敗した場合は「推測で続行」せずidentity unavailableとしてfail-closedにします。
+`diskutil` の plist 解釈は platform adapter 内の純粋 parser として分離し、欠損・型違い・fallback 順序をテストしています。外部 command 自体も bounded execution とし、stdout / stderr を同時に drain しながら timeout します。
 
-さらに、OSのpersistent identifierとは別にprocess-localなmount session IDを持ち、取り外し・再接続・physical mapping変更が発生した場合は以前のscan approvalを無効化します。
+取得に失敗した場合は「推測で続行」せず identity unavailable として fail-closed にします。
+
+さらに、OS の persistent identifier とは別に process-local な mount session ID を持ち、取り外し・再接続・physical mapping 変更が発生した場合は以前の scan approval を無効化します。
 
 詳しくは [`docs/STORAGE_IDENTITY.md`](docs/STORAGE_IDENTITY.md) を参照してください。
 
@@ -360,48 +434,52 @@ volume identityに加えて、logical volume → partition → physical diskの�
 
 ## 常駐動作と複数SDカード
 
-Photo OrganizerはWindowsのsystem tray / macOSのmenu barに常駐できます。
+Photo Organizer は Windows の system tray / macOS の menu bar に常駐できます。
 
-- idle中にメインwindowを閉じると、通常は監視を続けたままwindowを隠します
-- tray / menu barからwindowを再表示できます
-- 明示的なQuitで終了できます
-- import中の通常終了は拒否されます
+- idle 中にメイン window を閉じると、監視を続けたまま window を隠します
+- tray / menu bar から window を再表示できます
+- 明示的な Quit で終了できます
+- import 中の通常終了は拒否されます
 - `--background` 起動に対応します
-- login auto-startとbackground startを個別に設定できます
-- background中でも有効なcamera cardを検知するとworkflow windowを表示できます
+- login auto-start と background start を個別に設定できます
+- background 中でも有効な camera card を検知すると workflow window を表示できます
 
-処理中に2枚目のcamera cardが接続されても、active cardを勝手に変更しません。
+処理中に2枚目の camera card が接続されても、active card を勝手に変更しません。
 
-2枚目はqueueへ入り、現在の処理が終了・resetされた後に扱われます。
+2枚目は queue へ入り、現在の処理が終了・reset された後に扱われます。
+
+mount event や実際の login startup は OS 境界そのものなので、unit test だけに依存せず release acceptance でも実機確認します。
 
 ---
 
 ## 設定
 
-初期保存先はOSの **Pictures / ピクチャ** directoryです。
+初期保存先は OS の **Pictures / ピクチャ** directory です。
 
 主な設定:
 
 - 保存先
-- RAW拡張子
+- RAW 拡張子
 - ログイン時自動起動
 - バックグラウンド起動
 
-通常設定はOSのLocal Application Data配下にある `PhotoOrganizer/settings.json`、background設定は `PhotoOrganizer/background-settings.json` に保存されます。
+通常設定は OS の Local Application Data 配下にある `PhotoOrganizer/settings.json`、background 設定は `PhotoOrganizer/background-settings.json` に保存されます。
 
 安全判定そのものは設定ファイルへ永続化しません。
 
-**アプリを再起動した時点で、以前のgreen状態は引き継がれません。**
+**アプリを再起動した時点で、以前の green 状態は引き継がれません。**
 
-新しいprocessでは再度scan / import / verificationが必要です。
+新しい process では再度 scan / import / verification が必要です。
 
 ---
 
-## インストール / 配布状況
+## インストールと配布状況
 
-正式配布物はGitHubの [Releases](https://github.com/PeachGumi/PhotoOrganizer/releases) から提供する設計です。
+正式配布物は GitHub の [Releases](https://github.com/PeachGumi/PhotoOrganizer/releases) から提供します。
 
-production releaseでは同一commitから次の4artifactを生成します。
+### 正式版が公開されている場合
+
+自分の環境に合う成果物を選びます。
 
 | Platform | Architecture | 配布形式 |
 |---|---|---|
@@ -410,22 +488,27 @@ production releaseでは同一commitから次の4artifactを生成します。
 | macOS | Apple Silicon / arm64 | signed + notarized DMG |
 | macOS | Intel / x64 | signed + notarized DMG |
 
-Windows artifactはAuthenticode署名、macOS artifactはDeveloper ID Application署名・Hardened Runtime・Apple Notarization・stapling・Gatekeeper検証をrelease条件とします。
+self-contained build のため、正式配布 ZIP / DMG の実行に .NET SDK を別途インストールすることは想定していません。
 
-### 安定版がまだ公開されていない場合
+### stable release がまだない場合
 
-このrepositoryは、署名済みbuildが成功しただけではstable releaseとしません。
+この repository は、署名済み build が成功しただけでは stable release としません。
 
-1. signed Prerelease candidateを生成
-2. clean machine / real SD cardで [`docs/RELEASE_ACCEPTANCE.md`](docs/RELEASE_ACCEPTANCE.md) を実施
-3. exact candidateのevidenceを記録
-4. 別workflowで同じartifactをstable / Latestへpromotion
+```text
+main の exact commit
+      ↓
+署名済み Prerelease candidate
+      ↓
+clean machine / real SD card acceptance
+      ↓
+acceptance evidence 記録
+      ↓
+同じ artifact を stable / Latest へ promotion
+```
 
-という2段階releaseを採用しています。
+GitHub Releases に stable release が存在しない場合、一般利用者向け production build はまだ公開前です。
 
-GitHub Releasesにstable releaseが存在しない場合、一般利用者向けproduction buildはまだ公開前です。
-
-詳しくは [`docs/RELEASE.md`](docs/RELEASE.md) を参照してください。
+詳しくは [`docs/RELEASE.md`](docs/RELEASE.md) と [`docs/RELEASE_ACCEPTANCE.md`](docs/RELEASE_ACCEPTANCE.md) を参照してください。
 
 ---
 
@@ -447,30 +530,37 @@ dotnet run --project src/PhotoOrganizer.App/PhotoOrganizer.App.csproj -c Release
 dotnet build src/PhotoOrganizer.App/PhotoOrganizer.App.csproj -c Release
 ```
 
-### Core test
+### Core tests
 
 ```bash
 dotnet test tests/PhotoOrganizer.Core.Tests/PhotoOrganizer.Core.Tests.csproj -c Release
 ```
 
-### platform adapter test
+### platform adapter tests
 
 ```bash
 dotnet test tests/PhotoOrganizer.App.Tests/PhotoOrganizer.App.Tests.csproj -c Release
 ```
 
-ローカルbuildはproduction署名・notarization済み配布物とは別物です。第三者へ正式配布する場合はrelease workflowを使用してください。
+### I/O benchmark
+
+```bash
+dotnet run --project tools/PhotoOrganizer.IoBenchmark/PhotoOrganizer.IoBenchmark.csproj -c Release
+```
+
+ローカル build は production 署名・notarization 済み配布物とは別物です。第三者へ正式配布する場合は release workflow を使用してください。
 
 ---
 
 ## アーキテクチャ
 
-Photo Organizerは、OSによって安全ロジックが分岐しないように設計しています。
+Photo Organizer は、OS によって安全ロジックが分岐しないように設計しています。
 
 ```text
 ┌─────────────────────────────────────────────┐
 │ PhotoOrganizer.App                          │
 │ Avalonia UI / tray / menu bar / settings    │
+│ startup / storage platform adapters          │
 └──────────────────────┬──────────────────────┘
                        │
                        v
@@ -482,22 +572,21 @@ Photo Organizerは、OSによって安全ロジックが分岐しないように
 │ - duplicate detection                       │
 │ - safe copy transaction                     │
 │ - durable destination verification          │
-│ - SD reuse safety state machine              │
+│ - SD reuse safety state machine             │
 └──────────────────────┬──────────────────────┘
                        │
                        v
 ┌─────────────────────────────────────────────┐
-│ Platform adapters                           │
+│ OS / filesystem                             │
 │                                             │
-│ Windows: volume / physical disk / startup   │
-│ macOS: diskutil / whole disk / login item   │
-│ packaging / signing / lifecycle             │
+│ Windows: volume / physical disk / registry  │
+│ macOS: diskutil / whole disk / LaunchAgent  │
 └─────────────────────────────────────────────┘
 ```
 
-CoreはWinForms、AppKit、SwiftUI、Windows Management API、Avalonia UI typeへ依存しません。
+Core は WinForms、AppKit、SwiftUI、Windows Management API、Avalonia UI type へ依存しません。
 
-UI / platform layerからCoreへ依存し、CoreからOS固有layerへ逆依存しない方向を維持します。
+UI / platform layer から Core へ依存し、Core から OS 固有 layer へ逆依存しない方向を維持します。
 
 詳細は [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) を参照してください。
 
@@ -508,11 +597,11 @@ UI / platform layerからCoreへ依存し、CoreからOS固有layerへ逆依存�
 ```text
 PhotoOrganizer/
 ├─ src/
-│  ├─ PhotoOrganizer.Core/       # 共有の安全・取り込みロジック
-│  └─ PhotoOrganizer.App/        # Avalonia desktop application
+│  ├─ PhotoOrganizer.Core/        # 共有の安全・取り込みロジック
+│  └─ PhotoOrganizer.App/         # Avalonia desktop app + platform adapters
 ├─ tests/
-│  ├─ PhotoOrganizer.Core.Tests/ # cross-platform safety regression
-│  └─ PhotoOrganizer.App.Tests/  # platform adapter / storage identity tests
+│  ├─ PhotoOrganizer.Core.Tests/  # cross-platform safety regression
+│  └─ PhotoOrganizer.App.Tests/   # OS adapter / diskutil / startup / identity tests
 ├─ tools/
 │  └─ PhotoOrganizer.IoBenchmark/ # SHA-256 / destination lookup I/O benchmark
 ├─ docs/
@@ -522,17 +611,50 @@ PhotoOrganizer/
 │  ├─ RELEASE.md
 │  ├─ RELEASE_ACCEPTANCE.md
 │  └─ STORAGE_IDENTITY.md
-├─ Scripts/                      # repository / release configuration helpers
-└─ .github/workflows/            # CI / CodeQL / benchmark / release
+├─ Scripts/                       # repository / release configuration helpers
+└─ .github/workflows/             # CI / CodeQL / benchmark / release
 ```
 
 ---
 
 ## テストとCI
 
-通常CIでは、WindowsとmacOSの両方で安全ロジックとdesktop applicationを検証します。
+Photo Organizer は、**Core の安全契約・platform adapter・実OS・package・release contract・実機 acceptance** を別々の層で検証します。
 
-主な検証内容:
+### テストの役割分担
+
+| 層 | 主な対象 |
+|---|---|
+| `PhotoOrganizer.Core.Tests` | complete scan、source immutability、重複判定、copy transaction、format safety、mount session、race / failure handling |
+| `PhotoOrganizer.App.Tests` | Windows / macOS storage identity、`diskutil` plist parser、bounded process execution、startup registration format、実OS volume resolution |
+| Package smoke | Windows x64/ARM64 ZIP、macOS arm64/x64 DMG の生成・展開 / mount |
+| CodeQL | C# static analysis |
+| I/O Benchmark | SHA-256 / destination lookup の読み取り量回帰 |
+| Release acceptance | 実SDカード、実ストレージ、unplug、logout/login、Gatekeeper / Authenticode、durability interruption |
+
+platform adapter tests は、OS API をすべて mock 化する方針ではありません。
+
+たとえば macOS storage identity は、
+
+```text
+diskutil subprocess
+        ↓
+BoundedProcessRunner
+        ↓
+raw plist
+        ↓
+MacDiskutilInfoParser
+        ↓
+volume / physical identity
+```
+
+のように、**OS コマンド実行部分と純粋な解釈ロジックを分離**しています。
+
+これにより、実 runner 上で `diskutil` が動くことを integration test しつつ、plist の欠損・型違い・fallback 順序・malformed XML は高速な unit test で網羅できます。
+
+同様に startup registration も、実際の Registry / LaunchAgent mutation と、書き込む command / plist の生成を分けてテストします。
+
+### 通常CIで確認するもの
 
 - shared Core safety tests
 - source immutability regression
@@ -541,9 +663,12 @@ PhotoOrganizer/
 - symlink / junction alias rejection
 - nested mounted-volume traversal rejection
 - volume / physical-device / mount-session replacement detection
-- durability failure時のfail-closed
-- durable sync中にdestinationが変化したraceの再hash検証
+- durability failure時の fail-closed
+- durable sync 中に destination が変化した race の再hash検証
 - Windows / macOS platform storage identity tests
+- `diskutil` plist parser の fallback / malformed input
+- subprocess timeout / stdout・stderr pipe handling
+- startup registration command / LaunchAgent plist generation
 - unified desktop app build
 - Windows x64 / ARM64 package smoke
 - macOS arm64 / x64 DMG smoke
@@ -561,45 +686,45 @@ workflows:
 .github/workflows/promote-release.yml
 ```
 
-安全性に関するbugは、可能な限り再現testを追加してから修正します。
+安全性に関する bug は、可能な限り再現 test を追加してから修正します。
 
 ---
 
 ## Release設計
 
-WindowsとmacOSは**同じversion・同じsource commit**からreleaseします。
+Windows と macOS は **同じ version・同じ source commit** から release します。
 
-production releaseはfail-closedです。
+production release は fail-closed です。
 
-- signing credentialが不足 → publishしない
-- Windowsだけ成功 → publishしない
-- macOSだけ成功 → publishしない
-- checksum不一致 → publishしない
-- signing / notarization失敗 → publishしない
-- real-device acceptance未完了 → stableへpromotionしない
+- signing credential が不足 → publish しない
+- Windows だけ成功 → publish しない
+- macOS だけ成功 → publish しない
+- checksum 不一致 → publish しない
+- signing / notarization 失敗 → publish しない
+- real-device acceptance 未完了 → stable へ promotion しない
 
-release authorityも分離されています。
+release authority も分離されています。
 
-- `production-signing` — signing / notarization credentialを保持
-- `production-release` — acceptance済みcandidateをstableへpromotionする権限
+- `production-signing` — signing / notarization credential を保持
+- `production-release` — acceptance 済み candidate を stable へ promotion する権限
 
-署名済みcandidate作成とstable promotionを別workflowへ分けることで、CI成功だけで一般配布が進まない構成です。
+署名済み candidate 作成と stable promotion を別 workflow へ分けることで、CI 成功だけで一般配布が進まない構成です。
 
 ---
 
 ## セキュリティと脆弱性報告
 
-次の問題は特に重大なrelease blockerとして扱います。
+次の問題は特に重大な release blocker として扱います。
 
-- source mediaの削除・変更
-- destination既存ファイルの上書き
+- source media の削除・変更
+- destination 既存ファイルの上書き
 - false duplicate detection
 - false SD-reuse approval
-- selected storage外へのpath traversal
+- selected storage 外への path traversal
 - signing bypass
 - arbitrary code execution
 
-データ消失の再現詳細、秘密鍵、certificate、password、token、実際のユーザー写真などをpublic Issueへ投稿しないでください。
+データ消失の再現詳細、秘密鍵、certificate、password、token、実際のユーザー写真などを public Issue へ投稿しないでください。
 
 報告方法は [`SECURITY.md`](SECURITY.md) を参照してください。
 
@@ -609,74 +734,94 @@ release authorityも分離されています。
 
 ### 1つの保存先はバックアップ戦略そのものではない
 
-Photo Organizerは、選択した保存先コピーの整合性を厳格に確認しますが、保存先device自体が壊れればデータを失う可能性があります。
+Photo Organizer は選択した保存先コピーの整合性を厳格に確認しますが、保存先 device 自体が壊れればデータを失う可能性があります。
 
-重要データでは別媒体・NAS・cloud等を組み合わせた追加バックアップを用意してください。
+重要データでは別媒体・NAS・cloud 等を組み合わせた追加バックアップを用意してください。
 
 ### ネットワーク / 仮想 / 特殊filesystem
 
-このアプリはsourceとdestinationの物理的な独立性を安全判定へ利用します。
+このアプリは source と destination の物理的な独立性を安全判定へ利用します。
 
-そのため、physical-device identityをOSから確立できないnetwork share、virtual filesystem、特殊mountなどではfail-closedとなる場合があります。
+そのため、physical-device identity を OS から確立できない network share、virtual filesystem、特殊 mount などでは fail-closed となる場合があります。
 
 「書き込めるから安全な保存先として使える」とは限りません。
 
-### storage firmwareの保証まではできない
+### storage firmware の保証まではできない
 
-Photo OrganizerはWindows / macOSが提供するdurability primitiveを使用しますが、device firmwareがflush要求に対して不正な成功を返すようなhardware failureまで検出できるわけではありません。
+Photo Organizer は Windows / macOS が提供する durability primitive を使用しますが、device firmware が flush 要求に対して不正な成功を返すような hardware failure まで検出できるわけではありません。
 
-production releaseでは、使い捨てdestinationを用いたabrupt disconnect → remount → independent rehashのreal-device acceptanceも要求しています。
+production release では、使い捨て destination を用いた abrupt disconnect → remount → independent rehash の real-device acceptance も要求しています。
 
 ---
 
 ## よくある質問
 
-### Q. 緑になったらSDカードをフォーマットしていい？
+### Q. 緑になったら SD カードをフォーマットしていい？
 
-Photo Organizerの対応対象ファイルについては、選択保存先への実bytes一致とdurable synchronizationまで確認済みという判定です。
+Photo Organizer の対応対象ファイルについては、選択保存先への実 bytes 一致と durable synchronization まで確認済みという判定です。
 
-ただし、greenは二重バックアップの意味ではありません。重要撮影では保存先側の追加バックアップも推奨します。
+ただし green は二重バックアップの意味ではありません。重要撮影では保存先側の追加バックアップも推奨します。
 
-### Q. Photo OrganizerがSDカードを自動で消すことはある？
+### Q. コピーが100%になったら SD カードを抜いていい？
 
-ありません。アプリにformat / erase機能はありません。
+いいえ。**green の「SDカード再利用可能」が表示されるまで待ってください。**
 
-### Q. XMP sidecarも保存される？
+コピー後にも complete rescan、fresh SHA-256、durable synchronization、storage identity の最終確認があります。
 
-現在は保存されません。XMP / XML / TXTなどは取り込み・SD再利用判定の対象外です。
+### Q. Photo Organizer が SD カードを自動で消すことはある？
 
-### Q. SDカードに前回の写真を残したまま再度取り込める？
+ありません。アプリに format / erase 機能はありません。
 
-できます。保存先全体からsize + SHA-256一致を確認できた既存データはskipし、新しいbytesだけを取り込みます。
+### Q. XMP sidecar も保存される？
+
+現在は保存されません。XMP / XML / TXT などは取り込み・SD 再利用判定の対象外です。
+
+### Q. SD カードに前回の写真を残したまま再度取り込める？
+
+できます。保存先全体から size + SHA-256 一致を確認できた既存データは skip し、新しい bytes だけを取り込みます。
 
 ### Q. 同名写真があると上書きされる？
 
-されません。同じbytesならduplicate、違うbytesなら `_2`, `_3` ... の別名で保持します。
+されません。同じ bytes なら duplicate、違う bytes なら `_2`, `_3` ... の別名で保持します。
 
-### Q. 保存先を同じSDカードの別partitionにしてもいい？
+### Q. 同じ内容の写真が別名で存在したら？
 
-できません。同じphysical storage deviceは独立したbackup locationとみなさず、取り込み前に拒否します。
+size + SHA-256 が一致する完全同一 bytes であれば、既に保存済みの内容として扱います。ファイル名は重複判定の主キーではありません。
 
-### Q. コピーが100%になったらSDカードを抜いていい？
+### Q. 保存先を同じ SD カードの別 partition にしてもいい？
 
-いいえ。**greenの「SDカード再利用可能」が表示されるまで待ってください。**
+できません。同じ physical storage device は独立した backup location とみなさず、取り込み前に拒否します。
 
-コピー後にもcomplete rescan、fresh SHA-256、durable synchronization、storage identityの最終確認があります。
+### Q. NAS を保存先にできる？
+
+physical-device identity を安全に確立できない network share は fail-closed になる可能性があります。現在の安全契約は、source と destination の物理的独立性を OS から確認できる保存先を前提にしています。
+
+### Q. アプリを再起動したら前回の green は残る？
+
+残りません。安全状態は永続化せず、新しい process では再度検証が必要です。
+
+### Q. 2枚の SD カードを同時に挿したら？
+
+処理中の active card は切り替えません。2枚目は待機 queue へ入り、現在の処理が終わった後に扱います。
+
+### Q. Windows版とmacOS版で安全判定は違う？
+
+基本的な安全契約は共通 Core にあります。OS ごとに異なるのは、volume / physical-device identity、durability primitive、startup / resident integration などの platform adapter 部分です。
 
 ---
 
 ## 移行について
 
-このrepositoryは、旧Windows版・macOS版を統合した新しいcanonical implementationです。
+この repository は、旧 Windows 版・macOS 版を統合した canonical implementation です。
 
 - [`PeachGumi/PhotoOrganizer-win`](https://github.com/PeachGumi/PhotoOrganizer-win) — original Windows implementation
 - [`PeachGumi/PhotoOrganizer-mac`](https://github.com/PeachGumi/PhotoOrganizer-mac) — hardened macOS safety reference
 
-旧実装で得たplatform固有の知見を引き継ぎつつ、現在はshared Coreを安全仕様のsource of truthとしています。
+旧実装で得た platform 固有の知見を引き継ぎつつ、現在は shared Core を安全仕様の source of truth としています。
 
-旧repositoryは、統合版の署名済みcandidateがreal-device acceptanceを完了しstableへpromotionされるまでreferenceとして保持します。
+旧 repository は、統合版の署名済み candidate が real-device acceptance を完了し stable へ promotion されるまで reference として保持します。
 
-意図的なbehavior差分とretirement条件は [`docs/MIGRATION_PLAN.md`](docs/MIGRATION_PLAN.md) を参照してください。
+意図的な behavior 差分と retirement 条件は [`docs/MIGRATION_PLAN.md`](docs/MIGRATION_PLAN.md) を参照してください。
 
 ---
 
@@ -684,12 +829,12 @@ Photo Organizerの対応対象ファイルについては、選択保存先へ�
 
 | Document | 内容 |
 |---|---|
-| [`docs/DATA_SAFETY.md`](docs/DATA_SAFETY.md) | データ安全性のnormative contract |
+| [`docs/DATA_SAFETY.md`](docs/DATA_SAFETY.md) | データ安全性の normative contract |
 | [`docs/STORAGE_IDENTITY.md`](docs/STORAGE_IDENTITY.md) | volume / physical device / mount session identity |
-| [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | shared Coreとplatform layerの設計 |
-| [`docs/MIGRATION_PLAN.md`](docs/MIGRATION_PLAN.md) | legacy版から統合版への移行方針 |
+| [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | shared Core と platform layer の設計 |
+| [`docs/MIGRATION_PLAN.md`](docs/MIGRATION_PLAN.md) | legacy 版から統合版への移行方針 |
 | [`docs/RELEASE.md`](docs/RELEASE.md) | signing / notarization / prerelease / stable promotion |
-| [`docs/RELEASE_ACCEPTANCE.md`](docs/RELEASE_ACCEPTANCE.md) | clean-machine / real-SD release acceptance |
+| [`docs/RELEASE_ACCEPTANCE.md`](docs/RELEASE_ACCEPTANCE.md) | clean-machine / real-SD / unplug / login / signing acceptance |
 | [`SECURITY.md`](SECURITY.md) | vulnerability reporting / security policy |
 
 ---

--- a/Scripts/configure_repository.sh
+++ b/Scripts/configure_repository.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 REPO="${1:-PeachGumi/PhotoOrganizer}"
 SIGNING_ENVIRONMENT="production-signing"
 RELEASE_ENVIRONMENT="production-release"
+DESCRIPTION='SDカードの写真・動画をWindows / macOSへ安全に取り込み、日付・イベント単位で整理。SHA-256検証と永続化確認後にSDカード再利用可否を判定する写真整理アプリ。'
 
 command -v gh >/dev/null 2>&1 || { echo "GitHub CLI (gh) is required." >&2; exit 1; }
 gh auth status >/dev/null
@@ -11,7 +12,7 @@ gh auth status >/dev/null
 echo "Configuring repository settings for ${REPO}..."
 
 gh api --method PATCH "repos/${REPO}" \
-  -f description='Cross-platform photo/video organizer for Windows and macOS with fail-safe SD-card import verification.' \
+  -f description="$DESCRIPTION" \
   -F has_issues=true \
   -F has_projects=false \
   -F has_wiki=false \
@@ -24,7 +25,18 @@ gh api --method PATCH "repos/${REPO}" \
 
 gh api --method PUT "repos/${REPO}/topics" --input - >/dev/null <<'JSON'
 {
-  "names": ["photography", "photo-organizer", "windows", "macos", "dotnet", "avalonia"]
+  "names": [
+    "photography",
+    "photo-organizer",
+    "sd-card",
+    "raw-photo",
+    "video-import",
+    "photo-backup",
+    "windows",
+    "macos",
+    "dotnet",
+    "avalonia"
+  ]
 }
 JSON
 
@@ -102,6 +114,7 @@ configure_main_only_environment "$RELEASE_ENVIRONMENT"
 
 # Post-configuration verification is intentionally fatal. Do not print a success
 # message when GitHub rejected or partially applied a hardening setting.
+[[ "$(gh api "repos/${REPO}" --jq '.description')" == "$DESCRIPTION" ]]
 [[ "$(gh api "repos/${REPO}" --jq '.allow_squash_merge')" == "true" ]]
 [[ "$(gh api "repos/${REPO}" --jq '.allow_merge_commit')" == "false" ]]
 [[ "$(gh api "repos/${REPO}" --jq '.allow_rebase_merge')" == "false" ]]
@@ -116,4 +129,4 @@ configure_main_only_environment "$RELEASE_ENVIRONMENT"
 verify_main_only_environment "$SIGNING_ENVIRONMENT"
 verify_main_only_environment "$RELEASE_ENVIRONMENT"
 
-echo "Repository settings, main protection, ${SIGNING_ENVIRONMENT}, and ${RELEASE_ENVIRONMENT} main-only policies verified."
+echo "Repository About, settings, main protection, ${SIGNING_ENVIRONMENT}, and ${RELEASE_ENVIRONMENT} main-only policies verified."


### PR DESCRIPTION
## 概要

PhotoOrganizer の GitHub About と README を、Media Sniper / extstore と同じ水準の日本語プロジェクト入口として整備します。

## About

`Scripts/configure_repository.sh` の repository description を日本語化し、About に表示する topics も PhotoOrganizer の用途へ合わせて拡充しました。

設定する説明文:

> SDカードの写真・動画をWindows / macOSへ安全に取り込み、日付・イベント単位で整理。SHA-256検証と永続化確認後にSDカード再利用可否を判定する写真整理アプリ。

また、スクリプト実行後に description が期待値どおり反映されたことを fail-closed で検証します。

## README

既存の安全設計を維持したまま、README を利用者向けの入口として全面再構成しました。

- CI / CodeQL / I/O Benchmark / .NET / platform / License badges
- 冒頭ナビゲーション
- 現在の配布状態を明示
- 機能を一覧表へ整理
- 想定ユースケースを追加
- クイックスタートを前方へ移動
- 対応OS / architecture / 配布形式を明示
- green判定条件を表で要約
- storage identity / durable commit / post-durability rehash を整理
- macOS `diskutil` parser と bounded subprocess の説明を追加
- App.Tests / Core.Tests / package smoke / CodeQL / I/O benchmark / 実機acceptance の役割分担を明示
- FAQ を拡充
- release / migration / security docs への導線を整理

## 注意

GitHub connector には repository settings の PATCH 操作が公開されていないため、About の実際の description/topics 更新は `bash Scripts/configure_repository.sh` で適用する設計です。README とスクリプト変更はこの PR で main へ入れます。

CI / CodeQL / package smoke / release contract が全て green になってから merge します。