### PR TITLE
Expand runtime safety validation

### DIFF
--- a/docs/DATA_SAFETY.md
+++ b/docs/DATA_SAFETY.md
@@ -77,7 +77,9 @@ Reuse approval requires all of the following after copy processing:
 - an independent destination file with equal size and SHA-256 exists for every supported source file;
 - every destination file used as proof of backup can be durably synchronized at final verification time;
 - a source path itself, including the same bytes reached through a path alias, is never accepted as proof of an independent destination copy;
-- storage identity is checked again after hashing and durability synchronization before approval is displayed.
+- storage identity is checked again after hashing and durability synchronization;
+- a second complete whole-card scan after final byte verification sees exactly the same supported-file set that was verified, so media added or removed during verification cannot be silently omitted;
+- storage identity is checked again after that final consistency scan before approval is displayed.
 
 A SHA-256 match served from operating-system or device caches is not by itself sufficient proof that the camera card can be reformatted. Green approval requires durable destination commit in addition to byte verification.
 
@@ -91,7 +93,7 @@ Platform adapters are responsible for mounted-volume, physical-device, and proce
 
 ## Multi-card behavior
 
-A newly detected second card must never replace the currently selected/processing card. It may be queued and scanned only after the current operation is safely completed or reset.
+A newly detected second card must never replace the currently selected/processing card. It may be queued and scanned only after the current operation is safely completed or reset. Queue advancement may skip only an otherwise valid card that contains no supported media; a real scan/safety failure or cancellation must stop automatic advancement so the blocked state remains visible.
 
 ## Test policy
 

--- a/docs/IMPORT_SAFETY.md
+++ b/docs/IMPORT_SAFETY.md
@@ -25,10 +25,12 @@ The only transition to `SafeToReuse` is the complete sequence below. Every error
 13. Re-scan the complete card.
 14. Require the rescan to be complete and non-empty, and require every supported path observed before import to still be present.
 15. Freshly verify every supported file currently visible on the card against the destination library by size and SHA-256.
-16. Re-check both storage identities after hashing.
-17. Only then transition to `SafeToReuse`.
+16. Re-check both storage identities after hashing and durability synchronization.
+17. Re-scan the complete card once more and require the supported-file set to be identical to the set that was just verified. This catches supported media added or removed while final SHA-256/durability verification was running.
+18. Re-check both storage identities after that final consistency scan.
+19. Only then transition to `SafeToReuse`.
 
-A new supported file that appears on the card after copying is intentionally included by the final rescan. If no byte-identical destination copy exists, reuse approval is blocked.
+A new supported file that appears on the card after copying is intentionally included by the post-copy rescan. If no byte-identical destination copy exists, reuse approval is blocked. A supported file that appears or disappears while final verification is running is caught by the final consistency scan and also blocks reuse approval.
 
 ## Filesystem boundaries
 
@@ -40,8 +42,8 @@ The application never deletes, moves, renames, overwrites, formats, or otherwise
 
 ## Duplicate-only runs
 
-If every supported source file already has an independent byte-identical copy in the destination library, no new event directory is created. A fresh post-import scan and fresh final verification are still required before reuse approval.
+If every supported source file already has an independent byte-identical copy in the destination library, no new event directory is created. Fresh post-import and post-verification scans plus fresh final verification are still required before reuse approval.
 
 ## Cancellation and application exit
 
-Cancellation, exceptions, or process termination before the final verification completes cannot produce or preserve a `SafeToReuse` state. The UI must present these cases as blocked/not verified.
+Cancellation, exceptions, or process termination before the final consistency scan and verification sequence completes cannot produce or preserve a `SafeToReuse` state. The UI must present these cases as blocked/not verified.

--- a/src/PhotoOrganizer.App/MainWindowViewModel.CardWorkflow.cs
+++ b/src/PhotoOrganizer.App/MainWindowViewModel.CardWorkflow.cs
@@ -6,6 +6,8 @@ namespace PhotoOrganizer.App;
 
 public sealed partial class MainWindowViewModel
 {
+    private bool _drainingPendingCards;
+
     public async Task InitializeAsync()
     {
         if (_disposed) return;
@@ -45,6 +47,7 @@ public sealed partial class MainWindowViewModel
         }
 
         var scanCancellation = new CancellationTokenSource();
+        var continuePendingAfterScan = false;
         _scanCancellation = scanCancellation;
         _isScanning = true;
         RaiseCommandState();
@@ -65,6 +68,7 @@ public sealed partial class MainWindowViewModel
             {
                 if (autoDetected && result.IsNoSupportedMedia)
                 {
+                    continuePendingAfterScan = true;
                     AppendLog($"自動選択スキップ（対象メディアなし）: {path}");
                     ProgressLabel = "待機中";
                     return result;
@@ -120,7 +124,14 @@ public sealed partial class MainWindowViewModel
             }
 
             _isScanning = false;
-            if (!_disposed) RaiseCommandState();
+            if (!_disposed)
+            {
+                RaiseCommandState();
+                if (continuePendingAfterScan && !_drainingPendingCards)
+                {
+                    await ScanNextPendingIfPossibleAsync().ConfigureAwait(true);
+                }
+            }
         }
     }
 
@@ -214,19 +225,28 @@ public sealed partial class MainWindowViewModel
 
     private async Task ScanNextPendingIfPossibleAsync()
     {
-        if (_disposed || IsBusy || _scanSession is not null) return;
-        while (_pendingCards.Count > 0)
-        {
-            if (_disposed || IsBusy || _scanSession is not null) return;
+        if (_drainingPendingCards || _disposed || IsBusy || _scanSession is not null) return;
 
-            var next = _pendingCards[0];
-            _pendingCards.RemoveAt(0);
-            RaisePendingState();
-            var exists = await Task.Run(() => Directory.Exists(next)).ConfigureAwait(true);
-            if (_disposed) return;
-            if (!exists) continue;
-            await ScanCardAsync(next, autoDetected: true).ConfigureAwait(true);
-            if (_scanSession is not null) return;
+        _drainingPendingCards = true;
+        try
+        {
+            while (_pendingCards.Count > 0)
+            {
+                if (_disposed || IsBusy || _scanSession is not null) return;
+
+                var next = _pendingCards[0];
+                _pendingCards.RemoveAt(0);
+                RaisePendingState();
+                var exists = await Task.Run(() => Directory.Exists(next)).ConfigureAwait(true);
+                if (_disposed) return;
+                if (!exists) continue;
+                await ScanCardAsync(next, autoDetected: true).ConfigureAwait(true);
+                if (_scanSession is not null) return;
+            }
+        }
+        finally
+        {
+            _drainingPendingCards = false;
         }
     }
 

--- a/src/PhotoOrganizer.App/MainWindowViewModel.CardWorkflow.cs
+++ b/src/PhotoOrganizer.App/MainWindowViewModel.CardWorkflow.cs
@@ -240,8 +240,14 @@ public sealed partial class MainWindowViewModel
                 var exists = await Task.Run(() => Directory.Exists(next)).ConfigureAwait(true);
                 if (_disposed) return;
                 if (!exists) continue;
-                await ScanCardAsync(next, autoDetected: true).ConfigureAwait(true);
+
+                var result = await ScanCardAsync(next, autoDetected: true).ConfigureAwait(true);
                 if (_scanSession is not null) return;
+
+                // Only a benign empty camera card may be skipped automatically.
+                // A real scan/safety failure or cancellation must remain visible and
+                // stop queue advancement instead of being overwritten by another scan.
+                if (result is null || !result.IsNoSupportedMedia) return;
             }
         }
         finally

--- a/src/PhotoOrganizer.Core/ImportCoordinator.cs
+++ b/src/PhotoOrganizer.Core/ImportCoordinator.cs
@@ -358,6 +358,39 @@ public sealed class ImportCoordinator
                     verification);
             }
 
+            // Verification can take long enough for another supported file to appear
+            // after the post-copy scan. A final whole-card enumeration closes that
+            // window without repeating the expensive SHA-256/durability pass.
+            var finalRescan = _scanner.Scan(session.CardRoot, cancellationToken);
+
+            if (!StorageMatches(session, destinationIdentity, destination))
+            {
+                return Blocked(
+                    "Source or destination storage changed during the final camera-card consistency scan.",
+                    summary,
+                    verification);
+            }
+
+            if (!finalRescan.IsComplete)
+            {
+                errors.AddRange(finalRescan.Errors);
+                return Blocked(
+                    "Final camera-card consistency scan was incomplete. Do not reuse the card.",
+                    summary,
+                    verification);
+            }
+
+            var finalFiles = finalRescan.Files
+                .Select(Path.GetFullPath)
+                .ToHashSet(PathComparer.Instance);
+            if (!rescanned.SetEquals(finalFiles))
+            {
+                return Blocked(
+                    "Supported media changed during final verification. Do not reuse the card.",
+                    summary,
+                    verification);
+            }
+
             progress?.Report(new ImportProgress(
                 ImportProgressPhase.Verifying,
                 verification.Verified,

--- a/tests/PhotoOrganizer.App.Tests/PendingCardQueueTests.cs
+++ b/tests/PhotoOrganizer.App.Tests/PendingCardQueueTests.cs
@@ -1,0 +1,108 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PhotoOrganizer.Core;
+
+namespace PhotoOrganizer.App.Tests;
+
+[TestClass]
+public sealed class PendingCardQueueTests
+{
+    [TestMethod]
+    public async Task EmptyAutoDetectedScan_ContinuesToCardQueuedWhileScanning()
+    {
+        using var temp = new TempDirectory();
+        var emptyCard = Directory.CreateDirectory(Path.Combine(temp.Path, "01-empty-card")).FullName;
+        var validCard = Directory.CreateDirectory(Path.Combine(temp.Path, "02-valid-card")).FullName;
+        Directory.CreateDirectory(Path.Combine(emptyCard, "DCIM"));
+        var validDcim = Directory.CreateDirectory(Path.Combine(validCard, "DCIM")).FullName;
+        File.WriteAllText(Path.Combine(validDcim, "photo.jpg"), "camera-data");
+
+        using var provider = new BlockingVolumeProvider(
+        [
+            new MountedVolumeInfo(emptyCard, "volume-empty", true, false, "device-empty"),
+            new MountedVolumeInfo(validCard, "volume-valid", true, false, "device-valid")
+        ]);
+        var sessions = new StorageSessionTracker(provider);
+        var roots = new CameraCardRootResolver(provider);
+        using var viewModel = new MainWindowViewModel(provider, sessions, roots);
+
+        var firstScan = viewModel.ScanCardAsync(emptyCard, autoDetected: true);
+        Assert.IsTrue(
+            provider.FirstEnumerationEntered.Wait(TimeSpan.FromSeconds(5)),
+            "The first scan did not enter volume enumeration in time.");
+        Assert.IsTrue(viewModel.IsBusy);
+
+        var queuedResult = await viewModel.ScanCardAsync(validCard, autoDetected: true);
+        Assert.IsNull(queuedResult);
+        Assert.AreEqual(1, viewModel.PendingSdCount);
+
+        provider.ReleaseFirstEnumeration.Set();
+        var firstResult = await firstScan.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.IsNotNull(firstResult);
+        Assert.IsTrue(firstResult.IsNoSupportedMedia);
+        Assert.AreEqual(PathSafety.Normalize(validCard), viewModel.SelectedSdPath);
+        Assert.AreEqual("RAW:0 / JPG:1 / MP4:0", viewModel.CountLabel);
+        Assert.AreEqual("取り込み準備完了", viewModel.ProgressLabel);
+        Assert.AreEqual(0, viewModel.PendingSdCount);
+    }
+
+    private sealed class BlockingVolumeProvider(IReadOnlyList<MountedVolumeInfo> volumes)
+        : IStorageVolumeProvider, IDisposable
+    {
+        private int _blockFirstEnumeration = 1;
+
+        public ManualResetEventSlim FirstEnumerationEntered { get; } = new(false);
+        public ManualResetEventSlim ReleaseFirstEnumeration { get; } = new(false);
+
+        public StringComparison PathComparison => OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        public IReadOnlyList<MountedVolumeInfo> GetMountedVolumes()
+        {
+            if (Interlocked.Exchange(ref _blockFirstEnumeration, 0) == 1)
+            {
+                FirstEnumerationEntered.Set();
+                if (!ReleaseFirstEnumeration.Wait(TimeSpan.FromSeconds(10)))
+                {
+                    throw new TimeoutException("Test did not release the first volume enumeration.");
+                }
+            }
+
+            return volumes;
+        }
+
+        public MountedVolumeInfo? ResolveVolumeForPath(string path)
+        {
+            var normalized = PathSafety.Normalize(path);
+            return volumes
+                .Where(volume => PathSafety.IsSameOrDescendant(normalized, volume.RootPath, PathComparison))
+                .OrderByDescending(volume => PathSafety.Normalize(volume.RootPath).Length)
+                .FirstOrDefault();
+        }
+
+        public void Dispose()
+        {
+            FirstEnumerationEntered.Dispose();
+            ReleaseFirstEnumeration.Dispose();
+        }
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"PhotoOrganizerPendingCards-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Path, recursive: true); } catch { }
+        }
+    }
+}

--- a/tests/PhotoOrganizer.App.Tests/PendingCardQueueTests.cs
+++ b/tests/PhotoOrganizer.App.Tests/PendingCardQueueTests.cs
@@ -46,6 +46,45 @@ public sealed class PendingCardQueueTests
         Assert.AreEqual(0, viewModel.PendingSdCount);
     }
 
+    [TestMethod]
+    public async Task SafetyFailure_DoesNotAutoAdvanceToQueuedCard()
+    {
+        using var temp = new TempDirectory();
+        var brokenCard = Directory.CreateDirectory(Path.Combine(temp.Path, "01-broken-card")).FullName;
+        var validCard = Directory.CreateDirectory(Path.Combine(temp.Path, "02-valid-card")).FullName;
+        var brokenDcim = Directory.CreateDirectory(Path.Combine(brokenCard, "DCIM")).FullName;
+        var validDcim = Directory.CreateDirectory(Path.Combine(validCard, "DCIM")).FullName;
+        File.WriteAllText(Path.Combine(brokenDcim, "broken.jpg"), "camera-data");
+        File.WriteAllText(Path.Combine(validDcim, "photo.jpg"), "camera-data");
+
+        using var provider = new BlockingVolumeProvider(
+        [
+            new MountedVolumeInfo(brokenCard, "volume-broken", true, false, null),
+            new MountedVolumeInfo(validCard, "volume-valid", true, false, "device-valid")
+        ]);
+        var sessions = new StorageSessionTracker(provider);
+        var roots = new CameraCardRootResolver(provider);
+        using var viewModel = new MainWindowViewModel(provider, sessions, roots);
+
+        var firstScan = viewModel.ScanCardAsync(brokenCard, autoDetected: true);
+        Assert.IsTrue(
+            provider.FirstEnumerationEntered.Wait(TimeSpan.FromSeconds(5)),
+            "The first scan did not enter volume enumeration in time.");
+
+        Assert.IsNull(await viewModel.ScanCardAsync(validCard, autoDetected: true));
+        Assert.AreEqual(1, viewModel.PendingSdCount);
+
+        provider.ReleaseFirstEnumeration.Set();
+        var firstResult = await firstScan.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.IsNotNull(firstResult);
+        Assert.AreEqual(ScanFailureReason.MissingPhysicalDeviceIdentity, firstResult.FailureReason);
+        Assert.AreEqual(string.Empty, viewModel.SelectedSdPath);
+        Assert.AreEqual("スキャン失敗", viewModel.ProgressLabel);
+        Assert.AreEqual(1, viewModel.PendingSdCount);
+        StringAssert.Contains(viewModel.SafetyDetail, "physical-device identity");
+    }
+
     private sealed class BlockingVolumeProvider(IReadOnlyList<MountedVolumeInfo> volumes)
         : IStorageVolumeProvider, IDisposable
     {

--- a/tests/PhotoOrganizer.App.Tests/PendingCardQueueTests.cs
+++ b/tests/PhotoOrganizer.App.Tests/PendingCardQueueTests.cs
@@ -85,6 +85,49 @@ public sealed class PendingCardQueueTests
         StringAssert.Contains(viewModel.SafetyDetail, "physical-device identity");
     }
 
+    [TestMethod]
+    public async Task QueueDrain_StopsOnSafetyFailureAndLeavesLaterCardPending()
+    {
+        using var temp = new TempDirectory();
+        var emptyCard = Directory.CreateDirectory(Path.Combine(temp.Path, "01-empty-card")).FullName;
+        var brokenCard = Directory.CreateDirectory(Path.Combine(temp.Path, "02-broken-card")).FullName;
+        var validCard = Directory.CreateDirectory(Path.Combine(temp.Path, "03-valid-card")).FullName;
+        Directory.CreateDirectory(Path.Combine(emptyCard, "DCIM"));
+        var brokenDcim = Directory.CreateDirectory(Path.Combine(brokenCard, "DCIM")).FullName;
+        var validDcim = Directory.CreateDirectory(Path.Combine(validCard, "DCIM")).FullName;
+        File.WriteAllText(Path.Combine(brokenDcim, "broken.jpg"), "camera-data");
+        File.WriteAllText(Path.Combine(validDcim, "photo.jpg"), "camera-data");
+
+        using var provider = new BlockingVolumeProvider(
+        [
+            new MountedVolumeInfo(emptyCard, "volume-empty", true, false, "device-empty"),
+            new MountedVolumeInfo(brokenCard, "volume-broken", true, false, null),
+            new MountedVolumeInfo(validCard, "volume-valid", true, false, "device-valid")
+        ]);
+        var sessions = new StorageSessionTracker(provider);
+        var roots = new CameraCardRootResolver(provider);
+        using var viewModel = new MainWindowViewModel(provider, sessions, roots);
+
+        var firstScan = viewModel.ScanCardAsync(emptyCard, autoDetected: true);
+        Assert.IsTrue(
+            provider.FirstEnumerationEntered.Wait(TimeSpan.FromSeconds(5)),
+            "The first scan did not enter volume enumeration in time.");
+
+        Assert.IsNull(await viewModel.ScanCardAsync(brokenCard, autoDetected: true));
+        Assert.IsNull(await viewModel.ScanCardAsync(validCard, autoDetected: true));
+        Assert.AreEqual(2, viewModel.PendingSdCount);
+
+        provider.ReleaseFirstEnumeration.Set();
+        var firstResult = await firstScan.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.IsNotNull(firstResult);
+        Assert.IsTrue(firstResult.IsNoSupportedMedia);
+        Assert.AreEqual(string.Empty, viewModel.SelectedSdPath);
+        Assert.AreEqual("スキャン失敗", viewModel.ProgressLabel);
+        Assert.AreEqual(1, viewModel.PendingSdCount);
+        StringAssert.Contains(viewModel.SafetyDetail, "physical-device identity");
+    }
+
     private sealed class BlockingVolumeProvider(IReadOnlyList<MountedVolumeInfo> volumes)
         : IStorageVolumeProvider, IDisposable
     {

--- a/tests/PhotoOrganizer.Core.Tests/ExtendedRuntimeSafetyTests.cs
+++ b/tests/PhotoOrganizer.Core.Tests/ExtendedRuntimeSafetyTests.cs
@@ -1,0 +1,180 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PhotoOrganizer.Core.Tests;
+
+[TestClass]
+public sealed class ExtendedRuntimeSafetyTests
+{
+    [TestMethod]
+    public async Task SupportedFileAppearingAfterRescanBeforeVerification_BlocksReuse()
+    {
+        using var env = RuntimeEnvironment.Create();
+        env.AddCameraFile("DCIM/original.jpg", "original-data", new DateTime(2026, 8, 30, 8, 0, 0));
+        var coordinator = env.CreateCoordinator();
+        var scan = coordinator.ScanCard(env.CardRoot);
+        Assert.IsTrue(scan.IsReady);
+
+        var added = false;
+        var progress = new InlineProgress(update =>
+        {
+            if (!added && update.Phase == ImportProgressPhase.Verifying)
+            {
+                added = true;
+                env.AddCameraFile("DCIM/late.jpg", "late-data", new DateTime(2026, 8, 30, 8, 1, 0));
+            }
+        });
+
+        var result = await coordinator.ImportAsync(
+            scan.Session!,
+            env.DestinationRoot,
+            "Race",
+            progress);
+
+        Assert.IsTrue(added, "The late media mutation was not injected.");
+        Assert.AreEqual(ImportSafetyStatus.Blocked, result.Status);
+        Assert.IsFalse(result.IsSafeToReuse);
+    }
+
+    [TestMethod]
+    public async Task DestinationParentOfCameraCard_IsRejectedBeforeCopy()
+    {
+        using var env = RuntimeEnvironment.Create();
+        env.AddCameraFile("DCIM/photo.jpg", "camera-data", new DateTime(2026, 8, 30));
+        var coordinator = env.CreateCoordinator();
+        var scan = coordinator.ScanCard(env.CardRoot);
+        Assert.IsTrue(scan.IsReady);
+
+        var result = await coordinator.ImportAsync(scan.Session!, env.Root, "UnsafeParent");
+
+        Assert.AreEqual(ImportSafetyStatus.Blocked, result.Status);
+        StringAssert.Contains(result.Message, "parent/child");
+        Assert.AreEqual("camera-data", File.ReadAllText(Path.Combine(env.CardRoot, "DCIM", "photo.jpg")));
+    }
+
+    [TestMethod]
+    public void NestedDcimSelection_ScansWholeCardIncludingPrivateMedia()
+    {
+        using var env = RuntimeEnvironment.Create();
+        var selected = Directory.CreateDirectory(Path.Combine(env.CardRoot, "DCIM", "100NIKON")).FullName;
+        var jpg = env.AddCameraFile("DCIM/100NIKON/photo.jpg", "jpg-data", new DateTime(2026, 8, 30));
+        var mov = env.AddCameraFile("PRIVATE/AVCHD/clip.mp4", "video-data", new DateTime(2026, 8, 30));
+
+        var scan = env.CreateCoordinator().ScanCard(selected);
+
+        Assert.IsTrue(scan.IsReady, scan.Message);
+        Assert.AreEqual(PathSafety.Normalize(env.CardRoot), scan.Session!.CardRoot);
+        CollectionAssert.AreEquivalent(
+            new[] { Path.GetFullPath(jpg), Path.GetFullPath(mov) },
+            scan.Session.Files.ToArray());
+    }
+
+    [TestMethod]
+    public void AmbiguousMountedIdentityForSameRoot_FailsClosed()
+    {
+        using var temp = new TempDirectory();
+        var root = Directory.CreateDirectory(Path.Combine(temp.Path, "volume")).FullName;
+        var provider = new StaticVolumeProvider(
+        [
+            new MountedVolumeInfo(root, "fingerprint-a", true, false, "physical-a"),
+            new MountedVolumeInfo(root, "fingerprint-b", true, false, "physical-b")
+        ]);
+        var tracker = new StorageSessionTracker(provider);
+
+        Assert.IsNull(tracker.Capture(root));
+    }
+
+    private sealed class InlineProgress(Action<ImportProgress> callback) : IProgress<ImportProgress>
+    {
+        public void Report(ImportProgress value) => callback(value);
+    }
+
+    private sealed class RuntimeEnvironment : IDisposable
+    {
+        private RuntimeEnvironment(string root, string cardRoot, string destinationRoot, StaticVolumeProvider provider)
+        {
+            Root = root;
+            CardRoot = cardRoot;
+            DestinationRoot = destinationRoot;
+            Provider = provider;
+            Tracker = new StorageSessionTracker(provider);
+        }
+
+        public string Root { get; }
+        public string CardRoot { get; }
+        public string DestinationRoot { get; }
+        public StaticVolumeProvider Provider { get; }
+        public StorageSessionTracker Tracker { get; }
+
+        public static RuntimeEnvironment Create()
+        {
+            var root = Path.Combine(Path.GetTempPath(), $"PhotoOrganizerExtendedRuntime-{Guid.NewGuid():N}");
+            var card = Path.Combine(root, "card");
+            var destination = Path.Combine(root, "destination");
+            Directory.CreateDirectory(Path.Combine(card, "DCIM"));
+            Directory.CreateDirectory(destination);
+
+            var provider = new StaticVolumeProvider(
+            [
+                new MountedVolumeInfo(card, "camera-volume", true, false, "physical-camera"),
+                new MountedVolumeInfo(destination, "destination-volume", false, false, "physical-destination")
+            ]);
+            return new RuntimeEnvironment(root, card, destination, provider);
+        }
+
+        public string AddCameraFile(string relativePath, string content, DateTime timestamp)
+        {
+            var path = Path.Combine(CardRoot, relativePath.Replace('/', Path.DirectorySeparatorChar));
+            Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+            File.WriteAllText(path, content);
+            File.SetLastWriteTime(path, timestamp);
+            return path;
+        }
+
+        public ImportCoordinator CreateCoordinator() => new(
+            new MediaClassifier(),
+            Tracker,
+            new CameraCardRootResolver(Provider),
+            Provider);
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Root, recursive: true); } catch { }
+        }
+    }
+
+    private sealed class StaticVolumeProvider(IReadOnlyList<MountedVolumeInfo> volumes) : IStorageVolumeProvider
+    {
+        public StringComparison PathComparison => OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        public IReadOnlyList<MountedVolumeInfo> GetMountedVolumes() => volumes;
+
+        public MountedVolumeInfo? ResolveVolumeForPath(string path)
+        {
+            var normalized = PathSafety.Normalize(path);
+            return volumes
+                .Where(volume => PathSafety.IsSameOrDescendant(normalized, volume.RootPath, PathComparison))
+                .OrderByDescending(volume => PathSafety.Normalize(volume.RootPath).Length)
+                .FirstOrDefault();
+        }
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"PhotoOrganizerAmbiguousIdentity-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Path, recursive: true); } catch { }
+        }
+    }
+}

--- a/tests/PhotoOrganizer.Core.Tests/SafeCopyRaceSafetyTests.cs
+++ b/tests/PhotoOrganizer.Core.Tests/SafeCopyRaceSafetyTests.cs
@@ -1,0 +1,120 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PhotoOrganizer.Core.Tests;
+
+[TestClass]
+public sealed class SafeCopyRaceSafetyTests
+{
+    [TestMethod]
+    public async Task FinalNameClaimedDuringFinalize_PreservesCompetitorAndUsesSuffix()
+    {
+        using var temp = new TempDirectory();
+        var sourceDirectory = Directory.CreateDirectory(Path.Combine(temp.Path, "source")).FullName;
+        var destinationDirectory = Directory.CreateDirectory(Path.Combine(temp.Path, "destination")).FullName;
+        var source = Path.Combine(sourceDirectory, "photo.jpg");
+        File.WriteAllText(source, "irreplaceable-camera-data");
+
+        var result = await new SafeCopyService(new ClaimFirstFinalNameDurabilityService())
+            .CopyAsync(source, destinationDirectory);
+
+        Assert.AreEqual(CopyStatus.Copied, result.Status, result.Error);
+        Assert.AreEqual("irreplaceable-camera-data", File.ReadAllText(source));
+        Assert.AreEqual("competing-user-data", File.ReadAllText(Path.Combine(destinationDirectory, "photo.jpg")));
+        Assert.AreEqual("irreplaceable-camera-data", File.ReadAllText(Path.Combine(destinationDirectory, "photo_2.jpg")));
+        Assert.IsFalse(Directory.EnumerateFiles(destinationDirectory, ".partial-*", SearchOption.TopDirectoryOnly).Any());
+    }
+
+    [TestMethod]
+    public async Task FinalizationFailureBeforeMove_CleansOnlyOwnedPartialAndPreservesSource()
+    {
+        using var temp = new TempDirectory();
+        var sourceDirectory = Directory.CreateDirectory(Path.Combine(temp.Path, "source")).FullName;
+        var destinationDirectory = Directory.CreateDirectory(Path.Combine(temp.Path, "destination")).FullName;
+        var source = Path.Combine(sourceDirectory, "photo.jpg");
+        File.WriteAllText(source, "irreplaceable-camera-data");
+
+        var result = await new SafeCopyService(new FailBeforeMoveDurabilityService())
+            .CopyAsync(source, destinationDirectory);
+
+        Assert.AreEqual(CopyStatus.Failed, result.Status);
+        Assert.AreEqual("irreplaceable-camera-data", File.ReadAllText(source));
+        Assert.IsFalse(File.Exists(Path.Combine(destinationDirectory, "photo.jpg")));
+        Assert.IsFalse(Directory.EnumerateFiles(destinationDirectory, ".partial-*", SearchOption.TopDirectoryOnly).Any());
+    }
+
+    [TestMethod]
+    public async Task ExistingByteIdenticalFileWithoutDurabilityProof_IsNotAcceptedAsDuplicate()
+    {
+        using var temp = new TempDirectory();
+        var sourceDirectory = Directory.CreateDirectory(Path.Combine(temp.Path, "source")).FullName;
+        var destinationDirectory = Directory.CreateDirectory(Path.Combine(temp.Path, "destination")).FullName;
+        var source = Path.Combine(sourceDirectory, "photo.jpg");
+        var destination = Path.Combine(destinationDirectory, "photo.jpg");
+        File.WriteAllText(source, "same-bytes");
+        File.WriteAllText(destination, "same-bytes");
+
+        var result = await new SafeCopyService(new DuplicateDurabilityFailureService())
+            .CopyAsync(source, destinationDirectory);
+
+        Assert.AreEqual(CopyStatus.Failed, result.Status);
+        Assert.AreEqual(destination, result.DestinationPath);
+        Assert.AreEqual("same-bytes", File.ReadAllText(source));
+        Assert.AreEqual("same-bytes", File.ReadAllText(destination));
+        StringAssert.Contains(result.Error ?? string.Empty, "simulated duplicate durability failure");
+    }
+
+    private sealed class ClaimFirstFinalNameDurabilityService : IFileDurabilityService
+    {
+        private int _calls;
+
+        public FinalizeFileResult FinalizeNewFile(string temporaryPath, string finalPath, DateTime lastWriteUtc)
+        {
+            if (Interlocked.Increment(ref _calls) == 1)
+            {
+                File.WriteAllText(finalPath, "competing-user-data");
+                return new FinalizeFileResult(FinalizeFileStatus.DestinationExists, false);
+            }
+
+            File.Move(temporaryPath, finalPath, overwrite: false);
+            File.SetLastWriteTimeUtc(finalPath, lastWriteUtc);
+            return new FinalizeFileResult(FinalizeFileStatus.Committed, true);
+        }
+
+        public DurabilityResult EnsureDurable(string filePath) => new(true);
+    }
+
+    private sealed class FailBeforeMoveDurabilityService : IFileDurabilityService
+    {
+        public FinalizeFileResult FinalizeNewFile(string temporaryPath, string finalPath, DateTime lastWriteUtc) =>
+            new(FinalizeFileStatus.Failed, false, "simulated failure before move");
+
+        public DurabilityResult EnsureDurable(string filePath) => new(true);
+    }
+
+    private sealed class DuplicateDurabilityFailureService : IFileDurabilityService
+    {
+        public FinalizeFileResult FinalizeNewFile(string temporaryPath, string finalPath, DateTime lastWriteUtc) =>
+            throw new NotSupportedException();
+
+        public DurabilityResult EnsureDurable(string filePath) =>
+            new(false, "simulated duplicate durability failure");
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"PhotoOrganizerSafeCopyRace-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Path, recursive: true); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
現行 main を対象に、実運用の故障・競合・差し替えを想定した追加動作検証を行いました。

## 今回実際に再現して修正した問題

1. スキャン中に2枚目のカードが待機キューへ入り、1枚目が「対象メディアなし」で終了すると、2枚目が自動で処理されず待機したままになる。
2. 待機キュー処理中、途中のカードで物理デバイスID不明などの実安全エラーが起きても、後続カードへ自動で進んでブロック状態を上書きし得る。
3. コピー後の全カード再スキャンが終わった直後〜最終SHA-256/durability検証中に新しい対応メディアが追加されると、そのファイルを検証しないまま SafeToReuse になり得る。

## 修正

- 自動検出の「対象メディアなし」だけを安全にスキップして待機カードへ進む。
- 実安全エラー/キャンセルでは待機キューの自動進行を停止し、fail-closed状態を保持する。
- 最終SHA-256/durability検証後に、カード全体をもう一度軽量スキャンし、直前に検証した対応ファイル集合と完全一致することを SafeToReuse の追加条件にする。
- この追加最終スキャンはファイル列挙のみで、SHA-256読み取り量は増やさない。

## 追加回帰テスト

- 空カード中に待機した有効カードへの継続
- 安全エラー時に待機カードへ進まないこと
- キュー途中の安全エラーで後続カードを残して停止
- 最終検証中に追加された対応ファイルで再利用判定をブロック
- 保存先がカード親ディレクトリの場合の事前拒否
- ネストしたDCIM選択からカード全体/DCIM+PRIVATEを走査
- 同一rootに曖昧なストレージIDが複数ある場合のfail-closed
- final name競合時に既存ファイルを保持してsuffixへ退避
- finalize失敗時に自分のpartialだけを掃除しソースを保持
- 既存同一bytesでもdurability証明不能ならduplicate扱いしない

## 安全不変条件

- ソースSD上のメディアは削除・移動・上書きしない。
- コピー完了だけではSD再利用可能にしない。
- ストレージ差し替え、ID不明、スキャン不完全、検証不完全はfail-closed。
- 保存先は別ボリュームかつ別物理ストレージ必須。
- no-clobber、SHA-256、durable commit、fresh source rehashを維持。

## 検証結果

最終実装headで Windows/macOS の共有安全テスト、プラットフォームIDテスト、Release build、macOSアイコン検証、Windows x64/ARM64 package smoke、macOS arm64/x64 package smoke、release contract、I/O benchmark、CodeQL がすべて成功。Windowsログでは Core 67/67、App 47/47、Release build 0 warnings / 0 errors。