### PR TITLE
Fix startup fallback across multiple camera cards

### DIFF
--- a/src/PhotoOrganizer.App/App.axaml.cs
+++ b/src/PhotoOrganizer.App/App.axaml.cs
@@ -68,7 +68,8 @@ public sealed partial class App : Application
             // Initial card discovery must also run when the application starts hidden.
             // A detected camera card will request that the workflow window be shown.
             var viewModel = _viewModel;
-            Dispatcher.UIThread.Post(() => _ = ObserveBackgroundTaskAsync(viewModel.InitializeAsync()));
+            Dispatcher.UIThread.Post(() => _ = ObserveBackgroundTaskAsync(
+                StartupCardDiscovery.InitializeAsync(viewModel, CameraCardRoots)));
         }
 
         base.OnFrameworkInitializationCompleted();

--- a/src/PhotoOrganizer.App/StartupCardDiscovery.cs
+++ b/src/PhotoOrganizer.App/StartupCardDiscovery.cs
@@ -1,0 +1,50 @@
+using PhotoOrganizer.Core;
+
+namespace PhotoOrganizer.App;
+
+public static class StartupCardDiscovery
+{
+    public static async Task InitializeAsync(
+        MainWindowViewModel viewModel,
+        CameraCardRootResolver cardRoots)
+    {
+        ArgumentNullException.ThrowIfNull(viewModel);
+        ArgumentNullException.ThrowIfNull(cardRoots);
+
+        IReadOnlyList<string> candidates;
+        try
+        {
+            // Platform enumeration may invoke diskutil/WMI. Keep it away from the
+            // Avalonia dispatcher just like the individual card scans below.
+            candidates = await Task.Run(cardRoots.GetCandidateRoots).ConfigureAwait(true);
+        }
+        catch (Exception exception)
+        {
+            viewModel.ReportUiFailure("起動時のSDカード検出", exception);
+            return;
+        }
+
+        foreach (var candidate in candidates)
+        {
+            if (viewModel.IsBusy || !string.IsNullOrWhiteSpace(viewModel.SelectedSdPath))
+            {
+                return;
+            }
+
+            await viewModel.ScanCardAsync(candidate, autoDetected: true).ConfigureAwait(true);
+
+            if (!string.IsNullOrWhiteSpace(viewModel.SelectedSdPath))
+            {
+                return;
+            }
+
+            // Auto-detected cards with no supported media deliberately return to the
+            // waiting state. Only that benign outcome should advance to the next card;
+            // cancellation or a real scan failure remains visible and fail-closed.
+            if (!string.Equals(viewModel.ProgressLabel, "待機中", StringComparison.Ordinal))
+            {
+                return;
+            }
+        }
+    }
+}

--- a/tests/PhotoOrganizer.App.Tests/StartupCardDiscoveryTests.cs
+++ b/tests/PhotoOrganizer.App.Tests/StartupCardDiscoveryTests.cs
@@ -1,0 +1,98 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PhotoOrganizer.Core;
+
+namespace PhotoOrganizer.App.Tests;
+
+[TestClass]
+public sealed class StartupCardDiscoveryTests
+{
+    [TestMethod]
+    public async Task InitializeAsync_SkipsEmptyFirstCardAndScansNextCandidate()
+    {
+        using var temp = new TempDirectory();
+        var emptyCard = Directory.CreateDirectory(Path.Combine(temp.Path, "01-empty-card")).FullName;
+        var validCard = Directory.CreateDirectory(Path.Combine(temp.Path, "02-valid-card")).FullName;
+        Directory.CreateDirectory(Path.Combine(emptyCard, "DCIM"));
+        var validDcim = Directory.CreateDirectory(Path.Combine(validCard, "DCIM")).FullName;
+        File.WriteAllText(Path.Combine(validDcim, "photo.jpg"), "camera-data");
+
+        var provider = new FakeVolumeProvider(
+        [
+            new MountedVolumeInfo(emptyCard, "volume-empty", true, false, "device-empty"),
+            new MountedVolumeInfo(validCard, "volume-valid", true, false, "device-valid")
+        ]);
+        var sessions = new StorageSessionTracker(provider);
+        var roots = new CameraCardRootResolver(provider);
+        using var viewModel = new MainWindowViewModel(provider, sessions, roots);
+
+        await StartupCardDiscovery.InitializeAsync(viewModel, roots);
+
+        Assert.AreEqual(PathSafety.Normalize(validCard), viewModel.SelectedSdPath);
+        Assert.AreEqual("RAW:0 / JPG:1 / MP4:0", viewModel.CountLabel);
+        Assert.AreEqual("取り込み準備完了", viewModel.ProgressLabel);
+        Assert.AreEqual(0, viewModel.PendingSdCount);
+    }
+
+    [TestMethod]
+    public async Task InitializeAsync_StopsOnRealScanFailureInsteadOfSkippingToAnotherCard()
+    {
+        using var temp = new TempDirectory();
+        var brokenCard = Directory.CreateDirectory(Path.Combine(temp.Path, "01-broken-card")).FullName;
+        var validCard = Directory.CreateDirectory(Path.Combine(temp.Path, "02-valid-card")).FullName;
+        Directory.CreateDirectory(Path.Combine(brokenCard, "DCIM"));
+        var validDcim = Directory.CreateDirectory(Path.Combine(validCard, "DCIM")).FullName;
+        File.WriteAllText(Path.Combine(validDcim, "photo.jpg"), "camera-data");
+
+        var provider = new FakeVolumeProvider(
+        [
+            // Missing physical-device identity is a safety failure, not a benign empty-card case.
+            new MountedVolumeInfo(brokenCard, "volume-broken", true, false, null),
+            new MountedVolumeInfo(validCard, "volume-valid", true, false, "device-valid")
+        ]);
+        var sessions = new StorageSessionTracker(provider);
+        var roots = new CameraCardRootResolver(provider);
+        using var viewModel = new MainWindowViewModel(provider, sessions, roots);
+
+        await StartupCardDiscovery.InitializeAsync(viewModel, roots);
+
+        Assert.AreEqual(string.Empty, viewModel.SelectedSdPath);
+        Assert.AreEqual("スキャン失敗", viewModel.ProgressLabel);
+        StringAssert.Contains(viewModel.SafetyDetail, "physical-device identity");
+    }
+
+    private sealed class FakeVolumeProvider(IReadOnlyList<MountedVolumeInfo> volumes) : IStorageVolumeProvider
+    {
+        public StringComparison PathComparison => OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        public IReadOnlyList<MountedVolumeInfo> GetMountedVolumes() => volumes;
+
+        public MountedVolumeInfo? ResolveVolumeForPath(string path)
+        {
+            var normalized = PathSafety.Normalize(path);
+            return volumes
+                .Where(volume => PathSafety.IsSameOrDescendant(normalized, volume.RootPath, PathComparison))
+                .OrderByDescending(volume => PathSafety.Normalize(volume.RootPath).Length)
+                .FirstOrDefault();
+        }
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"PhotoOrganizerStartup-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Path, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add resilient startup camera-card discovery
- skip a benign auto-detected card with no supported media and continue to the next mounted candidate
- stop fail-closed on real scan/safety failures
- add regression coverage for both paths

This addresses a startup case where an empty/unsupported first card could leave a later valid card undiscovered.