### PR TITLE
Add state-transition property tests and safety invariant gates

### DIFF
--- a/tests/PhotoOrganizer.App.Tests/StateTransitionPropertyTests.cs
+++ b/tests/PhotoOrganizer.App.Tests/StateTransitionPropertyTests.cs
@@ -151,11 +151,14 @@ public sealed class StateTransitionPropertyTests
         ];
     }
 
-    private static Dictionary<string, byte[]> SnapshotPermanentSourceMedia(IEnumerable<CardCase> cards) =>
-        cards
+    private static Dictionary<string, byte[]> SnapshotPermanentSourceMedia(IEnumerable<CardCase> cards)
+    {
+        var comparer = OperatingSystem.IsWindows() ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+        return cards
             .Where(card => card.Kind is not CardKind.Gone)
             .SelectMany(card => Directory.EnumerateFiles(card.Path, "*", SearchOption.AllDirectories))
-            .ToDictionary(Path.GetFullPath, File.ReadAllBytes, PathComparer.Instance);
+            .ToDictionary(Path.GetFullPath, File.ReadAllBytes, comparer);
+    }
 
     private static MountedVolumeInfo ToVolume(CardCase card) => new(
         card.Path,

--- a/tests/PhotoOrganizer.App.Tests/StateTransitionPropertyTests.cs
+++ b/tests/PhotoOrganizer.App.Tests/StateTransitionPropertyTests.cs
@@ -1,0 +1,288 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PhotoOrganizer.Core;
+
+namespace PhotoOrganizer.App.Tests;
+
+[TestClass]
+[DoNotParallelize]
+public sealed class StateTransitionPropertyTests
+{
+    private enum CardKind
+    {
+        Empty,
+        Valid,
+        BrokenIdentity,
+        Gone
+    }
+
+    private sealed record CardCase(string Path, CardKind Kind);
+
+    [TestMethod]
+    public async Task RandomizedQueuedScanSequences_RemainFailClosedAndMatchReferenceModel()
+    {
+        const int scenarioCount = 48;
+
+        for (var seed = 0; seed < scenarioCount; seed++)
+        {
+            using var temp = new TempDirectory(seed);
+            var cards = CreateCards(temp.Path);
+            var immutableSources = SnapshotPermanentSourceMedia(cards);
+
+            using var provider = new GateVolumeProvider(cards.Select(ToVolume).ToArray());
+            var sessions = new StorageSessionTracker(provider);
+            var roots = new CameraCardRootResolver(provider);
+            using var viewModel = new MainWindowViewModel(provider, sessions, roots);
+
+            var random = new Random(unchecked(seed * 7919 + 104729));
+            var active = cards[random.Next(3)]; // Empty, valid, or broken; never the disposable gone card.
+            var firstScan = viewModel.ScanCardAsync(active.Path, autoDetected: true);
+
+            Assert.IsTrue(
+                provider.FirstEnumerationEntered.Wait(TimeSpan.FromSeconds(5)),
+                $"seed={seed}: first scan never reached the controlled volume enumeration.");
+            Assert.IsTrue(viewModel.IsBusy, $"seed={seed}: scan should be busy while the provider gate is held.");
+
+            var modelQueue = new List<string>();
+            var operationCount = random.Next(5, 13);
+            var cancelled = false;
+
+            for (var operation = 0; operation < operationCount; operation++)
+            {
+                if (!cancelled && random.Next(5) == 0)
+                {
+                    viewModel.CancelImport();
+                    cancelled = true;
+                    continue;
+                }
+
+                var queued = cards[random.Next(cards.Count)];
+                var queuedResult = await viewModel.ScanCardAsync(queued.Path, autoDetected: true);
+                Assert.IsNull(queuedResult, $"seed={seed}: a concurrent scan unexpectedly replaced the active scan.");
+                ModelQueue(modelQueue, queued.Path, provider.PathComparison);
+            }
+
+            // Randomly make the disposable queued card disappear before queue draining.
+            var gone = cards.Single(card => card.Kind == CardKind.Gone);
+            var removeGone = random.Next(2) == 0;
+            if (removeGone && Directory.Exists(gone.Path))
+            {
+                Directory.Delete(gone.Path, recursive: true);
+            }
+
+            provider.ReleaseFirstEnumeration.Set();
+            var firstResult = await firstScan.WaitAsync(TimeSpan.FromSeconds(10));
+
+            var expected = EvaluateModel(
+                active,
+                modelQueue,
+                cards,
+                cancelled,
+                removeGone,
+                provider.PathComparison);
+
+            Assert.IsFalse(viewModel.IsBusy, $"seed={seed}: workflow remained busy after the controlled scan completed.");
+            Assert.AreEqual(expected.SelectedPath, viewModel.SelectedSdPath, $"seed={seed}: selected-card state diverged from model.");
+            Assert.AreEqual(expected.PendingCount, viewModel.PendingSdCount, $"seed={seed}: pending queue diverged from model.");
+            Assert.AreNotEqual(
+                "保存先コピー検証済み — SDカード再利用可能",
+                viewModel.SafetyHeadline,
+                $"seed={seed}: scan/queue activity alone must never produce reuse approval.");
+
+            if (cancelled)
+            {
+                Assert.IsNull(firstResult, $"seed={seed}: cancelled scan should not return a successful/blocked scan result.");
+                Assert.AreEqual("スキャンキャンセル", viewModel.ProgressLabel, $"seed={seed}: cancellation must remain visibly unverified.");
+            }
+            else if (active.Kind == CardKind.Valid)
+            {
+                Assert.IsNotNull(firstResult, $"seed={seed}: valid active card should produce a scan result.");
+                Assert.IsTrue(firstResult.IsReady, $"seed={seed}: valid active card should be ready.");
+            }
+            else if (active.Kind == CardKind.BrokenIdentity)
+            {
+                Assert.IsNotNull(firstResult, $"seed={seed}: broken identity should return a blocked result.");
+                Assert.AreEqual(ScanFailureReason.MissingPhysicalDeviceIdentity, firstResult.FailureReason, $"seed={seed}");
+            }
+            else
+            {
+                Assert.IsNotNull(firstResult, $"seed={seed}: empty card should return a benign no-media result.");
+                Assert.IsTrue(firstResult.IsNoSupportedMedia, $"seed={seed}: empty card must be classified as no supported media.");
+            }
+
+            foreach (var snapshot in immutableSources)
+            {
+                Assert.IsTrue(File.Exists(snapshot.Key), $"seed={seed}: source media disappeared: {snapshot.Key}");
+                CollectionAssert.AreEqual(
+                    snapshot.Value,
+                    File.ReadAllBytes(snapshot.Key),
+                    $"seed={seed}: source media bytes changed: {snapshot.Key}");
+            }
+        }
+    }
+
+    private static IReadOnlyList<CardCase> CreateCards(string root)
+    {
+        var empty = Directory.CreateDirectory(Path.Combine(root, "00-empty")).FullName;
+        Directory.CreateDirectory(Path.Combine(empty, "DCIM"));
+
+        var validA = Directory.CreateDirectory(Path.Combine(root, "01-valid-a")).FullName;
+        var validADcim = Directory.CreateDirectory(Path.Combine(validA, "DCIM", "100CAM")).FullName;
+        File.WriteAllBytes(Path.Combine(validADcim, "a.jpg"), [1, 2, 3, 4, 5]);
+
+        var broken = Directory.CreateDirectory(Path.Combine(root, "02-broken")).FullName;
+        var brokenDcim = Directory.CreateDirectory(Path.Combine(broken, "DCIM")).FullName;
+        File.WriteAllBytes(Path.Combine(brokenDcim, "broken.jpg"), [6, 7, 8, 9]);
+
+        var validB = Directory.CreateDirectory(Path.Combine(root, "03-valid-b")).FullName;
+        var validBDcim = Directory.CreateDirectory(Path.Combine(validB, "DCIM")).FullName;
+        File.WriteAllBytes(Path.Combine(validBDcim, "b.jpg"), [10, 11, 12]);
+
+        var gone = Directory.CreateDirectory(Path.Combine(root, "04-gone")).FullName;
+        var goneDcim = Directory.CreateDirectory(Path.Combine(gone, "DCIM")).FullName;
+        File.WriteAllBytes(Path.Combine(goneDcim, "gone.jpg"), [13, 14, 15]);
+
+        return
+        [
+            new CardCase(empty, CardKind.Empty),
+            new CardCase(validA, CardKind.Valid),
+            new CardCase(broken, CardKind.BrokenIdentity),
+            new CardCase(validB, CardKind.Valid),
+            new CardCase(gone, CardKind.Gone)
+        ];
+    }
+
+    private static Dictionary<string, byte[]> SnapshotPermanentSourceMedia(IEnumerable<CardCase> cards) =>
+        cards
+            .Where(card => card.Kind is not CardKind.Gone)
+            .SelectMany(card => Directory.EnumerateFiles(card.Path, "*", SearchOption.AllDirectories))
+            .ToDictionary(Path.GetFullPath, File.ReadAllBytes, PathComparer.Instance);
+
+    private static MountedVolumeInfo ToVolume(CardCase card) => new(
+        card.Path,
+        $"volume-{Path.GetFileName(card.Path)}",
+        IsRemovable: true,
+        IsSystem: false,
+        card.Kind == CardKind.BrokenIdentity ? null : $"device-{Path.GetFileName(card.Path)}");
+
+    private static void ModelQueue(List<string> queue, string path, StringComparison comparison)
+    {
+        var normalized = PathSafety.Normalize(path);
+        if (!queue.Any(existing => string.Equals(existing, normalized, comparison)))
+        {
+            queue.Add(normalized);
+        }
+    }
+
+    private static (string SelectedPath, int PendingCount) EvaluateModel(
+        CardCase active,
+        List<string> queued,
+        IReadOnlyList<CardCase> cards,
+        bool cancelled,
+        bool goneRemoved,
+        StringComparison comparison)
+    {
+        var remaining = queued.ToList();
+
+        if (cancelled)
+        {
+            return (string.Empty, remaining.Count);
+        }
+
+        if (active.Kind == CardKind.Valid)
+        {
+            remaining.RemoveAll(path => string.Equals(path, PathSafety.Normalize(active.Path), comparison));
+            return (PathSafety.Normalize(active.Path), remaining.Count);
+        }
+
+        if (active.Kind == CardKind.BrokenIdentity)
+        {
+            return (string.Empty, remaining.Count);
+        }
+
+        while (remaining.Count > 0)
+        {
+            var next = remaining[0];
+            remaining.RemoveAt(0);
+            var card = cards.Single(candidate => string.Equals(PathSafety.Normalize(candidate.Path), next, comparison));
+
+            if (card.Kind == CardKind.Gone && goneRemoved)
+            {
+                continue;
+            }
+
+            if (card.Kind == CardKind.Empty)
+            {
+                continue;
+            }
+
+            if (card.Kind == CardKind.BrokenIdentity)
+            {
+                return (string.Empty, remaining.Count);
+            }
+
+            return (PathSafety.Normalize(card.Path), remaining.Count);
+        }
+
+        return (string.Empty, 0);
+    }
+
+    private sealed class GateVolumeProvider(IReadOnlyList<MountedVolumeInfo> volumes)
+        : IStorageVolumeProvider, IDisposable
+    {
+        private int _gateFirstEnumeration = 1;
+
+        public ManualResetEventSlim FirstEnumerationEntered { get; } = new(false);
+        public ManualResetEventSlim ReleaseFirstEnumeration { get; } = new(false);
+
+        public StringComparison PathComparison => OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+        public IReadOnlyList<MountedVolumeInfo> GetMountedVolumes()
+        {
+            if (Interlocked.Exchange(ref _gateFirstEnumeration, 0) == 1)
+            {
+                FirstEnumerationEntered.Set();
+                if (!ReleaseFirstEnumeration.Wait(TimeSpan.FromSeconds(10)))
+                {
+                    throw new TimeoutException("Property test did not release the first volume enumeration.");
+                }
+            }
+
+            return volumes;
+        }
+
+        public MountedVolumeInfo? ResolveVolumeForPath(string path)
+        {
+            var normalized = PathSafety.Normalize(path);
+            return volumes
+                .Where(volume => PathSafety.IsSameOrDescendant(normalized, volume.RootPath, PathComparison))
+                .OrderByDescending(volume => PathSafety.Normalize(volume.RootPath).Length)
+                .FirstOrDefault();
+        }
+
+        public void Dispose()
+        {
+            FirstEnumerationEntered.Dispose();
+            ReleaseFirstEnumeration.Dispose();
+        }
+    }
+
+    private sealed class TempDirectory : IDisposable
+    {
+        public TempDirectory(int seed)
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"PhotoOrganizerStateProperty-{seed}-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Path, recursive: true); } catch { }
+        }
+    }
+}

--- a/tests/PhotoOrganizer.App.Tests/StateTransitionPropertyTests.cs
+++ b/tests/PhotoOrganizer.App.Tests/StateTransitionPropertyTests.cs
@@ -88,20 +88,24 @@ public sealed class StateTransitionPropertyTests
                 viewModel.SafetyHeadline,
                 $"seed={seed}: scan/queue activity alone must never produce reuse approval.");
 
-            if (cancelled)
+            // Missing physical-device identity is an immediate fail-closed condition.
+            // It is intentionally allowed to win the race over a cancellation request
+            // because ScanCard validates storage identity before entering the media scan.
+            if (active.Kind == CardKind.BrokenIdentity)
             {
-                Assert.IsNull(firstResult, $"seed={seed}: cancelled scan should not return a successful/blocked scan result.");
+                Assert.IsNotNull(firstResult, $"seed={seed}: broken identity should return a blocked result.");
+                Assert.AreEqual(ScanFailureReason.MissingPhysicalDeviceIdentity, firstResult.FailureReason, $"seed={seed}");
+                Assert.AreEqual("スキャン失敗", viewModel.ProgressLabel, $"seed={seed}: safety failure should remain visible.");
+            }
+            else if (cancelled)
+            {
+                Assert.IsNull(firstResult, $"seed={seed}: cancelled media scan should not return a successful/blocked scan result.");
                 Assert.AreEqual("スキャンキャンセル", viewModel.ProgressLabel, $"seed={seed}: cancellation must remain visibly unverified.");
             }
             else if (active.Kind == CardKind.Valid)
             {
                 Assert.IsNotNull(firstResult, $"seed={seed}: valid active card should produce a scan result.");
                 Assert.IsTrue(firstResult.IsReady, $"seed={seed}: valid active card should be ready.");
-            }
-            else if (active.Kind == CardKind.BrokenIdentity)
-            {
-                Assert.IsNotNull(firstResult, $"seed={seed}: broken identity should return a blocked result.");
-                Assert.AreEqual(ScanFailureReason.MissingPhysicalDeviceIdentity, firstResult.FailureReason, $"seed={seed}");
             }
             else
             {
@@ -186,6 +190,13 @@ public sealed class StateTransitionPropertyTests
     {
         var remaining = queued.ToList();
 
+        // Immediate storage-identity failure takes precedence over cancellation.
+        // Both leave selection empty and preserve the pending queue.
+        if (active.Kind == CardKind.BrokenIdentity)
+        {
+            return (string.Empty, remaining.Count);
+        }
+
         if (cancelled)
         {
             return (string.Empty, remaining.Count);
@@ -195,11 +206,6 @@ public sealed class StateTransitionPropertyTests
         {
             remaining.RemoveAll(path => string.Equals(path, PathSafety.Normalize(active.Path), comparison));
             return (PathSafety.Normalize(active.Path), remaining.Count);
-        }
-
-        if (active.Kind == CardKind.BrokenIdentity)
-        {
-            return (string.Empty, remaining.Count);
         }
 
         while (remaining.Count > 0)

--- a/tests/PhotoOrganizer.Core.Tests/SafetyInvariantContractTests.cs
+++ b/tests/PhotoOrganizer.Core.Tests/SafetyInvariantContractTests.cs
@@ -151,13 +151,17 @@ public sealed class SafetyInvariantContractTests
         (relative == "src/PhotoOrganizer.Core/SafeCopyService.cs"
          && line.Contains("File.Delete(temporaryPathForCleanup)", StringComparison.Ordinal))
         || (relative == "src/PhotoOrganizer.App/JsonSettingsFile.cs"
-            && line.Contains("File.Delete(temporary)", StringComparison.Ordinal));
+            && line.Contains("File.Delete(temporary)", StringComparison.Ordinal))
+        || (relative == "src/PhotoOrganizer.App/StartupRegistrationService.cs"
+            && line.Contains("File.Delete(plistPath)", StringComparison.Ordinal));
 
     private static bool IsAllowedMove(string relative, string line) =>
         (relative == "src/PhotoOrganizer.Core/FileDurability.cs"
          && line.Contains("File.Move(temporaryPath, finalPath, overwrite: false)", StringComparison.Ordinal))
         || (relative == "src/PhotoOrganizer.App/JsonSettingsFile.cs"
-            && line.Contains("File.Move(temporary, path, overwrite: true)", StringComparison.Ordinal));
+            && line.Contains("File.Move(temporary, path, overwrite: true)", StringComparison.Ordinal))
+        || (relative == "src/PhotoOrganizer.App/StartupRegistrationService.cs"
+            && line.Contains("File.Move(temporary, plistPath, overwrite: true)", StringComparison.Ordinal));
 
     private static string FindRepositoryRoot()
     {

--- a/tests/PhotoOrganizer.Core.Tests/SafetyInvariantContractTests.cs
+++ b/tests/PhotoOrganizer.Core.Tests/SafetyInvariantContractTests.cs
@@ -1,0 +1,194 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace PhotoOrganizer.Core.Tests;
+
+[TestClass]
+public sealed class SafetyInvariantContractTests
+{
+    [TestMethod]
+    public void ProductionCode_DestructiveFilesystemOperationsRemainExplicitlyAllowlisted()
+    {
+        var root = FindRepositoryRoot();
+        var sourceRoot = Path.Combine(root, "src");
+        var violations = new List<string>();
+
+        foreach (var file in Directory.EnumerateFiles(sourceRoot, "*.cs", SearchOption.AllDirectories))
+        {
+            var relative = Relative(root, file);
+            var lines = File.ReadAllLines(file);
+
+            for (var index = 0; index < lines.Length; index++)
+            {
+                var line = lines[index];
+                var lineNumber = index + 1;
+
+                if (line.Contains("Directory.Delete(", StringComparison.Ordinal))
+                {
+                    violations.Add($"{relative}:{lineNumber}: production Directory.Delete is forbidden");
+                }
+
+                if (line.Contains("File.Delete(", StringComparison.Ordinal)
+                    && !IsAllowedDelete(relative, line))
+                {
+                    violations.Add($"{relative}:{lineNumber}: unreviewed File.Delete: {line.Trim()}");
+                }
+
+                if (line.Contains("File.Move(", StringComparison.Ordinal)
+                    && !IsAllowedMove(relative, line))
+                {
+                    violations.Add($"{relative}:{lineNumber}: unreviewed File.Move: {line.Trim()}");
+                }
+
+                if (line.Contains("File.Replace(", StringComparison.Ordinal))
+                {
+                    violations.Add($"{relative}:{lineNumber}: File.Replace is not part of the safety contract");
+                }
+
+                if (line.Contains("File.Copy(", StringComparison.Ordinal))
+                {
+                    violations.Add($"{relative}:{lineNumber}: direct File.Copy bypasses SafeCopyService");
+                }
+            }
+        }
+
+        Assert.AreEqual(
+            0,
+            violations.Count,
+            "Production destructive-file API surface changed. Review the source-data safety contract before changing the allowlist:\n"
+            + string.Join(Environment.NewLine, violations));
+    }
+
+    [TestMethod]
+    public void SafeCopyService_RemainsNoClobberAndDeletesOnlyItsOwnedPartial()
+    {
+        var root = FindRepositoryRoot();
+        var safeCopy = File.ReadAllText(Path.Combine(root, "src", "PhotoOrganizer.Core", "SafeCopyService.cs"));
+        var durability = File.ReadAllText(Path.Combine(root, "src", "PhotoOrganizer.Core", "FileDurability.cs"));
+
+        StringAssert.Contains(safeCopy, "FileMode.CreateNew");
+        Assert.IsFalse(
+            safeCopy.Contains("FileMode.Create,", StringComparison.Ordinal),
+            "SafeCopyService must not create/overwrite a destination with FileMode.Create.");
+        StringAssert.Contains(safeCopy, "File.Delete(temporaryPathForCleanup)");
+        StringAssert.Contains(safeCopy, "temporaryPathForCleanup = null");
+        StringAssert.Contains(durability, "File.Move(temporaryPath, finalPath, overwrite: false)");
+        Assert.IsFalse(
+            durability.Contains("MoveFileReplaceExisting", StringComparison.OrdinalIgnoreCase),
+            "Windows finalization must not gain replace-existing semantics.");
+    }
+
+    [TestMethod]
+    public void SafeToReuse_HasOneProductionDecisionPathAfterFinalConsistencyProof()
+    {
+        var root = FindRepositoryRoot();
+        var productionFiles = Directory.EnumerateFiles(Path.Combine(root, "src"), "*.cs", SearchOption.AllDirectories).ToArray();
+        var decisionOccurrences = new List<string>();
+
+        foreach (var file in productionFiles)
+        {
+            var relative = Relative(root, file);
+            if (relative == "src/PhotoOrganizer.Core/ImportModels.cs")
+            {
+                continue; // The model exposes IsSafeToReuse; it does not grant approval.
+            }
+
+            var lines = File.ReadAllLines(file);
+            for (var index = 0; index < lines.Length; index++)
+            {
+                if (lines[index].Contains("ImportSafetyStatus.SafeToReuse", StringComparison.Ordinal))
+                {
+                    decisionOccurrences.Add($"{relative}:{index + 1}");
+                }
+            }
+        }
+
+        Assert.AreEqual(
+            1,
+            decisionOccurrences.Count,
+            "Exactly one production code path may construct SafeToReuse. Found: " + string.Join(", ", decisionOccurrences));
+        StringAssert.StartsWith(decisionOccurrences[0], "src/PhotoOrganizer.Core/ImportCoordinator.cs:");
+
+        var coordinator = File.ReadAllText(Path.Combine(root, "src", "PhotoOrganizer.Core", "ImportCoordinator.cs"));
+        var finalRescan = coordinator.IndexOf("var finalRescan = _scanner.Scan", StringComparison.Ordinal);
+        var setEquality = coordinator.IndexOf("rescanned.SetEquals(finalFiles)", StringComparison.Ordinal);
+        var safeDecision = coordinator.IndexOf("ImportSafetyStatus.SafeToReuse", StringComparison.Ordinal);
+
+        Assert.IsTrue(finalRescan >= 0, "Final whole-card consistency scan disappeared.");
+        Assert.IsTrue(setEquality > finalRescan, "Final supported-file set equality check must follow the final scan.");
+        Assert.IsTrue(safeDecision > setEquality, "SafeToReuse must remain after the final consistency proof.");
+    }
+
+    [TestMethod]
+    public void GreenReuseUi_HasOneLiteralAndIsGuardedByIsSafeToReuse()
+    {
+        var root = FindRepositoryRoot();
+        const string greenHeadline = "保存先コピー検証済み — SDカード再利用可能";
+        var occurrences = new List<string>();
+
+        foreach (var file in Directory.EnumerateFiles(Path.Combine(root, "src"), "*.cs", SearchOption.AllDirectories))
+        {
+            var relative = Relative(root, file);
+            var lines = File.ReadAllLines(file);
+            for (var index = 0; index < lines.Length; index++)
+            {
+                if (lines[index].Contains(greenHeadline, StringComparison.Ordinal))
+                {
+                    occurrences.Add($"{relative}:{index + 1}");
+                }
+            }
+        }
+
+        Assert.AreEqual(1, occurrences.Count, "The green reuse-approved UI must have exactly one production assignment site.");
+        StringAssert.StartsWith(occurrences[0], "src/PhotoOrganizer.App/MainWindowViewModel.ImportWorkflow.cs:");
+
+        var workflow = File.ReadAllText(Path.Combine(root, "src", "PhotoOrganizer.App", "MainWindowViewModel.ImportWorkflow.cs"));
+        var guard = workflow.IndexOf("if (result.IsSafeToReuse)", StringComparison.Ordinal);
+        var green = workflow.IndexOf(greenHeadline, StringComparison.Ordinal);
+        Assert.IsTrue(guard >= 0 && green > guard, "Green reuse approval must remain behind result.IsSafeToReuse.");
+    }
+
+    private static bool IsAllowedDelete(string relative, string line) =>
+        (relative == "src/PhotoOrganizer.Core/SafeCopyService.cs"
+         && line.Contains("File.Delete(temporaryPathForCleanup)", StringComparison.Ordinal))
+        || (relative == "src/PhotoOrganizer.App/JsonSettingsFile.cs"
+            && line.Contains("File.Delete(temporary)", StringComparison.Ordinal));
+
+    private static bool IsAllowedMove(string relative, string line) =>
+        (relative == "src/PhotoOrganizer.Core/FileDurability.cs"
+         && line.Contains("File.Move(temporaryPath, finalPath, overwrite: false)", StringComparison.Ordinal))
+        || (relative == "src/PhotoOrganizer.App/JsonSettingsFile.cs"
+            && line.Contains("File.Move(temporary, path, overwrite: true)", StringComparison.Ordinal));
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "PhotoOrganizer.slnx")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        // dotnet test normally runs below the checkout, but keep a working-directory
+        // fallback for IDE/test-runner layouts that copy binaries elsewhere.
+        directory = new DirectoryInfo(Environment.CurrentDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "PhotoOrganizer.slnx")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        Assert.Fail("Could not locate repository root containing PhotoOrganizer.slnx.");
+        throw new InvalidOperationException("Unreachable after Assert.Fail.");
+    }
+
+    private static string Relative(string root, string path) =>
+        Path.GetRelativePath(root, path).Replace('\\', '/');
+}


### PR DESCRIPTION
## Summary
- add deterministic model-based randomized scan/queue/cancel tests across 48 reproducible seeds
- exercise duplicate queueing, valid/empty/broken cards, cancellation while scanning, disappearing queued media, queue draining, and fail-closed UI state
- byte-snapshot permanent source media and assert every randomized sequence leaves source data unchanged
- add CI-enforced source safety contracts that reject new destructive filesystem APIs outside a narrow allowlist
- require SafeToReuse to have exactly one production construction path after the final whole-card consistency proof
- require the green reuse-approved UI to have exactly one assignment site guarded by `result.IsSafeToReuse`
- lock SafeCopyService no-clobber semantics (`CreateNew`, owned-partial cleanup, non-overwriting final move)

## Property-testing approach
The randomized cases use fixed seeds rather than nondeterministic fuzzing. Any failure reports its seed, making the exact operation sequence reproducible in CI and locally without adding a new test-framework dependency.

## Safety intent
These tests are designed to make future refactors fail CI if they accidentally add source deletion/move primitives, bypass SafeCopyService, create another SafeToReuse path, or allow scan/queue/cancel transitions to surface a green reuse state.