### PR TITLE
UIをシンプルかつ実用的なワークフローへ再設計

### DIFF
--- a/src/PhotoOrganizer.App/App.axaml
+++ b/src/PhotoOrganizer.App/App.axaml
@@ -16,7 +16,7 @@
             <NativeMenuItem Header="Photo Organizerを表示" Click="ShowWindowMenu_Click" />
             <NativeMenuItemSeparator />
             <NativeMenuItem Header="設定…" Click="SettingsMenu_Click" />
-            <NativeMenuItem Header="詳細ログ…" Click="DiagnosticsMenu_Click" />
+            <NativeMenuItem Header="処理ログ…" Click="DiagnosticsMenu_Click" />
             <NativeMenuItemSeparator />
             <NativeMenuItem Header="終了" Click="QuitMenu_Click" />
           </NativeMenu>

--- a/src/PhotoOrganizer.App/App.axaml.cs
+++ b/src/PhotoOrganizer.App/App.axaml.cs
@@ -80,7 +80,11 @@ public sealed partial class App : Application
 
     private void ShowWindowMenu_Click(object? sender, EventArgs e) => ShowMainWindow();
 
-    private void SettingsMenu_Click(object? sender, EventArgs e)
+    private void SettingsMenu_Click(object? sender, EventArgs e) => ShowSettingsWindow();
+
+    private void DiagnosticsMenu_Click(object? sender, EventArgs e) => ShowDiagnosticsWindow();
+
+    internal void ShowSettingsWindow()
     {
         if (_viewModel is null) return;
         if (_settingsWindow is null)
@@ -91,7 +95,7 @@ public sealed partial class App : Application
         ShowUtilityWindow(_settingsWindow);
     }
 
-    private void DiagnosticsMenu_Click(object? sender, EventArgs e)
+    internal void ShowDiagnosticsWindow()
     {
         if (_viewModel is null) return;
         if (_diagnosticsWindow is null)

--- a/src/PhotoOrganizer.App/DiagnosticsWindow.axaml
+++ b/src/PhotoOrganizer.App/DiagnosticsWindow.axaml
@@ -12,7 +12,8 @@
         Background="#101617">
   <Grid Margin="14" RowDefinitions="Auto,*" RowSpacing="9">
     <StackPanel Spacing="1">
-      <TextBlock Text="処理ログ" FontSize="17" FontWeight="SemiBold" Foreground="#EEF3F2" />
+      <TextBlock Text="処理ログ" FontSize="17" FontWeight="SemiBold" Foreground="#EEF3F2"
+                 AutomationProperties.HeadingLevel="1" />
       <TextBlock Text="SDカードの検出・取り込み・検証の記録"
                  FontSize="11" Foreground="#7F8D8A" />
     </StackPanel>

--- a/src/PhotoOrganizer.App/DiagnosticsWindow.axaml
+++ b/src/PhotoOrganizer.App/DiagnosticsWindow.axaml
@@ -3,28 +3,28 @@
         xmlns:vm="using:PhotoOrganizer.App"
         x:Class="PhotoOrganizer.App.DiagnosticsWindow"
         x:DataType="vm:MainWindowViewModel"
-        Title="Photo Organizer 詳細ログ"
+        Title="Photo Organizer 処理ログ"
         Icon="/Assets/photo-organizer-icon.ico"
-        Width="720" Height="430"
-        MinWidth="520" MinHeight="300"
-        WindowStartupLocation="CenterScreen"
+        Width="760" Height="450"
+        MinWidth="540" MinHeight="320"
+        WindowStartupLocation="CenterOwner"
         RequestedThemeVariant="Dark"
-        Background="#151B1C">
-  <Grid Margin="18" RowDefinitions="Auto,*" RowSpacing="10">
-    <StackPanel Spacing="2">
-      <TextBlock Text="詳細ログ" FontSize="18" FontWeight="SemiBold" Foreground="#EEF3F2" />
-      <TextBlock Text="SDカードの検出・取り込み・検証結果"
-                 FontSize="11" Foreground="#81918E" />
+        Background="#101617">
+  <Grid Margin="14" RowDefinitions="Auto,*" RowSpacing="9">
+    <StackPanel Spacing="1">
+      <TextBlock Text="処理ログ" FontSize="17" FontWeight="SemiBold" Foreground="#EEF3F2" />
+      <TextBlock Text="SDカードの検出・取り込み・検証の記録"
+                 FontSize="11" Foreground="#7F8D8A" />
     </StackPanel>
-    <Border Grid.Row="1" Background="#101617" BorderBrush="#2B3939"
-            BorderThickness="1" CornerRadius="9" Padding="7">
+    <Border Grid.Row="1" Background="#131A1C" BorderBrush="#2B3939"
+            BorderThickness="1" CornerRadius="8" Padding="5">
       <TextBox Text="{Binding LogText}" IsReadOnly="True" AcceptsReturn="True"
-               Background="Transparent" BorderThickness="0" Padding="9,7"
+               Background="Transparent" BorderThickness="0" Padding="8,6"
                TextWrapping="NoWrap"
                ScrollViewer.VerticalScrollBarVisibility="Auto"
                ScrollViewer.HorizontalScrollBarVisibility="Auto"
                FontFamily="monospace" FontSize="11"
-               AutomationProperties.Name="詳細ログ" />
+               AutomationProperties.Name="処理ログ" />
     </Border>
   </Grid>
 </Window>

--- a/src/PhotoOrganizer.App/DiagnosticsWindow.axaml
+++ b/src/PhotoOrganizer.App/DiagnosticsWindow.axaml
@@ -7,7 +7,7 @@
         Icon="/Assets/photo-organizer-icon.ico"
         Width="760" Height="450"
         MinWidth="540" MinHeight="320"
-        WindowStartupLocation="CenterOwner"
+        WindowStartupLocation="CenterScreen"
         RequestedThemeVariant="Dark"
         Background="#101617">
   <Grid Margin="14" RowDefinitions="Auto,*" RowSpacing="9">

--- a/src/PhotoOrganizer.App/MainWindow.axaml
+++ b/src/PhotoOrganizer.App/MainWindow.axaml
@@ -257,8 +257,7 @@
                            Height="6"
                            AutomationProperties.Name="取り込み進捗" />
               <TextBlock Text="{Binding ProgressLabel}"
-                         Classes="caption" TextWrapping="Wrap"
-                         AutomationProperties.LiveSetting="Polite" />
+                         Classes="caption" TextWrapping="Wrap" />
             </StackPanel>
           </StackPanel>
         </Border>

--- a/src/PhotoOrganizer.App/MainWindow.axaml
+++ b/src/PhotoOrganizer.App/MainWindow.axaml
@@ -5,26 +5,24 @@
         x:DataType="vm:MainWindowViewModel"
         Title="Photo Organizer"
         Icon="/Assets/photo-organizer-icon.ico"
-        Width="1000"
-        Height="680"
-        MinWidth="880"
-        MinHeight="640"
+        Width="940"
+        Height="640"
+        MinWidth="760"
+        MinHeight="560"
         RequestedThemeVariant="Dark"
         Background="#101617">
   <Window.Resources>
     <SolidColorBrush x:Key="PageForeground">#EEF3F2</SolidColorBrush>
-    <SolidColorBrush x:Key="MutedForeground">#9EADAA</SolidColorBrush>
-    <SolidColorBrush x:Key="SubtleForeground">#71817E</SolidColorBrush>
+    <SolidColorBrush x:Key="MutedForeground">#A7B3B0</SolidColorBrush>
+    <SolidColorBrush x:Key="SubtleForeground">#7F8D8A</SolidColorBrush>
     <SolidColorBrush x:Key="SurfaceBrush">#182022</SolidColorBrush>
-    <SolidColorBrush x:Key="ElevatedSurfaceBrush">#1E292A</SolidColorBrush>
-    <SolidColorBrush x:Key="SoftSurfaceBrush">#141C1D</SolidColorBrush>
+    <SolidColorBrush x:Key="SoftSurfaceBrush">#131A1C</SolidColorBrush>
     <SolidColorBrush x:Key="BorderBrush">#2B3939</SolidColorBrush>
     <SolidColorBrush x:Key="AccentBrush">#70B8A5</SolidColorBrush>
-    <SolidColorBrush x:Key="AccentStrongBrush">#87CDBA</SolidColorBrush>
+    <SolidColorBrush x:Key="AccentStrongBrush">#8ACDBB</SolidColorBrush>
     <SolidColorBrush x:Key="AccentSurfaceBrush">#19302D</SolidColorBrush>
-    <SolidColorBrush x:Key="WarningBrush">#D2A96F</SolidColorBrush>
+    <SolidColorBrush x:Key="WarningBrush">#D7AE73</SolidColorBrush>
     <SolidColorBrush x:Key="WarningSurfaceBrush">#30281E</SolidColorBrush>
-    <SolidColorBrush x:Key="SuccessBrush">#83BE96</SolidColorBrush>
     <SolidColorBrush x:Key="SuccessSurfaceBrush">#1B2C22</SolidColorBrush>
   </Window.Resources>
 
@@ -36,21 +34,13 @@
       <Setter Property="Background" Value="{StaticResource SurfaceBrush}" />
       <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}" />
       <Setter Property="BorderThickness" Value="1" />
-      <Setter Property="CornerRadius" Value="10" />
+      <Setter Property="CornerRadius" Value="9" />
     </Style>
     <Style Selector="Border.soft">
       <Setter Property="Background" Value="{StaticResource SoftSurfaceBrush}" />
       <Setter Property="BorderBrush" Value="{StaticResource BorderBrush}" />
       <Setter Property="BorderThickness" Value="1" />
-      <Setter Property="CornerRadius" Value="8" />
-    </Style>
-    <Style Selector="Border.stepNumber">
-      <Setter Property="Width" Value="24" />
-      <Setter Property="Height" Value="24" />
-      <Setter Property="CornerRadius" Value="12" />
-      <Setter Property="Background" Value="{StaticResource AccentSurfaceBrush}" />
-      <Setter Property="BorderBrush" Value="#31544E" />
-      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="7" />
     </Style>
     <Style Selector="TextBlock.sectionTitle">
       <Setter Property="FontSize" Value="14" />
@@ -66,14 +56,19 @@
       <Setter Property="Foreground" Value="{StaticResource SubtleForeground}" />
     </Style>
     <Style Selector="Button">
-      <Setter Property="Padding" Value="12,7" />
+      <Setter Property="Padding" Value="11,7" />
       <Setter Property="CornerRadius" Value="7" />
       <Setter Property="FontWeight" Value="SemiBold" />
+    </Style>
+    <Style Selector="Button.compact">
+      <Setter Property="Padding" Value="10,6" />
+      <Setter Property="FontSize" Value="11" />
     </Style>
     <Style Selector="Button.primary">
       <Setter Property="Background" Value="{StaticResource AccentBrush}" />
       <Setter Property="Foreground" Value="#10201C" />
       <Setter Property="BorderBrush" Value="{StaticResource AccentStrongBrush}" />
+      <Setter Property="MinWidth" Value="132" />
     </Style>
     <Style Selector="TextBox">
       <Setter Property="CornerRadius" Value="7" />
@@ -87,216 +82,214 @@
     </Style>
   </Window.Styles>
 
-  <Grid Margin="18" RowDefinitions="Auto,Auto,*" RowSpacing="10">
+  <Grid Margin="16" RowDefinitions="Auto,Auto,*" RowSpacing="10">
     <Grid Grid.Row="0" ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10">
-      <Border Width="38" Height="38" CornerRadius="10"
-              Background="{StaticResource ElevatedSurfaceBrush}"
-              BorderBrush="#35504B" BorderThickness="1">
-        <Image Source="/Assets/photo-organizer-icon.png" Width="28" Height="28" />
-      </Border>
-      <StackPanel Grid.Column="1" Spacing="1" VerticalAlignment="Center">
-        <TextBlock Text="Photo Organizer" FontSize="20" FontWeight="SemiBold" />
-        <TextBlock Text="写真・動画を安全に整理して取り込み"
-                   Foreground="{StaticResource MutedForeground}" FontSize="12" />
+      <Image Source="/Assets/photo-organizer-icon.png"
+             Width="34" Height="34"
+             VerticalAlignment="Center" />
+      <StackPanel Grid.Column="1" Spacing="0" VerticalAlignment="Center">
+        <TextBlock Text="Photo Organizer" FontSize="18" FontWeight="SemiBold" />
+        <TextBlock Text="SDカードから写真・動画を安全に取り込み"
+                   Classes="caption" />
       </StackPanel>
-      <Border Grid.Column="2" Padding="9,4" CornerRadius="10"
-              Background="{StaticResource AccentSurfaceBrush}"
-              VerticalAlignment="Center">
-        <TextBlock Text="SAFE IMPORT" FontSize="10" FontWeight="Bold"
-                   Foreground="{StaticResource AccentStrongBrush}" />
-      </Border>
+      <StackPanel Grid.Column="2" Orientation="Horizontal" Spacing="6"
+                  VerticalAlignment="Center">
+        <Button Classes="compact" Content="設定"
+                Click="Settings_Click"
+                IsEnabled="{Binding !IsBusy}"
+                AutomationProperties.Name="設定を開く" />
+        <Button Classes="compact" Content="ログ"
+                Click="Diagnostics_Click"
+                AutomationProperties.Name="処理ログを開く" />
+      </StackPanel>
     </Grid>
 
-    <Border Grid.Row="1" Classes="surface" Padding="11,9"
+    <Border Grid.Row="1" Classes="surface" Padding="10,8"
             Background="{StaticResource AccentSurfaceBrush}"
             BorderBrush="#31544E"
-            AutomationProperties.Name="次に行う操作">
+            AutomationProperties.Name="現在の状態">
       <Grid ColumnDefinitions="Auto,*" ColumnSpacing="9">
-        <Border Width="26" Height="26" CornerRadius="13" Background="#294943">
-          <TextBlock Text="→" FontSize="14" FontWeight="SemiBold"
-                     Foreground="{StaticResource AccentStrongBrush}"
-                     HorizontalAlignment="Center" VerticalAlignment="Center" />
-        </Border>
-        <StackPanel Grid.Column="1" Spacing="1" VerticalAlignment="Center">
+        <Border Width="8" Height="8" CornerRadius="4"
+                Background="{StaticResource AccentStrongBrush}"
+                VerticalAlignment="Center" />
+        <StackPanel Grid.Column="1" Spacing="1">
           <TextBlock Text="{Binding WorkflowHeadline}"
-                     FontSize="15" FontWeight="SemiBold" TextWrapping="Wrap" />
+                     FontSize="14" FontWeight="SemiBold" TextWrapping="Wrap" />
           <TextBlock Text="{Binding WorkflowDetail}"
-                     Foreground="{StaticResource MutedForeground}"
-                     FontSize="12" TextWrapping="Wrap" />
+                     Classes="caption" Foreground="{StaticResource MutedForeground}"
+                     TextWrapping="Wrap" />
         </StackPanel>
       </Grid>
     </Border>
 
-    <Grid Grid.Row="2" ColumnDefinitions="8*,5*" ColumnSpacing="10">
-      <Border Grid.Column="0" Classes="surface" Padding="14">
-        <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" RowSpacing="8"
-              VerticalAlignment="Top">
-          <Grid Grid.Row="0" ColumnDefinitions="Auto,*" ColumnSpacing="8">
-            <Border Classes="stepNumber">
-              <TextBlock Text="01" FontSize="10" FontWeight="Bold"
-                         Foreground="{StaticResource AccentStrongBrush}"
-                         HorizontalAlignment="Center" VerticalAlignment="Center" />
-            </Border>
-            <TextBlock Grid.Column="1" Text="SDカード" Classes="sectionTitle"
-                       VerticalAlignment="Center" />
-          </Grid>
-          <StackPanel Grid.Row="1" Margin="32,0,0,0" Spacing="5">
-            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
-              <Border Grid.Column="0" Classes="soft" Padding="9,7">
+    <ScrollViewer Grid.Row="2"
+                  VerticalScrollBarVisibility="Auto"
+                  HorizontalScrollBarVisibility="Disabled">
+      <StackPanel Spacing="10">
+        <Border Classes="surface" Padding="13">
+          <StackPanel Spacing="10">
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+              <TextBlock Text="取り込み" Classes="sectionTitle" />
+              <TextBlock Grid.Column="1"
+                         Text="JPG/JPEG・RAW・MOV/MP4"
+                         Classes="caption"
+                         VerticalAlignment="Center" />
+            </Grid>
+
+            <Grid ColumnDefinitions="92,*,Auto" ColumnSpacing="8">
+              <TextBlock Text="SDカード" Classes="label"
+                         VerticalAlignment="Center" />
+              <Border Grid.Column="1" Classes="soft" Padding="9,7">
                 <TextBlock Text="{Binding SelectedSdDisplay}"
-                           TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"
+                           TextWrapping="NoWrap"
+                           TextTrimming="CharacterEllipsis"
                            ToolTip.Tip="{Binding SelectedSdDisplay}"
                            AutomationProperties.Name="選択中のSDカード" />
               </Border>
-              <Button Grid.Column="1" Content="SDカードを選択…"
-                      Click="SelectSd_Click" IsEnabled="{Binding !IsBusy}"
+              <Button Grid.Column="2" Content="選択…"
+                      Click="SelectSd_Click"
+                      IsEnabled="{Binding !IsBusy}"
                       AutomationProperties.Name="SDカードを選択" />
             </Grid>
-            <Grid IsVisible="{Binding ShowMediaSummary}" ColumnDefinitions="Auto,*" ColumnSpacing="7">
-              <TextBlock Text="✓" Foreground="{StaticResource AccentStrongBrush}" FontWeight="Bold" />
-              <TextBlock Grid.Column="1" Text="{Binding CountLabel}" FontWeight="SemiBold"
-                         TextWrapping="Wrap" />
+
+            <Grid Margin="100,-3,0,0" ColumnDefinitions="Auto,*" ColumnSpacing="10">
+              <TextBlock IsVisible="{Binding ShowMediaSummary}"
+                         Text="{Binding CountLabel}"
+                         FontSize="11" FontWeight="SemiBold"
+                         Foreground="{StaticResource AccentStrongBrush}" />
+              <TextBlock Grid.Column="1"
+                         IsVisible="{Binding HasPendingCards}"
+                         Text="{Binding PendingSdText}"
+                         Classes="caption" />
             </Grid>
-            <TextBlock IsVisible="{Binding HasPendingCards}" Text="{Binding PendingSdText}"
-                       Classes="caption" TextWrapping="Wrap" />
-            <TextBlock Text="対象形式: JPG/JPEG・設定済みRAW・MOV/MP4"
-                       Classes="caption" />
-          </StackPanel>
 
-          <Grid Grid.Row="2" ColumnDefinitions="Auto,*" ColumnSpacing="8">
-            <Border Classes="stepNumber">
-              <TextBlock Text="02" FontSize="10" FontWeight="Bold"
-                         Foreground="{StaticResource AccentStrongBrush}"
-                         HorizontalAlignment="Center" VerticalAlignment="Center" />
-            </Border>
-            <TextBlock Grid.Column="1" Text="保存先" Classes="sectionTitle"
-                       VerticalAlignment="Center" />
-          </Grid>
-          <Grid Grid.Row="3" Margin="32,0,0,0" ColumnDefinitions="*,Auto" ColumnSpacing="7">
-            <TextBox Grid.Column="0" Text="{Binding DestinationPath, Mode=TwoWay}"
-                     IsEnabled="{Binding !IsBusy}" PlaceholderText="写真ライブラリの保存先"
-                     LostFocus="Destination_LostFocus"
-                     AutomationProperties.Name="写真の保存先" />
-            <Button Grid.Column="1" Content="選択…" Click="SelectDestination_Click"
-                    IsEnabled="{Binding !IsBusy}"
-                    AutomationProperties.Name="写真の保存先を選択" />
-          </Grid>
+            <Border Height="1" Background="{StaticResource BorderBrush}" />
 
-          <Grid Grid.Row="4" ColumnDefinitions="Auto,*" ColumnSpacing="8">
-            <Border Classes="stepNumber">
-              <TextBlock Text="03" FontSize="10" FontWeight="Bold"
-                         Foreground="{StaticResource AccentStrongBrush}"
-                         HorizontalAlignment="Center" VerticalAlignment="Center" />
-            </Border>
-            <TextBlock Grid.Column="1" Text="イベント名" Classes="sectionTitle"
-                       VerticalAlignment="Center" />
-          </Grid>
-          <StackPanel Grid.Row="5" Margin="32,0,0,0" Spacing="5">
-            <TextBox Text="{Binding EventName, Mode=TwoWay}"
-                     IsEnabled="{Binding !IsBusy}"
-                     PlaceholderText="例: 旅行、運動会、撮影会"
-                     AutomationProperties.Name="イベント名" />
+            <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
+              <StackPanel Spacing="5">
+                <TextBlock Text="保存先" Classes="label" />
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
+                  <TextBox Text="{Binding DestinationPath, Mode=TwoWay}"
+                           IsEnabled="{Binding !IsBusy}"
+                           PlaceholderText="写真ライブラリの保存先"
+                           LostFocus="Destination_LostFocus"
+                           AutomationProperties.Name="写真の保存先" />
+                  <Button Grid.Column="1" Classes="compact" Content="選択…"
+                          Click="SelectDestination_Click"
+                          IsEnabled="{Binding !IsBusy}"
+                          AutomationProperties.Name="写真の保存先を選択" />
+                </Grid>
+              </StackPanel>
+
+              <StackPanel Grid.Column="1" Spacing="5">
+                <TextBlock Text="イベント名" Classes="label" />
+                <TextBox Text="{Binding EventName, Mode=TwoWay}"
+                         IsEnabled="{Binding !IsBusy}"
+                         PlaceholderText="例: 京都旅行"
+                         AutomationProperties.Name="イベント名" />
+              </StackPanel>
+            </Grid>
+
             <Border IsVisible="{Binding HasInputValidationError}"
-                    Padding="10,8" CornerRadius="8" BorderThickness="1"
-                    Background="{StaticResource WarningSurfaceBrush}" BorderBrush="#6C5332"
+                    Padding="9,7" CornerRadius="7" BorderThickness="1"
+                    Background="{StaticResource WarningSurfaceBrush}"
+                    BorderBrush="#6C5332"
                     AutomationProperties.Name="入力内容の確認">
-              <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
-                <TextBlock Text="!" FontWeight="Bold" Foreground="{StaticResource WarningBrush}" />
-                <TextBlock Grid.Column="1" Text="{Binding InputValidationMessage}"
-                           Foreground="{StaticResource WarningBrush}"
-                           TextWrapping="Wrap"
-                           ToolTip.Tip="{Binding InputValidationMessage}" />
+              <TextBlock Text="{Binding InputValidationMessage}"
+                         Foreground="{StaticResource WarningBrush}"
+                         FontSize="11" TextWrapping="Wrap"
+                         ToolTip.Tip="{Binding InputValidationMessage}" />
+            </Border>
+
+            <Border Classes="soft" Padding="10">
+              <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+                <StackPanel Spacing="2" VerticalAlignment="Center">
+                  <TextBlock Text="保存先プレビュー" Classes="label" />
+                  <TextBlock x:Name="DestinationPreviewText"
+                             FontFamily="monospace" FontSize="11"
+                             Foreground="{StaticResource AccentStrongBrush}"
+                             TextWrapping="Wrap"
+                             AutomationProperties.Name="保存先プレビュー" />
+                </StackPanel>
+                <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6"
+                            VerticalAlignment="Center">
+                  <Button Content="キャンセル"
+                          Click="Cancel_Click"
+                          IsVisible="{Binding CanCancel}"
+                          IsEnabled="{Binding CanCancel}"
+                          AutomationProperties.Name="取り込みをキャンセル" />
+                  <Button Classes="primary" Content="取り込み開始"
+                          Click="Import_Click"
+                          IsEnabled="{Binding CanImport}"
+                          AutomationProperties.Name="取り込みを開始" />
+                </StackPanel>
               </Grid>
             </Border>
-          </StackPanel>
-        </Grid>
-      </Border>
 
-      <Grid Grid.Column="1" RowDefinitions="Auto,*" RowSpacing="8">
-        <Border Grid.Row="0" Classes="surface" Padding="12">
-          <StackPanel Spacing="8">
-            <StackPanel Spacing="4">
-            <TextBlock Text="保存先プレビュー" Classes="label" />
-            <TextBlock x:Name="DestinationPreviewText" FontFamily="monospace"
-                       Foreground="{StaticResource AccentStrongBrush}"
-                       TextWrapping="Wrap"
-                       AutomationProperties.Name="保存先プレビュー" />
-            <TextBlock Text="撮影日とイベント名から自動整理します" Classes="caption" />
-            </StackPanel>
-            <Border Height="1" Background="{StaticResource BorderBrush}" />
-            <StackPanel Orientation="Horizontal" Spacing="8">
-              <Button Classes="primary" Content="取り込みを開始"
-                      Click="Import_Click" IsEnabled="{Binding CanImport}"
-                      MinWidth="140" AutomationProperties.Name="取り込みを開始" />
-              <Button Content="キャンセル" Click="Cancel_Click"
-                      IsEnabled="{Binding CanCancel}"
-                      AutomationProperties.Name="取り込みをキャンセル" />
-            </StackPanel>
             <StackPanel IsVisible="{Binding IsBusy}" Spacing="5">
               <ProgressBar Minimum="0" Maximum="{Binding ProgressMaximum}"
                            Value="{Binding ProgressValue}"
                            IsIndeterminate="{Binding ProgressIsIndeterminate}"
-                           Height="6" AutomationProperties.Name="取り込み進捗" />
-              <TextBlock Text="{Binding ProgressLabel}" Classes="caption"
-                         TextWrapping="Wrap" />
+                           Height="6"
+                           AutomationProperties.Name="取り込み進捗" />
+              <TextBlock Text="{Binding ProgressLabel}"
+                         Classes="caption" TextWrapping="Wrap" />
             </StackPanel>
-            <TextBlock IsVisible="{Binding !IsBusy}" Text="{Binding ProgressLabel}"
-                       Classes="caption" TextWrapping="Wrap" />
           </StackPanel>
         </Border>
 
-        <StackPanel Grid.Row="1" Spacing="8">
-          <Border IsVisible="{Binding HasCompletedImport}"
-                  Padding="12" CornerRadius="10" BorderThickness="1"
-                  Background="{StaticResource SuccessSurfaceBrush}" BorderBrush="#365C42"
-                  AutomationProperties.Name="直前の取り込み結果">
-            <StackPanel Spacing="6">
-              <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
-                <TextBlock Text="✓" FontWeight="Bold" Foreground="{StaticResource SuccessBrush}" />
-                <TextBlock Grid.Column="1" Text="取り込み完了" FontWeight="SemiBold"
-                           Foreground="{StaticResource SuccessBrush}" />
-              </Grid>
-              <TextBlock Text="{Binding CompletionSummary}" FontSize="12"
-                         TextWrapping="Wrap" />
-              <Grid ColumnDefinitions="*,Auto" ColumnSpacing="7">
-                <TextBlock Text="{Binding LastImportBasePath}" FontFamily="monospace"
-                           TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"
-                           ToolTip.Tip="{Binding LastImportBasePath}"
-                           AutomationProperties.Name="直前の取り込み先" />
-                <Button Grid.Column="1" Content="保存先を開く" Click="OpenDestination_Click"
-                        IsEnabled="{Binding !IsBusy}"
-                        AutomationProperties.Name="直前の取り込み先を開く" />
-              </Grid>
-            </StackPanel>
-          </Border>
-
-          <Border IsVisible="{Binding ShowSafetyPanel}"
-                  Padding="12" CornerRadius="10" BorderThickness="2"
-                  Background="{StaticResource SurfaceBrush}" BorderBrush="{Binding SafetyBrush}"
-                  AutomationProperties.Name="SDカード再利用の安全状態">
-            <StackPanel Spacing="4">
-              <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
-                <TextBlock Text="SDカードの再利用" Classes="label" VerticalAlignment="Center" />
-                <Button Grid.Column="1"
-                        IsVisible="{Binding EjectSupported}"
-                        Content="安全に取り出す"
-                        Click="EjectSd_Click"
-                        IsEnabled="{Binding CanEjectSelectedSd}"
-                        Padding="11,6"
-                        AutomationProperties.Name="SDカードを安全に取り出す" />
-              </Grid>
-              <TextBlock Text="{Binding SafetyHeadline}" FontSize="16" FontWeight="SemiBold"
+        <Border IsVisible="{Binding ShowSafetyPanel}"
+                Classes="surface" Padding="12"
+                BorderThickness="2"
+                BorderBrush="{Binding SafetyBrush}"
+                AutomationProperties.Name="SDカード再利用の安全状態">
+          <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+            <StackPanel Spacing="3">
+              <TextBlock Text="SDカードの安全確認" Classes="label" />
+              <TextBlock Text="{Binding SafetyHeadline}"
+                         FontSize="14" FontWeight="SemiBold"
                          Foreground="{Binding SafetyBrush}"
                          TextWrapping="Wrap" />
-              <TextBlock Text="{Binding SafetyDetail}" FontSize="12"
-                         TextWrapping="Wrap" />
-              <TextBlock Text="実ファイル照合と永続化の確認結果です。二重バックアップ済みという意味ではありません。"
+              <TextBlock Text="{Binding SafetyDetail}"
+                         FontSize="11" TextWrapping="Wrap" />
+              <TextBlock Text="再利用可否は対象ファイルの照合結果です。バックアップの有無とは別です。"
                          Classes="caption" TextWrapping="Wrap" />
             </StackPanel>
-          </Border>
-        </StackPanel>
-      </Grid>
-    </Grid>
+            <Button Grid.Column="1"
+                    IsVisible="{Binding EjectSupported}"
+                    Content="安全に取り出す"
+                    Click="EjectSd_Click"
+                    IsEnabled="{Binding CanEjectSelectedSd}"
+                    VerticalAlignment="Top"
+                    AutomationProperties.Name="SDカードを安全に取り出す" />
+          </Grid>
+        </Border>
 
+        <Border IsVisible="{Binding HasCompletedImport}"
+                Classes="surface" Padding="12"
+                Background="{StaticResource SuccessSurfaceBrush}"
+                BorderBrush="#365C42"
+                AutomationProperties.Name="直前の取り込み結果">
+          <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
+            <StackPanel Spacing="3">
+              <TextBlock Text="取り込み完了" FontSize="14" FontWeight="SemiBold" />
+              <TextBlock Text="{Binding CompletionSummary}"
+                         FontSize="11" TextWrapping="Wrap" />
+              <TextBlock Text="{Binding LastImportBasePath}"
+                         FontFamily="monospace" FontSize="11"
+                         Foreground="{StaticResource MutedForeground}"
+                         TextWrapping="NoWrap" TextTrimming="CharacterEllipsis"
+                         ToolTip.Tip="{Binding LastImportBasePath}"
+                         AutomationProperties.Name="直前の取り込み先" />
+            </StackPanel>
+            <Button Grid.Column="1" Content="保存先を開く"
+                    Click="OpenDestination_Click"
+                    IsEnabled="{Binding !IsBusy}"
+                    VerticalAlignment="Center"
+                    AutomationProperties.Name="直前の取り込み先を開く" />
+          </Grid>
+        </Border>
+      </StackPanel>
+    </ScrollViewer>
   </Grid>
 </Window>

--- a/src/PhotoOrganizer.App/MainWindow.axaml
+++ b/src/PhotoOrganizer.App/MainWindow.axaml
@@ -92,7 +92,8 @@
              Width="34" Height="34"
              VerticalAlignment="Center" />
       <StackPanel Grid.Column="1" Spacing="0" VerticalAlignment="Center">
-        <TextBlock Text="Photo Organizer" FontSize="18" FontWeight="SemiBold" />
+        <TextBlock Text="Photo Organizer" FontSize="18" FontWeight="SemiBold"
+                   AutomationProperties.HeadingLevel="1" />
         <TextBlock Text="SDカードから写真・動画を安全に取り込み"
                    Classes="caption" />
       </StackPanel>
@@ -117,7 +118,8 @@
                 VerticalAlignment="Center" />
         <TextBlock Grid.Column="1" Text="{Binding WorkflowHeadline}"
                    FontSize="14" FontWeight="SemiBold"
-                   TextWrapping="Wrap" VerticalAlignment="Center" />
+                   TextWrapping="Wrap" VerticalAlignment="Center"
+                   AutomationProperties.LiveSetting="Polite" />
       </Grid>
     </Border>
 
@@ -128,7 +130,8 @@
         <Border Classes="surface" Padding="13">
           <StackPanel Spacing="10">
             <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
-              <TextBlock Text="取り込み" Classes="sectionTitle" />
+              <TextBlock Text="取り込み" Classes="sectionTitle"
+                         AutomationProperties.HeadingLevel="2" />
               <TextBlock Grid.Column="1"
                          Text="JPG/JPEG・設定済みRAW・MOV/MP4"
                          Classes="caption"
@@ -181,7 +184,8 @@
                            PlaceholderText="写真ライブラリの保存先"
                            LostFocus="Destination_LostFocus"
                            TabIndex="1"
-                           AutomationProperties.Name="写真の保存先" />
+                           AutomationProperties.Name="写真の保存先"
+                           AutomationProperties.IsRequiredForForm="True" />
                   <Button Grid.Column="1" Classes="compact" Content="選択…"
                           Click="SelectDestination_Click"
                           IsEnabled="{Binding !IsBusy}"
@@ -199,7 +203,8 @@
                          IsEnabled="{Binding !IsBusy}"
                          PlaceholderText="例: 京都旅行"
                          TabIndex="3"
-                         AutomationProperties.Name="イベント名" />
+                         AutomationProperties.Name="イベント名"
+                         AutomationProperties.IsRequiredForForm="True" />
               </StackPanel>
             </Grid>
 
@@ -211,7 +216,8 @@
               <TextBlock Text="{Binding InputValidationMessage}"
                          Foreground="{StaticResource WarningBrush}"
                          FontSize="11" TextWrapping="Wrap"
-                         ToolTip.Tip="{Binding InputValidationMessage}" />
+                         ToolTip.Tip="{Binding InputValidationMessage}"
+                         AutomationProperties.LiveSetting="Assertive" />
             </Border>
 
             <Border Classes="soft" Padding="10">
@@ -230,12 +236,14 @@
                           Click="Cancel_Click"
                           IsVisible="{Binding CanCancel}"
                           IsEnabled="{Binding CanCancel}"
+                          IsCancel="True"
                           TabIndex="5"
                           AutomationProperties.Name="取り込みをキャンセル" />
                   <Button Classes="primary" Content="取り込み開始"
                           Click="Import_Click"
                           IsVisible="{Binding !IsSafeToReuseCurrentCard}"
                           IsEnabled="{Binding CanImport}"
+                          IsDefault="True"
                           TabIndex="4"
                           AutomationProperties.Name="取り込みを開始" />
                 </StackPanel>
@@ -249,7 +257,8 @@
                            Height="6"
                            AutomationProperties.Name="取り込み進捗" />
               <TextBlock Text="{Binding ProgressLabel}"
-                         Classes="caption" TextWrapping="Wrap" />
+                         Classes="caption" TextWrapping="Wrap"
+                         AutomationProperties.LiveSetting="Polite" />
             </StackPanel>
           </StackPanel>
         </Border>
@@ -261,11 +270,13 @@
                 AutomationProperties.Name="SDカード再利用の安全状態">
           <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
             <StackPanel Spacing="3">
-              <TextBlock Text="SDカードの安全確認" Classes="label" />
+              <TextBlock Text="SDカードの安全確認" Classes="label"
+                         AutomationProperties.HeadingLevel="2" />
               <TextBlock Text="{Binding SafetyHeadline}"
                          FontSize="14" FontWeight="SemiBold"
                          Foreground="{Binding SafetyBrush}"
-                         TextWrapping="Wrap" />
+                         TextWrapping="Wrap"
+                         AutomationProperties.LiveSetting="Assertive" />
               <TextBlock Text="{Binding SafetyDetail}"
                          FontSize="11" TextWrapping="Wrap" />
               <TextBlock Text="再利用可否は対象ファイルの照合結果です。バックアップの有無とは別です。"
@@ -287,7 +298,8 @@
                 AutomationProperties.Name="直前の取り込み先">
           <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
             <StackPanel Spacing="3">
-              <TextBlock Text="取り込み先" FontSize="13" FontWeight="SemiBold" />
+              <TextBlock Text="取り込み先" FontSize="13" FontWeight="SemiBold"
+                         AutomationProperties.HeadingLevel="2" />
               <TextBlock Text="{Binding LastImportBasePath}"
                          FontFamily="monospace" FontSize="11"
                          Foreground="{StaticResource MutedForeground}"

--- a/src/PhotoOrganizer.App/MainWindow.axaml
+++ b/src/PhotoOrganizer.App/MainWindow.axaml
@@ -20,10 +20,8 @@
     <SolidColorBrush x:Key="BorderBrush">#2B3939</SolidColorBrush>
     <SolidColorBrush x:Key="AccentBrush">#70B8A5</SolidColorBrush>
     <SolidColorBrush x:Key="AccentStrongBrush">#8ACDBB</SolidColorBrush>
-    <SolidColorBrush x:Key="AccentSurfaceBrush">#19302D</SolidColorBrush>
     <SolidColorBrush x:Key="WarningBrush">#D7AE73</SolidColorBrush>
     <SolidColorBrush x:Key="WarningSurfaceBrush">#30281E</SolidColorBrush>
-    <SolidColorBrush x:Key="SuccessSurfaceBrush">#1B2C22</SolidColorBrush>
   </Window.Resources>
 
   <Window.Styles>
@@ -96,7 +94,6 @@
                   VerticalAlignment="Center">
         <Button Classes="compact" Content="設定"
                 Click="Settings_Click"
-                IsEnabled="{Binding !IsBusy}"
                 AutomationProperties.Name="設定を開く" />
         <Button Classes="compact" Content="ログ"
                 Click="Diagnostics_Click"
@@ -105,12 +102,10 @@
     </Grid>
 
     <Border Grid.Row="1" Classes="surface" Padding="10,7"
-            Background="{StaticResource AccentSurfaceBrush}"
-            BorderBrush="#31544E"
             AutomationProperties.Name="現在の状態">
       <Grid ColumnDefinitions="Auto,*" ColumnSpacing="9">
         <Border Width="8" Height="8" CornerRadius="4"
-                Background="{StaticResource AccentStrongBrush}"
+                Background="{StaticResource MutedForeground}"
                 VerticalAlignment="Center" />
         <TextBlock Grid.Column="1" Text="{Binding WorkflowHeadline}"
                    FontSize="14" FontWeight="SemiBold"
@@ -148,15 +143,16 @@
                       AutomationProperties.Name="SDカードを選択" />
             </Grid>
 
-            <Grid Margin="100,-3,0,0" ColumnDefinitions="Auto,*" ColumnSpacing="10">
-              <TextBlock IsVisible="{Binding ShowMediaSummary}"
-                         Text="{Binding CountLabel}"
-                         FontSize="11" FontWeight="SemiBold"
-                         Foreground="{StaticResource AccentStrongBrush}" />
-              <TextBlock Grid.Column="1"
-                         IsVisible="{Binding HasPendingCards}"
-                         Text="{Binding PendingSdText}"
-                         Classes="caption" />
+            <Grid ColumnDefinitions="92,*" ColumnSpacing="8">
+              <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="10">
+                <TextBlock IsVisible="{Binding ShowMediaSummary}"
+                           Text="{Binding CountLabel}"
+                           FontSize="11" FontWeight="SemiBold"
+                           Foreground="{StaticResource AccentStrongBrush}" />
+                <TextBlock IsVisible="{Binding HasPendingCards}"
+                           Text="{Binding PendingSdText}"
+                           Classes="caption" />
+              </StackPanel>
             </Grid>
 
             <Border Height="1" Background="{StaticResource BorderBrush}" />
@@ -216,6 +212,7 @@
                           AutomationProperties.Name="取り込みをキャンセル" />
                   <Button Classes="primary" Content="取り込み開始"
                           Click="Import_Click"
+                          IsVisible="{Binding !IsSafeToReuseCurrentCard}"
                           IsEnabled="{Binding CanImport}"
                           AutomationProperties.Name="取り込みを開始" />
                 </StackPanel>
@@ -263,14 +260,10 @@
 
         <Border IsVisible="{Binding HasCompletedImport}"
                 Classes="surface" Padding="12"
-                Background="{StaticResource SuccessSurfaceBrush}"
-                BorderBrush="#365C42"
-                AutomationProperties.Name="直前の取り込み結果">
+                AutomationProperties.Name="直前の取り込み先">
           <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12">
             <StackPanel Spacing="3">
-              <TextBlock Text="取り込み完了" FontSize="14" FontWeight="SemiBold" />
-              <TextBlock Text="{Binding CompletionSummary}"
-                         FontSize="11" TextWrapping="Wrap" />
+              <TextBlock Text="取り込み先" FontSize="13" FontWeight="SemiBold" />
               <TextBlock Text="{Binding LastImportBasePath}"
                          FontFamily="monospace" FontSize="11"
                          Foreground="{StaticResource MutedForeground}"

--- a/src/PhotoOrganizer.App/MainWindow.axaml
+++ b/src/PhotoOrganizer.App/MainWindow.axaml
@@ -104,7 +104,7 @@
       </StackPanel>
     </Grid>
 
-    <Border Grid.Row="1" Classes="surface" Padding="10,8"
+    <Border Grid.Row="1" Classes="surface" Padding="10,7"
             Background="{StaticResource AccentSurfaceBrush}"
             BorderBrush="#31544E"
             AutomationProperties.Name="現在の状態">
@@ -112,13 +112,9 @@
         <Border Width="8" Height="8" CornerRadius="4"
                 Background="{StaticResource AccentStrongBrush}"
                 VerticalAlignment="Center" />
-        <StackPanel Grid.Column="1" Spacing="1">
-          <TextBlock Text="{Binding WorkflowHeadline}"
-                     FontSize="14" FontWeight="SemiBold" TextWrapping="Wrap" />
-          <TextBlock Text="{Binding WorkflowDetail}"
-                     Classes="caption" Foreground="{StaticResource MutedForeground}"
-                     TextWrapping="Wrap" />
-        </StackPanel>
+        <TextBlock Grid.Column="1" Text="{Binding WorkflowHeadline}"
+                   FontSize="14" FontWeight="SemiBold"
+                   TextWrapping="Wrap" VerticalAlignment="Center" />
       </Grid>
     </Border>
 
@@ -131,7 +127,7 @@
             <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
               <TextBlock Text="取り込み" Classes="sectionTitle" />
               <TextBlock Grid.Column="1"
-                         Text="JPG/JPEG・RAW・MOV/MP4"
+                         Text="JPG/JPEG・設定済みRAW・MOV/MP4"
                          Classes="caption"
                          VerticalAlignment="Center" />
             </Grid>

--- a/src/PhotoOrganizer.App/MainWindow.axaml
+++ b/src/PhotoOrganizer.App/MainWindow.axaml
@@ -49,6 +49,12 @@
       <Setter Property="FontWeight" Value="SemiBold" />
       <Setter Property="Foreground" Value="{StaticResource MutedForeground}" />
     </Style>
+    <Style Selector="Label.fieldLabel">
+      <Setter Property="FontSize" Value="11" />
+      <Setter Property="FontWeight" Value="SemiBold" />
+      <Setter Property="Foreground" Value="{StaticResource MutedForeground}" />
+      <Setter Property="Padding" Value="0" />
+    </Style>
     <Style Selector="TextBlock.caption">
       <Setter Property="FontSize" Value="11" />
       <Setter Property="Foreground" Value="{StaticResource SubtleForeground}" />
@@ -94,9 +100,11 @@
                   VerticalAlignment="Center">
         <Button Classes="compact" Content="設定"
                 Click="Settings_Click"
+                TabIndex="20"
                 AutomationProperties.Name="設定を開く" />
         <Button Classes="compact" Content="ログ"
                 Click="Diagnostics_Click"
+                TabIndex="21"
                 AutomationProperties.Name="処理ログを開く" />
       </StackPanel>
     </Grid>
@@ -128,8 +136,10 @@
             </Grid>
 
             <Grid ColumnDefinitions="92,*,Auto" ColumnSpacing="8">
-              <TextBlock Text="SDカード" Classes="label"
-                         VerticalAlignment="Center" />
+              <Label Classes="fieldLabel"
+                     Target="SdSelectButton"
+                     Content="SDカード"
+                     VerticalAlignment="Center" />
               <Border Grid.Column="1" Classes="soft" Padding="9,7">
                 <TextBlock Text="{Binding SelectedSdDisplay}"
                            TextWrapping="NoWrap"
@@ -137,9 +147,11 @@
                            ToolTip.Tip="{Binding SelectedSdDisplay}"
                            AutomationProperties.Name="選択中のSDカード" />
               </Border>
-              <Button Grid.Column="2" Content="選択…"
+              <Button x:Name="SdSelectButton"
+                      Grid.Column="2" Content="選択…"
                       Click="SelectSd_Click"
                       IsEnabled="{Binding !IsBusy}"
+                      TabIndex="0"
                       AutomationProperties.Name="SDカードを選択" />
             </Grid>
 
@@ -159,25 +171,34 @@
 
             <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
               <StackPanel Spacing="5">
-                <TextBlock Text="保存先" Classes="label" />
+                <Label Classes="fieldLabel"
+                       Target="DestinationTextBox"
+                       Content="保存先" />
                 <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
-                  <TextBox Text="{Binding DestinationPath, Mode=TwoWay}"
+                  <TextBox x:Name="DestinationTextBox"
+                           Text="{Binding DestinationPath, Mode=TwoWay}"
                            IsEnabled="{Binding !IsBusy}"
                            PlaceholderText="写真ライブラリの保存先"
                            LostFocus="Destination_LostFocus"
+                           TabIndex="1"
                            AutomationProperties.Name="写真の保存先" />
                   <Button Grid.Column="1" Classes="compact" Content="選択…"
                           Click="SelectDestination_Click"
                           IsEnabled="{Binding !IsBusy}"
+                          TabIndex="2"
                           AutomationProperties.Name="写真の保存先を選択" />
                 </Grid>
               </StackPanel>
 
               <StackPanel Grid.Column="1" Spacing="5">
-                <TextBlock Text="イベント名" Classes="label" />
-                <TextBox Text="{Binding EventName, Mode=TwoWay}"
+                <Label Classes="fieldLabel"
+                       Target="EventNameTextBox"
+                       Content="イベント名" />
+                <TextBox x:Name="EventNameTextBox"
+                         Text="{Binding EventName, Mode=TwoWay}"
                          IsEnabled="{Binding !IsBusy}"
                          PlaceholderText="例: 京都旅行"
+                         TabIndex="3"
                          AutomationProperties.Name="イベント名" />
               </StackPanel>
             </Grid>
@@ -209,11 +230,13 @@
                           Click="Cancel_Click"
                           IsVisible="{Binding CanCancel}"
                           IsEnabled="{Binding CanCancel}"
+                          TabIndex="5"
                           AutomationProperties.Name="取り込みをキャンセル" />
                   <Button Classes="primary" Content="取り込み開始"
                           Click="Import_Click"
                           IsVisible="{Binding !IsSafeToReuseCurrentCard}"
                           IsEnabled="{Binding CanImport}"
+                          TabIndex="4"
                           AutomationProperties.Name="取り込みを開始" />
                 </StackPanel>
               </Grid>
@@ -253,6 +276,7 @@
                     Content="安全に取り出す"
                     Click="EjectSd_Click"
                     IsEnabled="{Binding CanEjectSelectedSd}"
+                    TabIndex="6"
                     VerticalAlignment="Top"
                     AutomationProperties.Name="SDカードを安全に取り出す" />
           </Grid>
@@ -274,6 +298,7 @@
             <Button Grid.Column="1" Content="保存先を開く"
                     Click="OpenDestination_Click"
                     IsEnabled="{Binding !IsBusy}"
+                    TabIndex="7"
                     VerticalAlignment="Center"
                     AutomationProperties.Name="直前の取り込み先を開く" />
           </Grid>

--- a/src/PhotoOrganizer.App/MainWindow.axaml.cs
+++ b/src/PhotoOrganizer.App/MainWindow.axaml.cs
@@ -44,6 +44,16 @@ public sealed partial class MainWindow : Window
 
     internal void AllowExplicitClose() => _allowExplicitClose = true;
 
+    private void Settings_Click(object? sender, RoutedEventArgs e)
+    {
+        if (Application.Current is App app) app.ShowSettingsWindow();
+    }
+
+    private void Diagnostics_Click(object? sender, RoutedEventArgs e)
+    {
+        if (Application.Current is App app) app.ShowDiagnosticsWindow();
+    }
+
     private async void SelectDestination_Click(object? sender, RoutedEventArgs e)
     {
         try
@@ -162,7 +172,6 @@ public sealed partial class MainWindow : Window
             ReportUiFailure("SDカード取り出し", exception);
         }
     }
-
 
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {

--- a/src/PhotoOrganizer.App/SettingsWindow.axaml
+++ b/src/PhotoOrganizer.App/SettingsWindow.axaml
@@ -23,6 +23,11 @@
       <Setter Property="FontSize" Value="11" />
       <Setter Property="Foreground" Value="#7F8D8A" />
     </Style>
+    <Style Selector="Label.fieldLabel">
+      <Setter Property="FontSize" Value="11" />
+      <Setter Property="Foreground" Value="#7F8D8A" />
+      <Setter Property="Padding" Value="0" />
+    </Style>
     <Style Selector="Border.surface">
       <Setter Property="Background" Value="#182022" />
       <Setter Property="BorderBrush" Value="#2B3939" />
@@ -47,10 +52,14 @@
       <StackPanel Spacing="11">
         <StackPanel Spacing="5">
           <TextBlock Text="取り込み対象" Classes="section" />
-          <TextBlock Text="追加するRAW拡張子" Classes="caption" />
-          <TextBox Text="{Binding RawExtensionsText, Mode=TwoWay}"
+          <Label Classes="fieldLabel"
+                 Target="RawExtensionsTextBox"
+                 Content="追加するRAW拡張子" />
+          <TextBox x:Name="RawExtensionsTextBox"
+                   Text="{Binding RawExtensionsText, Mode=TwoWay}"
                    IsEnabled="{Binding !IsBusy}"
                    PlaceholderText=".arw, .cr3, .nef, ..."
+                   TabIndex="0"
                    AutomationProperties.Name="追加するRAW拡張子" />
           <TextBlock Text="JPG/JPEG・MOV/MP4は常に対象です。RAWだけ追加指定します。"
                      Classes="caption" TextWrapping="Wrap" />
@@ -62,9 +71,11 @@
           <TextBlock Text="起動" Classes="section" />
           <CheckBox Content="ログイン時に自動起動"
                     IsChecked="{Binding AutoStart, Mode=TwoWay}"
-                    IsEnabled="{Binding AutoStartSupported}" />
+                    IsEnabled="{Binding AutoStartSupported}"
+                    TabIndex="1" />
           <CheckBox x:Name="StartInBackgroundCheckBox"
-                    Content="起動時はメニューバーに常駐" />
+                    Content="起動時はメニューバーに常駐"
+                    TabIndex="2" />
           <TextBlock x:Name="BackgroundSettingStatus"
                      Margin="24,-1,0,0"
                      Classes="caption" TextWrapping="Wrap" />

--- a/src/PhotoOrganizer.App/SettingsWindow.axaml
+++ b/src/PhotoOrganizer.App/SettingsWindow.axaml
@@ -8,7 +8,7 @@
         Width="500" Height="350"
         MinWidth="460" MinHeight="330"
         CanResize="False"
-        WindowStartupLocation="CenterOwner"
+        WindowStartupLocation="CenterScreen"
         RequestedThemeVariant="Dark"
         Background="#101617">
   <Window.Styles>

--- a/src/PhotoOrganizer.App/SettingsWindow.axaml
+++ b/src/PhotoOrganizer.App/SettingsWindow.axaml
@@ -5,49 +5,70 @@
         x:DataType="vm:MainWindowViewModel"
         Title="Photo Organizer 設定"
         Icon="/Assets/photo-organizer-icon.ico"
-        Width="520" Height="390"
-        MinWidth="480" MinHeight="360"
+        Width="500" Height="350"
+        MinWidth="460" MinHeight="330"
         CanResize="False"
-        WindowStartupLocation="CenterScreen"
+        WindowStartupLocation="CenterOwner"
         RequestedThemeVariant="Dark"
-        Background="#151B1C">
+        Background="#101617">
   <Window.Styles>
-    <Style Selector="TextBlock"><Setter Property="Foreground" Value="#EEF3F2" /></Style>
-    <Style Selector="TextBlock.section"><Setter Property="FontSize" Value="13" /><Setter Property="FontWeight" Value="SemiBold" /></Style>
-    <Style Selector="TextBlock.caption"><Setter Property="FontSize" Value="11" /><Setter Property="Foreground" Value="#81918E" /></Style>
-    <Style Selector="Border.card"><Setter Property="Background" Value="#1B2425" /><Setter Property="BorderBrush" Value="#2B3939" /><Setter Property="BorderThickness" Value="1" /><Setter Property="CornerRadius" Value="10" /></Style>
-    <Style Selector="TextBox"><Setter Property="CornerRadius" Value="8" /><Setter Property="Padding" Value="10,8" /><Setter Property="Background" Value="#111819" /><Setter Property="BorderBrush" Value="#2B3939" /></Style>
+    <Style Selector="TextBlock">
+      <Setter Property="Foreground" Value="#EEF3F2" />
+    </Style>
+    <Style Selector="TextBlock.section">
+      <Setter Property="FontSize" Value="13" />
+      <Setter Property="FontWeight" Value="SemiBold" />
+    </Style>
+    <Style Selector="TextBlock.caption">
+      <Setter Property="FontSize" Value="11" />
+      <Setter Property="Foreground" Value="#7F8D8A" />
+    </Style>
+    <Style Selector="Border.surface">
+      <Setter Property="Background" Value="#182022" />
+      <Setter Property="BorderBrush" Value="#2B3939" />
+      <Setter Property="BorderThickness" Value="1" />
+      <Setter Property="CornerRadius" Value="9" />
+    </Style>
+    <Style Selector="TextBox">
+      <Setter Property="CornerRadius" Value="7" />
+      <Setter Property="Padding" Value="10,7" />
+      <Setter Property="Background" Value="#131A1C" />
+      <Setter Property="BorderBrush" Value="#2B3939" />
+    </Style>
   </Window.Styles>
 
-  <Grid Margin="22" RowDefinitions="Auto,Auto,Auto" RowSpacing="14">
-    <StackPanel Spacing="2">
-      <TextBlock Text="設定" FontSize="20" FontWeight="SemiBold" />
-      <TextBlock Text="メニューバーからいつでも変更できます" Classes="caption" />
+  <Grid Margin="16" RowDefinitions="Auto,*" RowSpacing="10">
+    <StackPanel Spacing="1">
+      <TextBlock Text="設定" FontSize="18" FontWeight="SemiBold" />
+      <TextBlock Text="変更内容は自動的に保存されます" Classes="caption" />
     </StackPanel>
 
-    <Border Grid.Row="1" Classes="card" Padding="14">
-      <StackPanel Spacing="8">
-        <TextBlock Text="取り込み対象" Classes="section" />
-        <TextBlock Text="追加するRAW拡張子" Classes="caption" />
-        <TextBox Text="{Binding RawExtensionsText, Mode=TwoWay}"
-                 IsEnabled="{Binding !IsBusy}"
-                 PlaceholderText=".arw, .cr3, .nef, ..."
-                 AutomationProperties.Name="追加するRAW拡張子" />
-        <TextBlock Text="JPG/JPEG・MOV/MP4は常に対象です。ここでは追加RAWだけ指定します。"
-                   Classes="caption" TextWrapping="Wrap" />
-      </StackPanel>
-    </Border>
+    <Border Grid.Row="1" Classes="surface" Padding="13">
+      <StackPanel Spacing="11">
+        <StackPanel Spacing="5">
+          <TextBlock Text="取り込み対象" Classes="section" />
+          <TextBlock Text="追加するRAW拡張子" Classes="caption" />
+          <TextBox Text="{Binding RawExtensionsText, Mode=TwoWay}"
+                   IsEnabled="{Binding !IsBusy}"
+                   PlaceholderText=".arw, .cr3, .nef, ..."
+                   AutomationProperties.Name="追加するRAW拡張子" />
+          <TextBlock Text="JPG/JPEG・MOV/MP4は常に対象です。RAWだけ追加指定します。"
+                     Classes="caption" TextWrapping="Wrap" />
+        </StackPanel>
 
-    <Border Grid.Row="2" Classes="card" Padding="14">
-      <StackPanel Spacing="7">
-        <TextBlock Text="起動動作" Classes="section" />
-        <CheckBox Content="ログイン時にPhoto Organizerを自動起動"
-                  IsChecked="{Binding AutoStart, Mode=TwoWay}"
-                  IsEnabled="{Binding AutoStartSupported}" />
-        <CheckBox x:Name="StartInBackgroundCheckBox"
-                  Content="起動時はメニューバーに常駐" />
-        <TextBlock x:Name="BackgroundSettingStatus" Margin="24,0,0,0"
-                   Classes="caption" TextWrapping="Wrap" />
+        <Border Height="1" Background="#2B3939" />
+
+        <StackPanel Spacing="6">
+          <TextBlock Text="起動" Classes="section" />
+          <CheckBox Content="ログイン時に自動起動"
+                    IsChecked="{Binding AutoStart, Mode=TwoWay}"
+                    IsEnabled="{Binding AutoStartSupported}" />
+          <CheckBox x:Name="StartInBackgroundCheckBox"
+                    Content="起動時はメニューバーに常駐" />
+          <TextBlock x:Name="BackgroundSettingStatus"
+                     Margin="24,-1,0,0"
+                     Classes="caption" TextWrapping="Wrap" />
+        </StackPanel>
       </StackPanel>
     </Border>
   </Grid>

--- a/src/PhotoOrganizer.App/SettingsWindow.axaml
+++ b/src/PhotoOrganizer.App/SettingsWindow.axaml
@@ -44,14 +44,16 @@
 
   <Grid Margin="16" RowDefinitions="Auto,*" RowSpacing="10">
     <StackPanel Spacing="1">
-      <TextBlock Text="設定" FontSize="18" FontWeight="SemiBold" />
+      <TextBlock Text="設定" FontSize="18" FontWeight="SemiBold"
+                 AutomationProperties.HeadingLevel="1" />
       <TextBlock Text="変更内容は自動的に保存されます" Classes="caption" />
     </StackPanel>
 
     <Border Grid.Row="1" Classes="surface" Padding="13">
       <StackPanel Spacing="11">
         <StackPanel Spacing="5">
-          <TextBlock Text="取り込み対象" Classes="section" />
+          <TextBlock Text="取り込み対象" Classes="section"
+                     AutomationProperties.HeadingLevel="2" />
           <Label Classes="fieldLabel"
                  Target="RawExtensionsTextBox"
                  Content="追加するRAW拡張子" />
@@ -68,7 +70,8 @@
         <Border Height="1" Background="#2B3939" />
 
         <StackPanel Spacing="6">
-          <TextBlock Text="起動" Classes="section" />
+          <TextBlock Text="起動" Classes="section"
+                     AutomationProperties.HeadingLevel="2" />
           <CheckBox Content="ログイン時に自動起動"
                     IsChecked="{Binding AutoStart, Mode=TwoWay}"
                     IsEnabled="{Binding AutoStartSupported}"
@@ -78,7 +81,8 @@
                     TabIndex="2" />
           <TextBlock x:Name="BackgroundSettingStatus"
                      Margin="24,-1,0,0"
-                     Classes="caption" TextWrapping="Wrap" />
+                     Classes="caption" TextWrapping="Wrap"
+                     AutomationProperties.LiveSetting="Polite" />
         </StackPanel>
       </StackPanel>
     </Border>


### PR DESCRIPTION
## 概要

Photo Organizer のメインUIを、実際のSDカード取り込み作業で迷いにくい構成へ全面的に整理しました。

## 主な変更

- 番号付き3ステップ + 右サイドパネルの二重構造を廃止し、1本の取り込みフローに統合
- 不要な余白、装飾的な「SAFE IMPORT」表示、冗長な説明を削減
- SDカード → 保存先 / イベント名 → 保存先プレビュー → 取り込み開始を1枚のカード内に整理
- キャンセルと進捗は処理中だけ表示
- SDカード再利用の安全情報は、カードが選択・検証されている時だけ独立表示
- 完了後は安全判定と取り込み先表示の役割を分離し、成功情報の重複を削減
- 検証完了後は不要になった「取り込み開始」ボタンを非表示
- 上部ステータスを中立的な表示にし、警告状態でも正常色に見える問題を解消
- SDカード件数表示の固定/負マージンを廃止し、レイアウトを安定化
- メイン画面から設定・処理ログへ直接アクセス可能に変更
- 処理中も設定・ログの参照は可能にし、変更不可項目だけ個別に無効化
- フォームラベルを入力欄へ関連付け、Tab順を取り込み作業優先に明示
- Enterで取り込み開始、処理中はEscでキャンセルできる標準的なキーボード操作を追加
- 状態変化・入力エラー・SDカード安全判定をスクリーンリーダーへ適切な優先度で通知
- 連続する詳細進捗は自動読み上げせず、必要な状態変化だけを通知して過剰な読み上げを抑制
- 見出し階層と必須入力項目をアクセシビリティ情報として明示
- 設定画面にもラベル関連付け、Tab順、見出し階層、状態通知を追加
- 処理ログ画面にも見出し構造を付与し、支援技術からの画面構造を統一
- 設定画面とログ画面も同じ密度・配色・文言へ統一
- 小さいウィンドウではスクロール可能にし、Windows/macOSでのレイアウト崩れを抑制
- 既存の安全判定、取り込み処理、データ保護ロジックには変更なし

## UX上の狙い

通常時に常時見せる情報を減らし、ユーザーが「今なにをすればいいか」「取り込みを開始できるか」「SDカードを再利用してよいか」を短時間で判断できるようにしています。マウス操作だけでなく、キーボード操作とスクリーンリーダー利用時も作業フローに沿うよう整理しています。

## 確認

Windows/macOS の安全テスト・プラットフォームテスト・デスクトップビルド、Windows/macOS のパッケージスモーク、Release contract、CodeQL を最終HEADで確認済みです。