### PR TITLE
Add process-level crash fault injection tests

### DIFF
--- a/PhotoOrganizer.slnx
+++ b/PhotoOrganizer.slnx
@@ -1,6 +1,7 @@
 <Solution>
   <Project Path="src/PhotoOrganizer.Core/PhotoOrganizer.Core.csproj" />
   <Project Path="src/PhotoOrganizer.App/PhotoOrganizer.App.csproj" />
+  <Project Path="tests/PhotoOrganizer.FaultInjection.Worker/PhotoOrganizer.FaultInjection.Worker.csproj" />
   <Project Path="tests/PhotoOrganizer.Core.Tests/PhotoOrganizer.Core.Tests.csproj" />
   <Project Path="tests/PhotoOrganizer.App.Tests/PhotoOrganizer.App.Tests.csproj" />
 </Solution>

--- a/tests/PhotoOrganizer.Core.Tests/PhotoOrganizer.Core.Tests.csproj
+++ b/tests/PhotoOrganizer.Core.Tests/PhotoOrganizer.Core.Tests.csproj
@@ -12,5 +12,6 @@
 
   <ItemGroup>
     <ProjectReference Include="../../src/PhotoOrganizer.Core/PhotoOrganizer.Core.csproj" />
+    <ProjectReference Include="../PhotoOrganizer.FaultInjection.Worker/PhotoOrganizer.FaultInjection.Worker.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/PhotoOrganizer.Core.Tests/ProcessCrashSafetyTests.cs
+++ b/tests/PhotoOrganizer.Core.Tests/ProcessCrashSafetyTests.cs
@@ -1,0 +1,260 @@
+using System.Diagnostics;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PhotoOrganizer.Core.Tests;
+
+[TestClass]
+[DoNotParallelize]
+public sealed class ProcessCrashSafetyTests
+{
+    private static readonly string[] FinalizationCrashModes =
+    [
+        "before-finalize",
+        "after-finalize-before-durable",
+        "after-durable-before-return"
+    ];
+
+    [TestMethod]
+    public async Task CrashMatrix_PreservesSourceNeverOverwritesAndRecoversSafely()
+    {
+        const int iterations = 18;
+
+        for (var iteration = 0; iteration < iterations; iteration++)
+        {
+            using var temp = new TempDirectory();
+            var sourceDirectory = Directory.CreateDirectory(Path.Combine(temp.Path, "card")).FullName;
+            var destinationDirectory = Directory.CreateDirectory(Path.Combine(temp.Path, "library")).FullName;
+            var source = Path.Combine(sourceDirectory, "photo.jpg");
+            var checkpoint = Path.Combine(temp.Path, "checkpoint.txt");
+            var payload = CreatePayload(iteration + 1000);
+            File.WriteAllBytes(source, payload);
+
+            var hasCollision = iteration % 2 == 1;
+            var competitorPath = Path.Combine(destinationDirectory, "photo.jpg");
+            var competitor = CreatePayload(iteration + 9000);
+            if (hasCollision)
+            {
+                File.WriteAllBytes(competitorPath, competitor);
+            }
+
+            var mode = FinalizationCrashModes[iteration % FinalizationCrashModes.Length];
+            await RunUntilCheckpointAndKillAsync(mode, source, destinationDirectory, checkpoint);
+
+            CollectionAssert.AreEqual(payload, File.ReadAllBytes(source), $"Source changed after crash mode {mode}, iteration {iteration}.");
+            if (hasCollision)
+            {
+                CollectionAssert.AreEqual(competitor, File.ReadAllBytes(competitorPath), $"Existing destination was overwritten in iteration {iteration}.");
+            }
+
+            var expectedFinal = Path.Combine(destinationDirectory, hasCollision ? "photo_2.jpg" : "photo.jpg");
+            if (mode == "before-finalize")
+            {
+                Assert.IsFalse(File.Exists(expectedFinal), $"Final file appeared before finalization in iteration {iteration}.");
+                Assert.AreEqual(1, Directory.EnumerateFiles(destinationDirectory, ".partial-*", SearchOption.TopDirectoryOnly).Count());
+            }
+            else
+            {
+                Assert.IsTrue(File.Exists(expectedFinal), $"Final file was missing after finalization in iteration {iteration}.");
+                CollectionAssert.AreEqual(payload, File.ReadAllBytes(expectedFinal));
+                Assert.IsFalse(Directory.EnumerateFiles(destinationDirectory, ".partial-*", SearchOption.TopDirectoryOnly).Any());
+            }
+
+            var recovery = await new SafeCopyService().CopyAsync(source, destinationDirectory);
+            var expectedStatus = mode == "before-finalize" ? CopyStatus.Copied : CopyStatus.SkippedDuplicate;
+            Assert.AreEqual(expectedStatus, recovery.Status, $"Recovery failed after {mode}, iteration {iteration}: {recovery.Error}");
+            Assert.AreEqual(expectedFinal, recovery.DestinationPath);
+            CollectionAssert.AreEqual(payload, File.ReadAllBytes(source));
+            CollectionAssert.AreEqual(payload, File.ReadAllBytes(expectedFinal));
+
+            if (hasCollision)
+            {
+                CollectionAssert.AreEqual(competitor, File.ReadAllBytes(competitorPath));
+            }
+        }
+    }
+
+    [TestMethod]
+    public async Task CrashDuringExistingDuplicateDurability_PreservesBothCopiesAndRecovers()
+    {
+        for (var iteration = 0; iteration < 4; iteration++)
+        {
+            using var temp = new TempDirectory();
+            var sourceDirectory = Directory.CreateDirectory(Path.Combine(temp.Path, "card")).FullName;
+            var destinationDirectory = Directory.CreateDirectory(Path.Combine(temp.Path, "library")).FullName;
+            var source = Path.Combine(sourceDirectory, "photo.jpg");
+            var destination = Path.Combine(destinationDirectory, "photo.jpg");
+            var checkpoint = Path.Combine(temp.Path, "checkpoint.txt");
+            var payload = CreatePayload(iteration + 2000);
+            File.WriteAllBytes(source, payload);
+            File.WriteAllBytes(destination, payload);
+
+            await RunUntilCheckpointAndKillAsync("duplicate-durability", source, destinationDirectory, checkpoint);
+
+            CollectionAssert.AreEqual(payload, File.ReadAllBytes(source));
+            CollectionAssert.AreEqual(payload, File.ReadAllBytes(destination));
+            Assert.IsFalse(Directory.EnumerateFiles(destinationDirectory, ".partial-*", SearchOption.TopDirectoryOnly).Any());
+
+            var recovery = await new SafeCopyService().CopyAsync(source, destinationDirectory);
+            Assert.AreEqual(CopyStatus.SkippedDuplicate, recovery.Status, recovery.Error);
+            Assert.AreEqual(destination, recovery.DestinationPath);
+            CollectionAssert.AreEqual(payload, File.ReadAllBytes(source));
+            CollectionAssert.AreEqual(payload, File.ReadAllBytes(destination));
+        }
+    }
+
+    [TestMethod]
+    public async Task RepeatedPreFinalizeCrashes_LeaveOnlyUnownedPartialsAndLaterImportStillSucceeds()
+    {
+        using var temp = new TempDirectory();
+        var sourceDirectory = Directory.CreateDirectory(Path.Combine(temp.Path, "card")).FullName;
+        var destinationDirectory = Directory.CreateDirectory(Path.Combine(temp.Path, "library")).FullName;
+        var source = Path.Combine(sourceDirectory, "photo.jpg");
+        var payload = CreatePayload(3000);
+        File.WriteAllBytes(source, payload);
+
+        const int crashCount = 6;
+        for (var iteration = 0; iteration < crashCount; iteration++)
+        {
+            var checkpoint = Path.Combine(temp.Path, $"checkpoint-{iteration}.txt");
+            await RunUntilCheckpointAndKillAsync("before-finalize", source, destinationDirectory, checkpoint);
+
+            CollectionAssert.AreEqual(payload, File.ReadAllBytes(source));
+            Assert.IsFalse(File.Exists(Path.Combine(destinationDirectory, "photo.jpg")));
+            Assert.AreEqual(
+                iteration + 1,
+                Directory.EnumerateFiles(destinationDirectory, ".partial-*", SearchOption.TopDirectoryOnly).Count(),
+                "A killed process may leave only its own never-finalized partial; existing partials must not be touched.");
+        }
+
+        var recovery = await new SafeCopyService().CopyAsync(source, destinationDirectory);
+        Assert.AreEqual(CopyStatus.Copied, recovery.Status, recovery.Error);
+        Assert.AreEqual(Path.Combine(destinationDirectory, "photo.jpg"), recovery.DestinationPath);
+        CollectionAssert.AreEqual(payload, File.ReadAllBytes(source));
+        CollectionAssert.AreEqual(payload, File.ReadAllBytes(recovery.DestinationPath!));
+        Assert.AreEqual(crashCount, Directory.EnumerateFiles(destinationDirectory, ".partial-*", SearchOption.TopDirectoryOnly).Count());
+    }
+
+    private static async Task RunUntilCheckpointAndKillAsync(
+        string mode,
+        string source,
+        string destinationDirectory,
+        string checkpoint)
+    {
+        var workerAssembly = FindWorkerAssembly();
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add(workerAssembly);
+        startInfo.ArgumentList.Add(mode);
+        startInfo.ArgumentList.Add(source);
+        startInfo.ArgumentList.Add(destinationDirectory);
+        startInfo.ArgumentList.Add(checkpoint);
+
+        using var process = Process.Start(startInfo) ?? throw new AssertFailedException("Failed to start fault-injection worker.");
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(30);
+
+        while (!File.Exists(checkpoint))
+        {
+            if (process.HasExited)
+            {
+                throw new AssertFailedException($"Fault-injection worker exited before checkpoint {mode} with code {process.ExitCode}.");
+            }
+
+            if (DateTime.UtcNow >= deadline)
+            {
+                try
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+                catch (InvalidOperationException)
+                {
+                }
+
+                throw new AssertFailedException($"Timed out waiting for fault-injection checkpoint {mode}.");
+            }
+
+            await Task.Delay(20);
+        }
+
+        process.Kill(entireProcessTree: true);
+        await process.WaitForExitAsync();
+        Assert.IsTrue(process.HasExited);
+    }
+
+    private static string FindWorkerAssembly()
+    {
+        var root = FindRepositoryRoot();
+        var configuration = typeof(ProcessCrashSafetyTests).Assembly
+            .GetCustomAttribute<AssemblyConfigurationAttribute>()?.Configuration ?? "Debug";
+        var binRoot = Path.Combine(root, "tests", "PhotoOrganizer.FaultInjection.Worker", "bin", configuration);
+        if (!Directory.Exists(binRoot))
+        {
+            throw new AssertFailedException($"Fault-injection worker output directory does not exist: {binRoot}");
+        }
+
+        var runtimeConfig = Directory
+            .EnumerateFiles(binRoot, "PhotoOrganizer.FaultInjection.Worker.runtimeconfig.json", SearchOption.AllDirectories)
+            .OrderByDescending(File.GetLastWriteTimeUtc)
+            .FirstOrDefault();
+        if (runtimeConfig is null)
+        {
+            throw new AssertFailedException($"Fault-injection worker runtimeconfig was not found under {binRoot}.");
+        }
+
+        var workerAssembly = Path.Combine(Path.GetDirectoryName(runtimeConfig)!, "PhotoOrganizer.FaultInjection.Worker.dll");
+        if (!File.Exists(workerAssembly))
+        {
+            throw new AssertFailedException($"Fault-injection worker assembly was not found: {workerAssembly}");
+        }
+
+        return workerAssembly;
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "PhotoOrganizer.slnx")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new AssertFailedException($"Repository root could not be found from {AppContext.BaseDirectory}.");
+    }
+
+    private static byte[] CreatePayload(int seed)
+    {
+        var bytes = new byte[64 * 1024];
+        new Random(seed).NextBytes(bytes);
+        return bytes;
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory()
+        {
+            Path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"PhotoOrganizer-Crash-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}

--- a/tests/PhotoOrganizer.FaultInjection.Worker/PhotoOrganizer.FaultInjection.Worker.csproj
+++ b/tests/PhotoOrganizer.FaultInjection.Worker/PhotoOrganizer.FaultInjection.Worker.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AssemblyName>PhotoOrganizer.FaultInjection.Worker</AssemblyName>
+    <RootNamespace>PhotoOrganizer.FaultInjection.Worker</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/PhotoOrganizer.Core/PhotoOrganizer.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/PhotoOrganizer.FaultInjection.Worker/Program.cs
+++ b/tests/PhotoOrganizer.FaultInjection.Worker/Program.cs
@@ -2,8 +2,6 @@ using PhotoOrganizer.Core;
 
 namespace PhotoOrganizer.FaultInjection.Worker;
 
-public static class WorkerAssemblyMarker;
-
 public static class Program
 {
     public static async Task<int> Main(string[] args)

--- a/tests/PhotoOrganizer.FaultInjection.Worker/Program.cs
+++ b/tests/PhotoOrganizer.FaultInjection.Worker/Program.cs
@@ -1,0 +1,112 @@
+using PhotoOrganizer.Core;
+
+namespace PhotoOrganizer.FaultInjection.Worker;
+
+public static class WorkerAssemblyMarker;
+
+public static class Program
+{
+    public static async Task<int> Main(string[] args)
+    {
+        if (args.Length != 4)
+        {
+            Console.Error.WriteLine("Usage: <mode> <source> <destination-directory> <checkpoint-file>");
+            return 64;
+        }
+
+        var mode = args[0];
+        var source = Path.GetFullPath(args[1]);
+        var destination = Path.GetFullPath(args[2]);
+        var checkpoint = Path.GetFullPath(args[3]);
+
+        Directory.CreateDirectory(destination);
+        Directory.CreateDirectory(Path.GetDirectoryName(checkpoint)!);
+
+        IFileDurabilityService durability = mode switch
+        {
+            "before-finalize" => new CheckpointDurabilityService(checkpoint, CheckpointMode.BeforeFinalize),
+            "after-finalize-before-durable" => new CheckpointDurabilityService(checkpoint, CheckpointMode.AfterFinalizeBeforeDurable),
+            "after-durable-before-return" => new CheckpointDurabilityService(checkpoint, CheckpointMode.AfterDurableBeforeReturn),
+            "duplicate-durability" => new CheckpointDurabilityService(checkpoint, CheckpointMode.DuplicateDurability),
+            _ => throw new ArgumentOutOfRangeException(nameof(args), mode, "Unknown fault-injection mode.")
+        };
+
+        var result = await new SafeCopyService(durability).CopyAsync(source, destination).ConfigureAwait(false);
+        Console.WriteLine($"{result.Status}|{result.DestinationPath}|{result.Error}");
+        return result.Status == CopyStatus.Failed ? 2 : 0;
+    }
+
+    private enum CheckpointMode
+    {
+        BeforeFinalize,
+        AfterFinalizeBeforeDurable,
+        AfterDurableBeforeReturn,
+        DuplicateDurability
+    }
+
+    private sealed class CheckpointDurabilityService : IFileDurabilityService
+    {
+        private readonly string _checkpointPath;
+        private readonly CheckpointMode _mode;
+        private readonly PlatformFileDurabilityService _platform = new();
+
+        public CheckpointDurabilityService(string checkpointPath, CheckpointMode mode)
+        {
+            _checkpointPath = checkpointPath;
+            _mode = mode;
+        }
+
+        public FinalizeFileResult FinalizeNewFile(string temporaryPath, string finalPath, DateTime lastWriteUtc)
+        {
+            if (_mode == CheckpointMode.BeforeFinalize)
+            {
+                StopAtCheckpoint("before-finalize");
+            }
+
+            if (_mode == CheckpointMode.AfterFinalizeBeforeDurable)
+            {
+                try
+                {
+                    File.Move(temporaryPath, finalPath, overwrite: false);
+                    File.SetLastWriteTimeUtc(finalPath, lastWriteUtc);
+                    StopAtCheckpoint("after-finalize-before-durable");
+                    throw new UnreachableException();
+                }
+                catch (IOException) when (File.Exists(finalPath) || Directory.Exists(finalPath))
+                {
+                    return new FinalizeFileResult(FinalizeFileStatus.DestinationExists, false);
+                }
+            }
+
+            if (_mode == CheckpointMode.AfterDurableBeforeReturn)
+            {
+                var result = _platform.FinalizeNewFile(temporaryPath, finalPath, lastWriteUtc);
+                if (result.Status == FinalizeFileStatus.Committed)
+                {
+                    StopAtCheckpoint("after-durable-before-return");
+                }
+
+                return result;
+            }
+
+            return _platform.FinalizeNewFile(temporaryPath, finalPath, lastWriteUtc);
+        }
+
+        public DurabilityResult EnsureDurable(string filePath)
+        {
+            if (_mode == CheckpointMode.DuplicateDurability)
+            {
+                StopAtCheckpoint("duplicate-durability");
+            }
+
+            return _platform.EnsureDurable(filePath);
+        }
+
+        private void StopAtCheckpoint(string checkpoint)
+        {
+            File.WriteAllText(_checkpointPath, checkpoint);
+            using var gate = new ManualResetEventSlim(false);
+            gate.Wait();
+        }
+    }
+}

--- a/tests/PhotoOrganizer.FaultInjection.Worker/Program.cs
+++ b/tests/PhotoOrganizer.FaultInjection.Worker/Program.cs
@@ -61,6 +61,7 @@ public static class Program
             if (_mode == CheckpointMode.BeforeFinalize)
             {
                 StopAtCheckpoint("before-finalize");
+                return new FinalizeFileResult(FinalizeFileStatus.Failed, false, "Checkpoint unexpectedly resumed.");
             }
 
             if (_mode == CheckpointMode.AfterFinalizeBeforeDurable)
@@ -70,7 +71,7 @@ public static class Program
                     File.Move(temporaryPath, finalPath, overwrite: false);
                     File.SetLastWriteTimeUtc(finalPath, lastWriteUtc);
                     StopAtCheckpoint("after-finalize-before-durable");
-                    throw new UnreachableException();
+                    return new FinalizeFileResult(FinalizeFileStatus.Failed, true, "Checkpoint unexpectedly resumed.");
                 }
                 catch (IOException) when (File.Exists(finalPath) || Directory.Exists(finalPath))
                 {
@@ -97,6 +98,7 @@ public static class Program
             if (_mode == CheckpointMode.DuplicateDurability)
             {
                 StopAtCheckpoint("duplicate-durability");
+                return new DurabilityResult(false, "Checkpoint unexpectedly resumed.");
             }
 
             return _platform.EnsureDurable(filePath);


### PR DESCRIPTION
## Summary
- add a dedicated fault-injection worker executable for deterministic process-kill checkpoints
- exercise crashes immediately before finalization, after rename but before durability proof, after durable commit but before return, and while re-validating an existing duplicate
- run an 18-case collision/no-collision crash matrix plus repeated-crash and duplicate-durability recovery scenarios
- verify source media is byte-identical after every kill, existing destination files are never overwritten, finalized copies are never removed, and a subsequent normal import safely recovers

## Safety intent
These tests deliberately terminate a separate process at safety-critical boundaries rather than simulating cancellation inside one process. A crash before finalization may leave the transaction's `.partial-*` file behind; this is intentionally treated as safer than deleting data whose ownership cannot be proven after a process crash.

## Validation
GitHub Actions will run the same process-level crash scenarios on the repository's Windows/macOS CI matrix.